### PR TITLE
Document branch protection rules and Git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,27 @@ The repository includes pre-commit hooks that enforce:
 
 The pre-commit hooks are automatically installed and will prevent commits with linting issues.
 
+## Git Workflow and Branch Protection
+
+### Branch Protection Rules
+
+The `main` branch is protected with the following rules:
+- **No direct pushes to main** - All changes must go through pull requests
+- **Required status checks** - CI tests must pass before merging
+- Pre-commit hooks enforce local quality checks before commits
+
+### Development Workflow
+
+When making changes:
+1. Create a feature branch: `git checkout -b feature-name`
+2. Make your changes and commit (pre-commit hooks will run)
+3. Push the branch: `git push -u origin feature-name`
+4. Create a pull request to `main`
+5. Wait for CI checks to pass
+6. Merge via GitHub UI after approval
+
+**Important**: Always work on feature branches. Never attempt to push directly to `main` as it will be rejected by branch protection rules.
+
 ## Project Structure
 
 The codebase follows this clean architecture:


### PR DESCRIPTION
## Summary
Adds documentation to CLAUDE.md about the new branch protection rules on the `main` branch.

## Changes
- Added "Git Workflow and Branch Protection" section to CLAUDE.md
- Documents that direct pushes to main are not allowed
- Explains the feature branch workflow required for all changes
- Clarifies that CI checks must pass before merging

## Purpose
Ensures Claude Code understands the repository's workflow and will:
- Create feature branches for all changes
- Never attempt to push directly to main
- Follow proper PR workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)