### PR TITLE
Phase 2: Remove duplicate ID fields from all agents

### DIFF
--- a/pkg/architect/dispatching.go
+++ b/pkg/architect/dispatching.go
@@ -105,7 +105,7 @@ func (d *Driver) dispatchReadyStory(ctx context.Context, storyID string) error {
 // sendStoryToDispatcher sends a story to the dispatcher.
 func (d *Driver) sendStoryToDispatcher(ctx context.Context, storyID string) error {
 	// Create story message for the dispatcher ("coder" targets any available coder).
-	storyMsg := proto.NewAgentMsg(proto.MsgTypeSTORY, d.architectID, "coder")
+	storyMsg := proto.NewAgentMsg(proto.MsgTypeSTORY, d.GetAgentID(), "coder")
 
 	// Build story payload
 	payloadData := make(map[string]any)

--- a/pkg/architect/effects.go
+++ b/pkg/architect/effects.go
@@ -94,7 +94,7 @@ func (e *DispatchStoryEffect) Execute(_ context.Context, runtime effect.Runtime)
 
 // ExecuteEffect executes a single Effect using the architect's runtime.
 func (d *Driver) ExecuteEffect(ctx context.Context, eff effect.Effect) error {
-	runtime := NewRuntime(d.dispatcher, d.logger, d.architectID, d.replyCh)
+	runtime := NewRuntime(d.dispatcher, d.logger, d.GetAgentID(), d.replyCh)
 	_, err := eff.Execute(ctx, runtime)
 	if err != nil {
 		return fmt.Errorf("effect execution failed: %w", err)

--- a/pkg/architect/escalated.go
+++ b/pkg/architect/escalated.go
@@ -45,7 +45,7 @@ func (d *Driver) handleEscalated(ctx context.Context) (proto.State, error) {
 		escalationText := d.buildEscalationMessage(originState, iterationCount, requestID, storyID)
 
 		resp, err := d.chatService.Post(ctx, &ChatPostRequest{
-			Author:   d.architectID,
+			Author:   d.GetAgentID(),
 			Text:     escalationText,
 			Channel:  "development", // Escalation goes to development channel
 			PostType: "escalate",

--- a/pkg/architect/questions.go
+++ b/pkg/architect/questions.go
@@ -158,7 +158,7 @@ func (qh *QuestionHandler) answerTechnicalQuestion(ctx context.Context, pendingQ
 		ExtractResult:  ExtractSubmitReply,
 		MaxIterations:  10,
 		MaxTokens:      agent.ArchitectMaxTokens,
-		AgentID:        qh.driver.architectID,
+		AgentID:        qh.driver.GetAgentID(),
 	})
 
 	if err != nil {

--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -227,7 +227,7 @@ func (d *Driver) handleQuestionRequest(ctx context.Context, questionMsg *proto.A
 			ExtractResult:  ExtractSubmitReply,
 			MaxIterations:  10,
 			MaxTokens:      agent.ArchitectMaxTokens,
-			AgentID:        d.architectID,
+			AgentID:        d.GetAgentID(),
 		})
 
 		if err == nil {
@@ -237,7 +237,7 @@ func (d *Driver) handleQuestionRequest(ctx context.Context, questionMsg *proto.A
 	}
 
 	// Create RESPONSE using unified protocol.
-	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.architectID, questionMsg.FromAgent)
+	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), questionMsg.FromAgent)
 	response.ParentMsgID = questionMsg.ID
 
 	// Set typed question response payload
@@ -366,7 +366,7 @@ func (d *Driver) handleApprovalRequest(ctx context.Context, requestMsg *proto.Ag
 		Type:       approvalType,
 		Status:     proto.ApprovalStatusApproved,
 		Feedback:   "", // Will be set after status determination and formatting
-		ReviewedBy: d.architectID,
+		ReviewedBy: d.GetAgentID(),
 		ReviewedAt: time.Now().UTC(),
 	}
 
@@ -481,7 +481,7 @@ func (d *Driver) handleApprovalRequest(ctx context.Context, requestMsg *proto.Ag
 	}
 
 	// Create RESPONSE using unified protocol with typed approval response payload.
-	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.architectID, requestMsg.FromAgent)
+	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), requestMsg.FromAgent)
 	response.ParentMsgID = requestMsg.ID
 
 	// Set typed approval response payload
@@ -558,7 +558,7 @@ func (d *Driver) buildApprovalResponseFromReviewComplete(ctx context.Context, re
 		Type:       approvalType,
 		Status:     status,
 		Feedback:   feedback,
-		ReviewedBy: d.architectID,
+		ReviewedBy: d.GetAgentID(),
 		ReviewedAt: time.Now().UTC(),
 	}
 
@@ -571,7 +571,7 @@ func (d *Driver) buildApprovalResponseFromReviewComplete(ctx context.Context, re
 	}
 
 	// Create response message
-	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.architectID, requestMsg.FromAgent)
+	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), requestMsg.FromAgent)
 	response.ParentMsgID = requestMsg.ID
 	response.SetTypedPayload(proto.NewApprovalResponsePayload(approvalResult))
 
@@ -859,7 +859,7 @@ func (d *Driver) handleIterativeApproval(ctx context.Context, requestMsg *proto.
 		},
 		MaxIterations: 20, // Allow multiple inspection iterations
 		MaxTokens:     agent.ArchitectMaxTokens,
-		AgentID:       d.architectID,
+		AgentID:       d.GetAgentID(),
 	})
 
 	if err != nil {
@@ -933,7 +933,7 @@ func (d *Driver) handleSingleTurnReview(ctx context.Context, requestMsg *proto.A
 		MaxIterations:  3, // Allow nudge retries
 		MaxTokens:      agent.ArchitectMaxTokens,
 		SingleTurn:     true, // Enforce single-turn completion
-		AgentID:        d.architectID,
+		AgentID:        d.GetAgentID(),
 	})
 
 	if err != nil {
@@ -1007,7 +1007,7 @@ func (d *Driver) buildApprovalResponseFromSubmit(ctx context.Context, requestMsg
 		Type:       approvalPayload.ApprovalType,
 		Status:     status,
 		Feedback:   feedback,
-		ReviewedBy: d.architectID,
+		ReviewedBy: d.GetAgentID(),
 		ReviewedAt: time.Now().UTC(),
 	}
 
@@ -1021,7 +1021,7 @@ func (d *Driver) buildApprovalResponseFromSubmit(ctx context.Context, requestMsg
 	}
 
 	// Create response message
-	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.architectID, requestMsg.FromAgent)
+	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), requestMsg.FromAgent)
 	response.ParentMsgID = requestMsg.ID
 	response.SetTypedPayload(proto.NewApprovalResponsePayload(approvalResult))
 
@@ -1201,7 +1201,7 @@ func (d *Driver) buildQuestionResponseFromSubmit(requestMsg *proto.AgentMsg, sub
 	answerPayload.Metadata[proto.KeyExplorationMethod] = "iterative_with_tools"
 
 	// Create response message
-	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.architectID, requestMsg.FromAgent)
+	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), requestMsg.FromAgent)
 	response.ParentMsgID = requestMsg.ID
 	response.SetTypedPayload(proto.NewQuestionResponsePayload(answerPayload))
 

--- a/pkg/architect/request_merge.go
+++ b/pkg/architect/request_merge.go
@@ -40,7 +40,7 @@ func (d *Driver) handleMergeRequest(ctx context.Context, request *proto.AgentMsg
 	mergeResult, err := d.attemptPRMerge(ctx, prURLStr, branchNameStr, storyIDStr)
 
 	// Create RESPONSE using unified protocol.
-	resultMsg := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.architectID, request.FromAgent)
+	resultMsg := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), request.FromAgent)
 	resultMsg.ParentMsgID = request.ID
 
 	// Copy story_id from request metadata for dispatcher validation

--- a/pkg/architect/request_spec.go
+++ b/pkg/architect/request_spec.go
@@ -57,7 +57,7 @@ func (d *Driver) handleSpecReview(ctx context.Context, requestMsg *proto.AgentMs
 		ExtractResult:  ExtractSpecReview,
 		MaxIterations:  20, // Increased for complex spec review workflows
 		MaxTokens:      agent.ArchitectMaxTokens,
-		AgentID:        d.architectID,
+		AgentID:        d.GetAgentID(),
 	})
 
 	if err != nil {
@@ -98,7 +98,7 @@ func (d *Driver) handleSpecReview(ctx context.Context, requestMsg *proto.AgentMs
 	}
 
 	// Create RESPONSE message with approval result
-	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.architectID, requestMsg.FromAgent)
+	response := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), requestMsg.FromAgent)
 	response.ParentMsgID = requestMsg.ID
 
 	// Determine approval status
@@ -115,7 +115,7 @@ func (d *Driver) handleSpecReview(ctx context.Context, requestMsg *proto.AgentMs
 		Type:       proto.ApprovalTypeSpec,
 		Status:     status,
 		Feedback:   feedback,
-		ReviewedBy: d.architectID,
+		ReviewedBy: d.GetAgentID(),
 		ReviewedAt: response.Timestamp,
 	}
 

--- a/pkg/coder/coding.go
+++ b/pkg/coder/coding.go
@@ -131,7 +131,7 @@ func (c *Coder) executeCodingWithTemplate(ctx context.Context, sm *agent.BaseSta
 		ToolProvider:   c.codingToolProvider,
 		MaxIterations:  maxCodingIterations,
 		MaxTokens:      8192, // Increased for comprehensive code generation
-		AgentID:        c.agentID,
+		AgentID:        c.GetAgentID(),
 		DebugLogging:   false,
 		CheckTerminal: func(calls []agent.ToolCall, results []any) string {
 			return c.checkCodingTerminal(ctx, sm, calls, results)

--- a/pkg/coder/driver_simple_test.go
+++ b/pkg/coder/driver_simple_test.go
@@ -34,15 +34,17 @@ func createBasicCoder(t *testing.T) *Coder {
 		Context: context.Background(),
 	})
 
+	// Create BaseStateMachine
+	sm := agent.NewBaseStateMachine(agentConfig.ID, proto.StateWaiting, nil, CoderTransitions)
+
 	return &Coder{
-		agentConfig:     agentConfig,
-		agentID:         "test-coder-001",
-		contextManager:  contextMgr,
-		renderer:        renderer,
-		logger:          logger,
-		workDir:         tempDir,
-		originalWorkDir: tempDir,
-		codingBudget:    3,
+		BaseStateMachine: sm,
+		contextManager:   contextMgr,
+		renderer:         renderer,
+		logger:           logger,
+		workDir:          tempDir,
+		originalWorkDir:  tempDir,
+		codingBudget:     3,
 	}
 }
 
@@ -146,7 +148,7 @@ func TestCoderToolProviders(t *testing.T) {
 func TestRuntimeOperations(t *testing.T) {
 	coder := createBasicCoder(t)
 	replyCh := make(chan *proto.AgentMsg, 1)
-	runtime := NewRuntime(coder.dispatcher, coder.logger, coder.agentID, replyCh)
+	runtime := NewRuntime(coder.dispatcher, coder.logger, coder.GetAgentID(), replyCh)
 
 	// Test GetAgentID
 	agentID := runtime.GetAgentID()

--- a/pkg/coder/plan_review.go
+++ b/pkg/coder/plan_review.go
@@ -310,7 +310,7 @@ Use the todos_add tool NOW to submit your implementation todos.`, plan, taskCont
 		ToolProvider:   todoToolProvider,
 		MaxIterations:  2,    // One call + one retry if needed
 		MaxTokens:      4096, // Sufficient for todo list
-		AgentID:        c.agentID,
+		AgentID:        c.GetAgentID(),
 		DebugLogging:   true, // Enable verbose logging for debugging
 		CheckTerminal: func(calls []agent.ToolCall, results []any) string {
 			return c.checkTodoCollectionTerminal(ctx, sm, calls, results)

--- a/pkg/coder/planning.go
+++ b/pkg/coder/planning.go
@@ -147,7 +147,7 @@ func (c *Coder) handlePlanning(ctx context.Context, sm *agent.BaseStateMachine) 
 		ToolProvider:   c.planningToolProvider,
 		MaxIterations:  maxPlanningIterations,
 		MaxTokens:      8192, // Increased for exploration
-		AgentID:        c.agentID,
+		AgentID:        c.GetAgentID(),
 		DebugLogging:   false,
 		CheckTerminal: func(calls []agent.ToolCall, results []any) string {
 			return c.checkPlanningTerminal(ctx, sm, calls, results)

--- a/pkg/pm/await_user.go
+++ b/pkg/pm/await_user.go
@@ -15,7 +15,7 @@ func (d *Driver) handleAwaitUser(ctx context.Context) (proto.State, error) {
 	d.logger.Debug("⏳ PM awaiting user response")
 
 	// Check for new messages without blocking
-	if !d.chatService.HaveNewMessages(d.pmID) {
+	if !d.chatService.HaveNewMessages(d.GetAgentID()) {
 		// No new messages yet - sleep briefly to avoid tight polling
 		time.Sleep(500 * time.Millisecond)
 		return StateAwaitUser, nil

--- a/pkg/pm/effects.go
+++ b/pkg/pm/effects.go
@@ -48,7 +48,7 @@ func (e *SendMessageEffect) Execute(_ context.Context, runtime effect.Runtime) (
 
 // ExecuteEffect executes a single Effect using the PM's runtime.
 func (d *Driver) ExecuteEffect(ctx context.Context, eff effect.Effect) error {
-	runtime := NewRuntime(d.dispatcher, d.logger, d.pmID, d.replyCh)
+	runtime := NewRuntime(d.dispatcher, d.logger, d.GetAgentID(), d.replyCh)
 	_, err := eff.Execute(ctx, runtime)
 	if err != nil {
 		return fmt.Errorf("effect execution failed: %w", err)

--- a/pkg/pm/working.go
+++ b/pkg/pm/working.go
@@ -235,7 +235,7 @@ func (d *Driver) callLLMWithTools(ctx context.Context, prompt string) (string, e
 		ToolProvider:   d.toolProvider, // PM's tool provider
 		MaxIterations:  10,
 		MaxTokens:      agent.ArchitectMaxTokens, // TODO: Add PMMaxTokens constant to config
-		AgentID:        d.pmID,                   // Agent ID for tool context
+		AgentID:        d.GetAgentID(),           // Agent ID for tool context
 		DebugLogging:   true,                     // Enable for debugging: shows messages sent to LLM
 		CheckTerminal: func(calls []agent.ToolCall, results []any) string {
 			// Process results and check for terminal signals
@@ -243,7 +243,7 @@ func (d *Driver) callLLMWithTools(ctx context.Context, prompt string) (string, e
 		},
 		ExtractResult: ExtractPMWorkingResult,
 		Escalation: &toolloop.EscalationConfig{
-			Key:       fmt.Sprintf("pm_working_%s", d.pmID),
+			Key:       fmt.Sprintf("pm_working_%s", d.GetAgentID()),
 			SoftLimit: 8,  // Warn at 8 iterations
 			HardLimit: 10, // Require user status update at 10 iterations
 			OnSoftLimit: func(count int) {
@@ -423,7 +423,7 @@ func (d *Driver) sendSpecApprovalRequest(_ context.Context) error {
 	requestMsg := &proto.AgentMsg{
 		ID:        fmt.Sprintf("pm-spec-req-%d", time.Now().UnixNano()),
 		Type:      proto.MsgTypeREQUEST,
-		FromAgent: d.pmID,
+		FromAgent: d.GetAgentID(),
 		ToAgent:   "architect-001", // TODO: Get architect ID from config or dispatcher
 		Payload:   proto.NewApprovalRequestPayload(approvalPayload),
 	}


### PR DESCRIPTION
## Summary

Completes Phase 2 of the refactor proposal (§2.7) - ID Unification.

This PR eliminates duplicate ID fields from all three agent types (Coder, Architect, PM) and standardizes on using `BaseStateMachine.GetAgentID()` everywhere.

## Changes

### Coder
- ✅ Removed `agentID` field from Coder struct
- ✅ Updated all references to use `GetAgentID()` in driver.go, planning.go, plan_review.go, coding.go
- ✅ Updated test file to create BaseStateMachine properly
- ✅ Removed unused `agentConfig` and `agentCtx` variables
- ✅ Removed unused "log" import

### Architect
- ✅ Removed `architectID` field from Architect struct
- ✅ Updated all references across 8 files: driver.go, dispatching.go, escalated.go, questions.go, request.go, request_merge.go, request_spec.go, effects.go

### PM
- ✅ Removed `pmID` field from PM struct
- ✅ Updated all references across 4 files: driver.go, await_user.go, effects.go, working.go

## Key Design Decision

User insight: "why special case coder? why not get rid of the shadow and just use c.GetAgentID() universally?"

Result: **Zero special cases** - all agents follow identical pattern with single source of truth:
```
agent.Config.ID → BaseStateMachine.agentID → GetAgentID() accessor
```

## Test Results

- ✅ All existing tests pass (cached)
- ✅ Full build with linting passes
- ✅ Pre-commit hooks pass
- ✅ Zero compilation errors

## Files Modified

18 files changed, 119 insertions(+), 104 deletions(-)

## Related

- Follows PR #30 (Phase 1: Runtime Unification)
- Part of proposal in docs/multi-agent-review-and-toolloop-refactor.md
- Next phase: Outcome[T] Refactor (§2.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)