### PR TITLE
Phase 3: Outcome[T] Refactor

### DIFF
--- a/pkg/agent/toolloop/errors.go
+++ b/pkg/agent/toolloop/errors.go
@@ -1,0 +1,21 @@
+package toolloop
+
+import "errors"
+
+// Extractor sentinel errors define a shared vocabulary for extraction failures.
+// These are returned by ExtractResult functions when terminal conditions aren't met.
+
+var (
+	// ErrNoTerminalTool indicates that required terminal tools weren't called.
+	// Example: Planning loop expects "plan_complete" tool but LLM didn't call it.
+	ErrNoTerminalTool = errors.New("no terminal tool was called")
+
+	// ErrNoActivity indicates the LLM did nothing meaningful (no tools, no changes).
+	// This is distinct from OutcomeNoToolTwice which is a loop-level guard.
+	// ErrNoActivity is an extractor-level semantic failure.
+	ErrNoActivity = errors.New("no tool calls or changes were made")
+
+	// ErrInvalidResult indicates a terminal tool was called but the payload is malformed.
+	// Example: "done" tool called but "summary" field is missing or empty.
+	ErrInvalidResult = errors.New("invalid tool result payload")
+)

--- a/pkg/agent/toolloop/outcome.go
+++ b/pkg/agent/toolloop/outcome.go
@@ -1,0 +1,87 @@
+package toolloop
+
+import "fmt"
+
+// OutcomeKind categorizes the result of a toolloop execution.
+// These are loop-level outcomes describing what happened during iteration.
+type OutcomeKind int
+
+const (
+	// OutcomeSuccess indicates the loop completed successfully with a terminal signal.
+	// Signal field contains the state transition signal (e.g., "PLAN_REVIEW", "TESTING").
+	// Value field contains the extracted result from ExtractResult.
+	OutcomeSuccess OutcomeKind = iota
+
+	// OutcomeNoToolTwice indicates the LLM failed to use tools twice in a row.
+	// This is a loop-level guard that prevents infinite loops when LLM ignores tools.
+	OutcomeNoToolTwice
+
+	// OutcomeIterationLimit indicates Escalation.HardLimit was reached.
+	// This is a normal termination condition for work that needs human intervention.
+	// Iteration field contains the 1-indexed iteration count at which limit was hit.
+	OutcomeIterationLimit
+
+	// OutcomeMaxIterations indicates MaxIterations was exceeded without hitting HardLimit.
+	// This occurs when no escalation config is provided or limits haven't been reached.
+	OutcomeMaxIterations
+
+	// OutcomeLLMError indicates the LLM client failed (network, API error, etc.).
+	// Err field contains the underlying error from the LLM client.
+	OutcomeLLMError
+
+	// OutcomeExtractionError indicates CheckTerminal signaled completion but ExtractResult failed.
+	// This happens when terminal tools were called but results couldn't be parsed.
+	// Use errors.Is(out.Err, ErrNoTerminalTool) for fine-grained handling of extraction failures.
+	OutcomeExtractionError
+)
+
+// String returns human-readable name for OutcomeKind.
+func (k OutcomeKind) String() string {
+	switch k {
+	case OutcomeSuccess:
+		return "Success"
+	case OutcomeNoToolTwice:
+		return "NoToolTwice"
+	case OutcomeIterationLimit:
+		return "IterationLimit"
+	case OutcomeMaxIterations:
+		return "MaxIterations"
+	case OutcomeLLMError:
+		return "LLMError"
+	case OutcomeExtractionError:
+		return "ExtractionError"
+	default:
+		return fmt.Sprintf("OutcomeKind(%d)", k)
+	}
+}
+
+// Outcome represents the result of a toolloop execution with typed result extraction.
+// Generic over result type T for type-safe extraction of terminal tool data.
+//
+//nolint:govet // Field order optimized for readability over memory alignment
+type Outcome[T any] struct {
+	// Kind categorizes what happened during the loop (success, error, limit, etc.).
+	Kind OutcomeKind
+
+	// Signal is the terminal signal from CheckTerminal (e.g., "PLAN_REVIEW", "TESTING").
+	// Only meaningful when Kind == OutcomeSuccess.
+	// Empty string means normal completion with no state transition.
+	Signal string
+
+	// Value is the extracted result from ExtractResult.
+	// Only valid when Kind == OutcomeSuccess.
+	// Zero value of T for all other outcomes.
+	Value T
+
+	// Err is the underlying error (non-nil for all non-Success outcomes).
+	// For OutcomeExtractionError, check with errors.Is for sentinel errors:
+	//   - errors.Is(out.Err, ErrNoTerminalTool)
+	//   - errors.Is(out.Err, ErrNoActivity)
+	//   - errors.Is(out.Err, ErrInvalidResult)
+	Err error
+
+	// Iteration is the 1-indexed iteration count when the outcome occurred.
+	// Useful for logging, metrics, and debugging.
+	// Example: "reached iteration limit at iteration 16"
+	Iteration int
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the toolloop refactor - replacing the 3-value return signature `(signal string, result T, err error)` with a typed `Outcome[T]` struct.

### Changes

**New Files:**
- `pkg/agent/toolloop/outcome.go` - Outcome[T] type and OutcomeKind enum
- `pkg/agent/toolloop/errors.go` - Extractor sentinel errors

**Modified Core:**
- `pkg/agent/toolloop/toolloop.go` - Changed Run signature to return Outcome[T]

**Updated Callsites (12 production):**
- `pkg/pm/working.go` - PM bootstrap workflow
- `pkg/coder/planning.go` - Coder planning with budget review escalation
- `pkg/coder/coding.go` - Coder implementation phase
- `pkg/coder/plan_review.go` - Todo collection phase
- `pkg/architect/questions.go` - Question answering
- `pkg/architect/request.go` - 3 callsites (auto-response, iterative approval, single-turn review)
- `pkg/architect/request_spec.go` - Spec review

**Updated Tests:**
- `pkg/agent/toolloop/toolloop_test.go` - All 11 test functions updated

**Documentation:**
- `docs/multi-agent-review-and-toolloop-refactor.md` - Phase 3 completion details

### Key Improvements

1. **Explicit outcome classification** via OutcomeKind enum (Success, NoToolTwice, IterationLimit, MaxIterations, LLMError, ExtractionError)
2. **Type-safe pattern**: Switch on `out.Kind` first, then `out.Signal` for state transitions
3. **No magic strings**: All signals use typed state constants (StateTesting, StateCoding, etc.)
4. **Preserved business logic**: All agent-specific error handling maintained
5. **Breaking change strategy**: Compiler errors forced explicit review of all callsites

### Test Results

- All tests passing ✅
- Full build with linting successful ✅
- 12 files changed: 549 insertions(+), 248 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)