### PR TITLE
Phase 5: Cleanup Dead Code

### DIFF
--- a/docs/multi-agent-review-and-toolloop-refactor.md
+++ b/docs/multi-agent-review-and-toolloop-refactor.md
@@ -1341,3 +1341,86 @@ case toolloop.OutcomeExtractionError:
 - ✅ Cleaner extractor contracts - clear separation of error cases
 
 **Next Phase:** Cleanup (§2.6) - remove dead code and finalize refactor
+
+---
+
+### Phase 5: Cleanup (§2.6) - ✅ COMPLETED
+
+**PR:** `refactor/cleanup-dead-code`
+
+**Status:** Implemented and tested
+
+**Changes:**
+- Removed dead code identified in the proposal (§2.6)
+- Removed unused functions and constants across PM, Coder, and Architect
+- Fixed incorrect `//nolint:unused` comments
+
+**Dead Code Removed:**
+
+1. **Coder Package** (`pkg/coder/`):
+   - ❌ Removed `loadTodoListFromState` - Never called, marked with `//nolint:unused`
+   - ❌ Removed `getExplorationHistory()` - Always returned empty `[]string{}`
+   - ❌ Removed `getFilesExamined()` - Always returned empty `[]string{}`
+   - ❌ Removed `getCurrentFindings()` - Always returned empty `map[string]any{}`
+   - ❌ Removed test `TestCoderHelperFunctions` - Only tested the above placeholder functions
+   - ✅ Kept `joinStrings` - Actually used by `getTodoListStatus` (removed incorrect nolint comment)
+   - ✅ Fixed `getTodoListStatus` - Removed incorrect `//nolint:unused` comment (function is actually used in coding.go)
+
+2. **PM Package** (`pkg/pm/`):
+   - ❌ Removed `renderWorkingPrompt()` - Never called, 43 lines of dead template rendering code
+
+3. **Architect Package** (`pkg/architect/`):
+   - ❌ Removed `acceptanceCriteriaHeader` constant - Never referenced
+
+**Impact:**
+
+- **Lines removed:** ~70 lines of truly dead code
+- **Files modified:** 4 files
+  - `pkg/coder/planning.go` - Removed 3 placeholder helper functions
+  - `pkg/coder/todo_handlers.go` - Removed unused function, fixed nolint comments
+  - `pkg/coder/driver_simple_test.go` - Removed test for dead helpers
+  - `pkg/pm/working.go` - Removed unused rendering function
+  - `pkg/architect/driver.go` - Removed unused constant
+
+**Design Decisions:**
+
+1. **Conservative Approach:** Only removed code explicitly identified in proposal + obvious unused items found during scan
+2. **Preserved Active Code:** Kept `joinStrings` and `getTodoListStatus` despite incorrect nolint markers because they ARE used
+3. **Test Cleanup:** Removed legacy test that only tested placeholder functions
+4. **No Functional Changes:** All removals are pure dead code - no behavioral changes
+
+**Why These Were Dead:**
+
+- **Exploration Helpers:** Placeholders for future feature that was never implemented. Always returned empty structures.
+- **loadTodoListFromState:** Intended for state restoration but never wired into initialization flow.
+- **renderWorkingPrompt:** Template rendering function that was superseded by toolloop-based PM working flow.
+- **acceptanceCriteriaHeader:** Leftover constant from refactoring, no longer used in any templates.
+
+**Test Results:**
+- ✅ All tests pass
+- ✅ Full build with linting succeeds
+- ✅ No compilation errors or warnings
+- ✅ No behavioral changes
+
+**Benefits:**
+
+1. **Reduced Codebase Size:** ~70 lines of dead code eliminated
+2. **Clearer Intent:** Removed misleading nolint comments that suggested code would be used "next"
+3. **Easier Maintenance:** Fewer functions to maintain and reason about
+4. **Better Code Quality:** Removes confusion about what code is actually active vs placeholder
+
+**Files Modified (4 total):**
+- `pkg/coder/planning.go` - Removed 3 placeholder helpers
+- `pkg/coder/todo_handlers.go` - Removed unused function + fixed comments
+- `pkg/coder/driver_simple_test.go` - Removed obsolete test
+- `pkg/pm/working.go` - Removed unused rendering function
+- `pkg/architect/driver.go` - Removed unused constant
+
+**Outcomes:**
+- ✅ All dead code from proposal removed
+- ✅ Incorrect nolint comments fixed
+- ✅ Codebase is cleaner and more maintainable
+- ✅ No functional regressions
+- ✅ Foundation for future feature work without misleading placeholders
+
+**Next Steps:** Review and merge Dependabot dependency updates

--- a/pkg/architect/driver.go
+++ b/pkg/architect/driver.go
@@ -22,11 +22,8 @@ import (
 	"orchestrator/pkg/workspace"
 )
 
-// Story content constants.
+// Tool signal constants.
 const (
-	acceptanceCriteriaHeader = "## Acceptance Criteria\n" //nolint:unused
-
-	// Tool signal constants.
 	signalSubmitStoriesComplete = "SUBMIT_STORIES_COMPLETE"
 	signalSpecFeedbackSent      = "SPEC_FEEDBACK_SENT"
 	signalReviewComplete        = "REVIEW_COMPLETE"

--- a/pkg/coder/driver_simple_test.go
+++ b/pkg/coder/driver_simple_test.go
@@ -235,27 +235,6 @@ func TestCoderStateConstants(t *testing.T) {
 	}
 }
 
-// Test helper functions that are just simple getters.
-func TestCoderHelperFunctions(t *testing.T) {
-	coder := createBasicCoder(t)
-
-	// Test exploration history functions - these return hardcoded values
-	history := coder.getExplorationHistory()
-	if history == nil {
-		t.Error("Expected non-nil exploration history")
-	}
-
-	files := coder.getFilesExamined()
-	if files == nil {
-		t.Error("Expected non-nil files examined")
-	}
-
-	findings := coder.getCurrentFindings()
-	if findings == nil {
-		t.Error("Expected non-nil current findings")
-	}
-}
-
 // Test auto action constants.
 func TestAutoActionConstants(t *testing.T) {
 	actions := []AutoAction{

--- a/pkg/coder/planning.go
+++ b/pkg/coder/planning.go
@@ -315,11 +315,6 @@ func (c *Coder) processPlanningResult(sm *agent.BaseStateMachine, result *Planni
 	return nil
 }
 
-// Context management placeholder helper methods for planning.
-func (c *Coder) getExplorationHistory() any { return []string{} }
-func (c *Coder) getFilesExamined() any      { return []string{} }
-func (c *Coder) getCurrentFindings() any    { return map[string]any{} }
-
 // retrieveKnowledgePack extracts key terms from story content and retrieves relevant knowledge.
 func (c *Coder) retrieveKnowledgePack(_ context.Context, taskContent string) (string, error) {
 	// Parse story content to extract description and acceptance criteria

--- a/pkg/coder/todo_handlers.go
+++ b/pkg/coder/todo_handlers.go
@@ -83,8 +83,6 @@ func (c *Coder) handleTodoUpdate(sm *agent.BaseStateMachine, index int, newDescr
 
 // getTodoListStatus returns a formatted string showing current todo status.
 // Used by templates to display current todo in CODING state.
-//
-//nolint:unused // Will be used in templates next
 func (c *Coder) getTodoListStatus() string {
 	if c.todoList == nil || len(c.todoList.Items) == 0 {
 		return "No todo list available"
@@ -125,24 +123,7 @@ func (c *Coder) getTodoListStatus() string {
 	return status
 }
 
-// loadTodoListFromState loads the todo list from state data (for restarts).
-// Called during agent initialization to restore todo list after restart.
-//
-//nolint:unused // Will be used in agent initialization next
-func (c *Coder) loadTodoListFromState(sm *agent.BaseStateMachine) {
-	if todoData, exists := sm.GetStateValue("todo_list"); exists {
-		if todoList, ok := todoData.(*TodoList); ok {
-			c.todoList = todoList
-			c.logger.Info("📋 [TODO] Restored todo list from state: %d items, %d completed",
-				c.todoList.GetTotalCount(),
-				c.todoList.GetCompletedCount())
-		}
-	}
-}
-
 // joinStrings joins strings (helper for getTodoListStatus).
-//
-//nolint:unused // Used by getTodoListStatus
 func joinStrings(strs []string, sep string) string {
 	if len(strs) == 0 {
 		return ""

--- a/pkg/pm/working.go
+++ b/pkg/pm/working.go
@@ -176,50 +176,6 @@ func (d *Driver) setupInterviewContext() error {
 	return nil
 }
 
-// renderWorkingPrompt renders the PM working template with current state.
-//
-//nolint:unused // Reserved for future PM template rendering functionality
-func (d *Driver) renderWorkingPrompt() (string, error) {
-	// Get state data
-	stateData := d.GetStateData()
-
-	// Get conversation history from state
-	conversationHistory, _ := stateData["conversation"].([]map[string]string)
-	expertise, _ := stateData["expertise"].(string)
-	if expertise == "" {
-		expertise = DefaultExpertise
-	}
-
-	// Get architect feedback if present
-	architectFeedback, _ := stateData["architect_feedback"].(string)
-
-	// Get draft spec if present
-	draftSpec, _ := stateData["draft_spec"].(string)
-
-	// Build template data
-	templateData := &templates.TemplateData{
-		Extra: map[string]any{
-			"Expertise":           expertise,
-			"ConversationHistory": conversationHistory,
-			"ArchitectFeedback":   architectFeedback,
-			"DraftSpec":           draftSpec,
-		},
-	}
-
-	// Render template with user instructions
-	prompt, err := d.renderer.RenderWithUserInstructions(
-		templates.PMWorkingTemplate,
-		templateData,
-		d.workDir,
-		"PM",
-	)
-	if err != nil {
-		return "", fmt.Errorf("failed to render PM working template: %w", err)
-	}
-
-	return prompt, nil
-}
-
 // callLLMWithTools calls the LLM with PM tools in an iteration loop.
 // Similar to architect's callLLMWithTools but with PM-specific tool handling.
 //


### PR DESCRIPTION
## Summary

Implements Phase 5 of the toolloop refactor (§2.6) - removes dead code identified in the proposal and fixes misleading `//nolint:unused` comments.

### Dead Code Removed

**Coder Package:**
- ❌ `loadTodoListFromState` - Never called, marked with `//nolint:unused`
- ❌ `getExplorationHistory()` - Always returned empty `[]string{}`
- ❌ `getFilesExamined()` - Always returned empty `[]string{}`
- ❌ `getCurrentFindings()` - Always returned empty `map[string]any{}`
- ❌ `TestCoderHelperFunctions` - Test that only tested the above placeholder functions

**PM Package:**
- ❌ `renderWorkingPrompt()` - 43 lines of unused template rendering code, superseded by toolloop-based flow

**Architect Package:**
- ❌ `acceptanceCriteriaHeader` constant - Never referenced

### Fixed Misleading Comments

- ✅ Removed incorrect `//nolint:unused` from `getTodoListStatus` (actually used in coding.go)
- ✅ Removed incorrect `//nolint:unused` from `joinStrings` (actually used by getTodoListStatus)

### Why This Code Was Dead

- **Exploration Helpers:** Placeholders for future feature never implemented
- **loadTodoListFromState:** Intended for state restoration but never wired into initialization
- **renderWorkingPrompt:** Superseded by toolloop-based PM working flow
- **acceptanceCriteriaHeader:** Leftover from refactoring

### Benefits

1. **Reduced Codebase Size** - ~70 lines of dead code eliminated
2. **Clearer Intent** - No more misleading "will be used next" comments
3. **Easier Maintenance** - Fewer placeholder functions to reason about
4. **Better Code Quality** - Removes confusion about active vs placeholder code

### Test Results

- All tests pass ✅
- Full build with linting succeeds ✅
- No functional changes ✅
- 6 files changed: 84 insertions(+), 93 deletions(-)

### Design Decisions

- **Conservative Approach:** Only removed code explicitly identified in proposal + obvious unused items
- **Preserved Active Code:** Kept functions despite incorrect nolint markers when actually used
- **No Functional Changes:** All removals are pure dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)