### PR TITLE
Fix architect tool configuration and workspace access

### DIFF
--- a/docs/ARCHITECT_TOOL_CONFIGURATION.md
+++ b/docs/ARCHITECT_TOOL_CONFIGURATION.md
@@ -1,0 +1,134 @@
+# Architect Tool Configuration
+
+This document defines the tool sets provided to the architect agent for different request types.
+
+## Tool Configuration by Request Type
+
+### 1. **Plan Approval** (Single-turn)
+- **Handler**: `handleSingleTurnReview`
+- **General Tools**: None
+- **Terminal Tool**: `review_complete`
+- **Rationale**: Plans are text descriptions submitted by the coder. The architect reviews the plan content directly without needing workspace inspection. Single-turn decision based on plan text alone.
+
+### 2. **Budget Review** (Single-turn)
+- **Handler**: `handleSingleTurnReview`
+- **General Tools**: None
+- **Terminal Tool**: `review_complete`
+- **Rationale**: Budget reviews evaluate resource usage and constraints based on request content. No workspace inspection needed, single-turn decision.
+
+### 3. **Code Approval** (Iterative)
+- **Handler**: `handleIterativeApproval`
+- **General Tools**: `read_file`, `list_files`, `get_diff`
+- **Terminal Tool**: `submit_reply`
+- **Rationale**: Code reviews require inspecting the workspace to verify implementation. The architect may need multiple iterations to explore the codebase. `get_diff` is useful for seeing changes.
+
+### 4. **Completion Review** (Iterative)
+- **Handler**: `handleIterativeApproval`
+- **General Tools**: `read_file`, `list_files`, `get_diff`
+- **Terminal Tool**: `submit_reply`
+- **Rationale**: Completion reviews verify all acceptance criteria are met by inspecting the final workspace state. Multiple iterations may be needed to check all criteria. `get_diff` helps see what was implemented.
+
+### 5. **Technical Questions** (Iterative)
+- **Handler**: `handleIterativeQuestion`
+- **General Tools**: `read_file`, `list_files`
+- **Terminal Tool**: `submit_reply`
+- **Rationale**: Questions require workspace inspection to understand the code context. Multiple iterations may be needed to explore. `get_diff` is excluded since there's no "change" being reviewed in a Q&A context.
+
+### 6. **Spec Review** (Special - from PM)
+- **Handler**: `handleSpecReview`
+- **General Tools**: `read_file`, `list_files`
+- **Terminal Tools**: `submit_stories` (approval), `spec_feedback` (rejection)
+- **Rationale**: Spec reviews from PM may need to reference existing project files. Uses PM-specific terminal tools for the workflow (submit stories on approval, provide feedback on rejection).
+
+---
+
+## Design Principles
+
+### Terminal Tools vs General Tools
+
+**Terminal Tools**: Signal completion of the review/question and transition to the next state. The architect must call exactly one terminal tool to complete the interaction.
+
+**General Tools**: Support exploration and analysis but do not complete the interaction. Can be called multiple times in iterative modes.
+
+### Single-turn vs Iterative
+
+**Single-turn** (`SingleTurn: true` in toolloop):
+- Only terminal tools provided (no general tools)
+- Architect must make decision immediately based on request content
+- Used for: Plan reviews, Budget reviews
+- Expects terminal tool call in first iteration
+
+**Iterative** (`SingleTurn: false` in toolloop):
+- Both general tools and terminal tools provided
+- Architect can explore workspace across multiple LLM calls
+- Used for: Code reviews, Completion reviews, Questions
+- Terminal tool called when analysis is complete
+
+### Tool Selection Rationale
+
+**Why no workspace tools for plan reviews?**
+- Plans are descriptions of intended implementation, not actual code
+- The plan text itself contains all information needed for review
+- Workspace inspection would show current state, not planned changes
+
+**Why include `get_diff` for code/completion but not questions?**
+- Code reviews: `get_diff` shows what changed (the diff is the subject of review)
+- Completion reviews: `get_diff` shows what was implemented (helps verify completeness)
+- Questions: No relevant "diff" - coder is asking about existing code or design decisions
+
+**Why different terminal tools?**
+- `review_complete`: For reviews requiring a decision (APPROVED/NEEDS_CHANGES/REJECTED)
+- `submit_reply`: For open-ended responses (questions, iterative review feedback)
+- `submit_stories`/`spec_feedback`: PM workflow-specific tools
+
+---
+
+## Implementation Details
+
+**Code Locations**:
+- Tool provider creation: `pkg/architect/driver.go::createReadToolProviderForCoder()`
+- Request routing: `pkg/architect/request.go::handleApprovalRequest()`
+- Single-turn handler: `pkg/architect/request.go::handleSingleTurnReview()`
+- Iterative approval handler: `pkg/architect/request.go::handleIterativeApproval()`
+- Question handler: `pkg/architect/request.go::handleIterativeQuestion()`
+- Spec review handler: `pkg/architect/request_spec.go::handleSpecReview()`
+
+**Tool Constants**: `pkg/tools/constants.go`
+
+**Key Function Signatures**:
+```go
+// Create tool provider for coder workspace with optional get_diff
+func (d *Driver) createReadToolProviderForCoder(coderID string, includeGetDiff bool) *tools.ToolProvider
+
+// Single-turn reviews (plan, budget)
+func (d *Driver) handleSingleTurnReview(ctx context.Context, requestMsg *proto.AgentMsg, approvalPayload *proto.ApprovalRequestPayload) (*proto.AgentMsg, error)
+
+// Iterative approvals (code, completion)
+func (d *Driver) handleIterativeApproval(ctx context.Context, requestMsg *proto.AgentMsg, approvalPayload *proto.ApprovalRequestPayload) (*proto.AgentMsg, error)
+
+// Iterative questions
+func (d *Driver) handleIterativeQuestion(ctx context.Context, requestMsg *proto.AgentMsg) (*proto.AgentMsg, error)
+```
+
+---
+
+## Future Considerations
+
+### Semantic Naming Improvement
+
+The current tool names could be more semantically consistent:
+- `review_complete` → `submit_review` (all approval types are "reviews")
+- This would make it clearer that questions use `submit_reply` (not a review) while all approvals use `submit_review` (they are reviews)
+
+### Potential Tool Additions
+
+- **Architecture-level tools**: For spec reviews, could add tools to query architectural patterns from knowledge graph
+- **Test execution tools**: For completion reviews, could add ability to run tests and inspect results
+- **Lint/validation tools**: For code reviews, could add static analysis tools
+
+### Tool Set Validation
+
+Consider adding runtime validation that:
+- Single-turn modes only receive terminal tools
+- Iterative modes always include at least one terminal tool
+- No tool set includes multiple terminal tools (except PM workflow)

--- a/pkg/architect/request_code.go
+++ b/pkg/architect/request_code.go
@@ -18,7 +18,11 @@ func (d *Driver) generateCodePrompt(requestMsg *proto.AgentMsg, approvalPayload 
 
 %s
 
-Please review the code changes, inspect their workspace, and provide your decision using submit_reply.
+Please review the code changes against the story acceptance criteria (shown in the system prompt above). Inspect their workspace to verify each acceptance criterion is met.
+
+The story acceptance criteria are the authoritative requirements. Do not introduce new requirements or reference external specifications not mentioned in the story.
+
+Provide your decision using submit_reply.
 
 Your response must start with: APPROVED, NEEDS_CHANGES, or REJECTED`, approvalPayload.Content)
 }

--- a/pkg/architect/request_completion.go
+++ b/pkg/architect/request_completion.go
@@ -18,7 +18,11 @@ func (d *Driver) generateCompletionPrompt(requestMsg *proto.AgentMsg, approvalPa
 
 %s
 
-Please verify completion by reviewing their workspace, checking all acceptance criteria are met, and provide your decision using submit_reply.
+Please verify completion by reviewing their workspace and checking that ALL acceptance criteria in the story (shown in the system prompt above) are met.
+
+The story acceptance criteria are the authoritative definition of "done". Each criterion must be satisfied for approval.
+
+Provide your decision using submit_reply.
 
 Your response must start with: APPROVED, NEEDS_CHANGES, or REJECTED`, approvalPayload.Content)
 }

--- a/pkg/architect/request_plan.go
+++ b/pkg/architect/request_plan.go
@@ -15,7 +15,11 @@ func (d *Driver) generatePlanPrompt(requestMsg *proto.AgentMsg, approvalPayload 
 
 %s
 
-Please review the plan and provide your decision using review_complete.
+Please review the plan against the story acceptance criteria (shown in the system prompt above). The acceptance criteria are the authoritative requirements - verify the plan addresses each one.
+
+If the plan contradicts the story requirements, request changes with specific reference to which acceptance criteria are not met.
+
+Provide your decision using review_complete.
 
 Your decision must be: APPROVED, NEEDS_CHANGES, or REJECTED`, approvalPayload.Content)
 }

--- a/pkg/architect/request_spec.go
+++ b/pkg/architect/request_spec.go
@@ -61,6 +61,7 @@ func (d *Driver) handleSpecReview(ctx context.Context, requestMsg *proto.AgentMs
 		MaxIterations:  20, // Increased for complex spec review workflows
 		MaxTokens:      agent.ArchitectMaxTokens,
 		AgentID:        d.GetAgentID(),
+		DebugLogging:   true, // Enable toolloop debug logging
 	})
 
 	// Handle outcome

--- a/pkg/templates/architect/system_prompt.tpl.md
+++ b/pkg/templates/architect/system_prompt.tpl.md
@@ -23,6 +23,9 @@ As the architect, you:
 - Provide clear, actionable feedback to guide implementation
 - Ensure code quality and adherence to requirements
 
+**Critical: Story Acceptance Criteria are Authoritative**
+The acceptance criteria in the story content above are the **single source of truth** for what must be implemented. Your reviews must validate against these exact requirements. Do not invent additional requirements, reference external "grading specs", or impose constraints not explicitly stated in the story. If you believe the story is unclear or incomplete, ask questions - but the story itself defines what is correct.
+
 ## Workspace Access
 
 When working with {{.Extra.AgentID}}:


### PR DESCRIPTION
## Summary

This PR resolves two critical issues with the architect agent's file system access and strengthens prompts to prevent hallucinated requirements.

## Issues Fixed

### 1. 🔴 Critical: Architect Cannot See Coder Files

**Problem**: The architect's read tools were either missing entirely (plan reviews) or pointed to wrong workspace paths, preventing it from inspecting coder-created files.

**Root Cause**: 
- Plan reviews had NO read tools at all
- Code/completion reviews used `createReadToolProviderForCoder()` correctly
- Questions used correct workspace mounting

**Solution**:
- Plan reviews now get only `review_complete` tool (no workspace inspection needed - plans are text)
- Code/completion reviews correctly mount coder workspaces at `/mnt/coders/{coder-id}` with `get_diff`
- Questions get read tools WITHOUT `get_diff` (not relevant for Q&A)

### 2. ⚠️ Architect Hallucinating Requirements

**Problem**: The architect invented a "grading spec" requiring `knowledge.dot` in repository root, contradicting the actual story which specified `.maestro/knowledge.dot`.

**Solution**: Strengthened all architect prompts with explicit warnings:
> "The acceptance criteria in the story content above are the **single source of truth** for what must be implemented. Do not invent additional requirements, reference external 'grading specs', or impose constraints not explicitly stated in the story."

### 3. 📊 Enabled Toolloop Debug Logging

Added `DebugLogging: true` to all architect toolloop calls for better visibility into LLM interactions.

## Changes

### Core Fixes
- `pkg/architect/driver.go`: Added `includeGetDiff` parameter to `createReadToolProviderForCoder()`
- `pkg/architect/request.go`: Fixed single-turn reviews to provide correct tool sets
  - Plan reviews: Only `review_complete` (no read tools)
  - Budget reviews: Only `review_complete` (no read tools)
  - Code/completion reviews: Read tools + `get_diff` + `submit_reply`
  - Questions: Read tools without `get_diff` + `submit_reply`

### Prompt Improvements
- `pkg/templates/architect/system_prompt.tpl.md`: Added "Story Acceptance Criteria are Authoritative" section
- `pkg/architect/request_plan.go`: Enhanced plan review prompt
- `pkg/architect/request_code.go`: Enhanced code review prompt  
- `pkg/architect/request_completion.go`: Enhanced completion review prompt

### Documentation
- `docs/ARCHITECT_TOOL_CONFIGURATION.md`: New comprehensive documentation of tool sets by request type

## Tool Configuration Summary

| Request Type | General Tools | Terminal Tool | Rationale |
|--------------|---------------|---------------|-----------|
| Plan Review | None | `review_complete` | Plans are text - no workspace inspection needed |
| Budget Review | None | `review_complete` | Decision based on request content only |
| Code Review | `read_file`, `list_files`, `get_diff` | `submit_reply` | Needs workspace inspection to verify implementation |
| Completion Review | `read_file`, `list_files`, `get_diff` | `submit_reply` | Needs to verify all acceptance criteria met |
| Questions | `read_file`, `list_files` | `submit_reply` | Needs workspace context, but no "diff" for Q&A |
| Spec Review | `read_file`, `list_files`, `submit_stories`, `spec_feedback` | Multiple (to be fixed in follow-up) | PM workflow |

## Testing

- ✅ Build passes with all changes
- ✅ Linting passes
- ✅ Pre-commit hooks pass

## Next Steps

This PR is a prerequisite for the larger toolloop refactor (see `docs/TOOLLOOP_REFACTOR_PLAN.md`) which will:
- Enforce exactly one terminal tool per toolloop at compile time
- Regularize all reviews to use `review_complete` instead of `submit_reply`
- Convert spec review to two-phase approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>