### PR TITLE
Add Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,3 +60,18 @@ release:
 
 changelog:
   use: git
+
+homebrew_casks:
+  - name: maestro
+    directory: Casks
+    repository:
+      owner: SnapdragonPartners
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: Maestro CI
+      email: maestro@snapdragonpartners.com
+    homepage: "https://github.com/SnapdragonPartners/maestro"
+    description: "Multi-agent AI coding system orchestrator"
+    binaries:
+      - maestro

--- a/README.md
+++ b/README.md
@@ -119,7 +119,16 @@ This distinction is transparent to the user—architect generates stories automa
 
 ## Quickstart
 
-> **Step 1:** Download binary from [releases](https://github.com/SnapdragonPartners/maestro/releases) (or build from source). Install it somewhere in your path.
+> **Step 1:** Install Maestro via Homebrew (macOS/Linux) or download from [releases](https://github.com/SnapdragonPartners/maestro/releases).
+>
+> **Option A: Homebrew (recommended)**
+> ```bash
+> brew tap SnapdragonPartners/tap
+> brew install --cask maestro
+> ```
+>
+> **Option B: Direct download**
+> Download the binary for your platform from [releases](https://github.com/SnapdragonPartners/maestro/releases) and install it somewhere in your path.
 >
 > **Step 2:** Export your API keys as environment variables for the models you want to use and Github.
 ```bash


### PR DESCRIPTION
## Summary
- Add `homebrew_casks` section to `.goreleaser.yaml` to generate `Casks/maestro.rb`
- Push cask to `SnapdragonPartners/homebrew-tap` on tagged releases
- Add `HOMEBREW_TAP_TOKEN` env var to release workflow
- Update README quickstart with Homebrew installation option

## After merging
Tag v0.4.0 to trigger the release workflow, which will:
1. Build and sign binaries (existing behavior)
2. Create GitHub release (existing behavior)
3. **NEW**: Generate and push `Casks/maestro.rb` to the homebrew-tap repo

## Installation (after release)
```bash
brew tap SnapdragonPartners/tap
brew install --cask maestro
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)