### PR TITLE
Fix goreleaser hooks for MCP proxy builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,8 +6,8 @@ before:
     - go mod tidy
     # Build MCP proxy binaries for embedding (must run before main build)
     - mkdir -p pkg/coder/claude/embedded
-    - CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o pkg/coder/claude/embedded/proxy-linux-arm64 ./cmd/maestro-mcp-proxy
-    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o pkg/coder/claude/embedded/proxy-linux-amd64 ./cmd/maestro-mcp-proxy
+    - sh -c 'CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o pkg/coder/claude/embedded/proxy-linux-arm64 ./cmd/maestro-mcp-proxy'
+    - sh -c 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o pkg/coder/claude/embedded/proxy-linux-amd64 ./cmd/maestro-mcp-proxy'
 
 builds:
   - id: maestro


### PR DESCRIPTION
## Summary
- Wrap CGO_ENABLED/GOOS/GOARCH commands in `sh -c` to ensure environment variables are properly interpreted by the shell in CI environments

## Problem
Goreleaser was failing in CI with:
```
exec: "CGO_ENABLED=0": executable file not found in $PATH
```

The issue is that goreleaser's `before.hooks` were parsing `CGO_ENABLED=0 GOOS=linux ...` as an executable name rather than environment variables followed by a command.

## Solution
Wrap the build commands in `sh -c '...'` so the shell properly interprets the environment variables:
```yaml
- sh -c 'CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ...'
```

## Test plan
- [ ] CI workflow passes
- [ ] Goreleaser successfully builds MCP proxy binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)