### PR TITLE
Small tweaks: security, debugging, and research tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ See the canonical state diagrams for details:
   - One working clone per coder, deleted when the coder terminates
 
 - **Docker:**
-  - Coders run in read-only containers for planning, read-write for coding
-  - Currently run as root for simplicity (rootless support under consideration)
+  - All agents run in Docker containers with security hardening
+  - Containers run as non-privileged user (1000:1000) for security
+  - Coders run read-only for planning, read-write for coding
   - Provides security isolation and portability
 
 - **Makefiles:**
@@ -301,7 +302,7 @@ No. Coders always run in Docker containers for isolation and reproducibility.
 By design. The architect enforces engineering discipline, ensures coders don't review their own work, and keeps technical debt low.
 
 **Q: Is this secure?**
-Maestro is intended as a single-user tool running locally. It is at least as secure as other common LLM-based coding agents (probably more so due to Docker isolation), but since code is already exchanged with third-party LLMs, the trade-off of running root containers is considered acceptable.
+Maestro is intended as a single-user tool running locally. All agents run in Docker containers as a non-privileged user (1000:1000) with security hardening including read-only root filesystem, no-new-privileges, and resource limits. Combined with Docker isolation, this provides reasonable security for local development.
 
 **Q: What happens if Maestro crashes?**
 All stories, states, tool use, messages, and progress are persisted in SQLite. On restart, coders and architect resume where they left off.

--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -9,6 +9,7 @@ import (
 
 	"orchestrator/pkg/agent"
 	"orchestrator/pkg/agent/toolloop"
+	"orchestrator/pkg/config"
 	"orchestrator/pkg/logx"
 	"orchestrator/pkg/persistence"
 	"orchestrator/pkg/proto"
@@ -876,7 +877,7 @@ func (d *Driver) handleIterativeApproval(ctx context.Context, requestMsg *proto.
 		MaxIterations: 20, // Allow multiple inspection iterations
 		MaxTokens:     agent.ArchitectMaxTokens,
 		AgentID:       d.GetAgentID(),
-		DebugLogging:  true, // Enable toolloop debug logging
+		DebugLogging:  config.GetDebugLLMMessages(),
 	})
 
 	// Handle outcome
@@ -976,7 +977,7 @@ func (d *Driver) handleSingleTurnReview(ctx context.Context, requestMsg *proto.A
 		MaxTokens:      agent.ArchitectMaxTokens,
 		SingleTurn:     true, // Enforce single-turn completion
 		AgentID:        d.GetAgentID(),
-		DebugLogging:   true, // Enable toolloop debug logging
+		DebugLogging:   config.GetDebugLLMMessages(),
 	})
 
 	// Handle outcome
@@ -1064,7 +1065,7 @@ func (d *Driver) handleIterativeQuestion(ctx context.Context, requestMsg *proto.
 		MaxIterations:  20, // Allow exploration of workspace
 		MaxTokens:      agent.ArchitectMaxTokens,
 		AgentID:        d.GetAgentID(),
-		DebugLogging:   true,
+		DebugLogging:   config.GetDebugLLMMessages(),
 		Escalation: &toolloop.EscalationConfig{
 			Key:       fmt.Sprintf("question-%s", requestMsg.ID),
 			SoftLimit: 8,

--- a/pkg/architect/request_spec.go
+++ b/pkg/architect/request_spec.go
@@ -6,6 +6,7 @@ import (
 
 	"orchestrator/pkg/agent"
 	"orchestrator/pkg/agent/toolloop"
+	"orchestrator/pkg/config"
 	"orchestrator/pkg/proto"
 	"orchestrator/pkg/templates"
 	"orchestrator/pkg/tools"
@@ -93,7 +94,7 @@ func (d *Driver) handleSpecReview(ctx context.Context, requestMsg *proto.AgentMs
 		MaxIterations:  20, // Allow exploration of project files
 		MaxTokens:      agent.ArchitectMaxTokens,
 		AgentID:        d.GetAgentID(),
-		DebugLogging:   true,
+		DebugLogging:   config.GetDebugLLMMessages(),
 	})
 
 	// Handle review outcome
@@ -198,7 +199,7 @@ func (d *Driver) handleSpecReview(ctx context.Context, requestMsg *proto.AgentMs
 		SingleTurn:     true, // Enforce single-turn completion
 		MaxTokens:      agent.ArchitectMaxTokens,
 		AgentID:        d.GetAgentID(),
-		DebugLogging:   true,
+		DebugLogging:   config.GetDebugLLMMessages(),
 	})
 
 	// Handle story generation outcome

--- a/pkg/coder/coding.go
+++ b/pkg/coder/coding.go
@@ -154,7 +154,7 @@ func (c *Coder) executeCodingWithTemplate(ctx context.Context, sm *agent.BaseSta
 		MaxIterations:  maxCodingIterations,
 		MaxTokens:      8192, // Increased for comprehensive code generation
 		AgentID:        c.GetAgentID(),
-		DebugLogging:   false,
+		DebugLogging:   config.GetDebugLLMMessages(),
 		Escalation: &toolloop.EscalationConfig{
 			Key:       fmt.Sprintf("coding_%s", utils.GetStateValueOr[string](sm, KeyStoryID, "unknown")),
 			SoftLimit: maxCodingIterations - 2, // Warn 2 iterations before limit

--- a/pkg/coder/plan_review.go
+++ b/pkg/coder/plan_review.go
@@ -8,6 +8,7 @@ import (
 
 	"orchestrator/pkg/agent"
 	"orchestrator/pkg/agent/toolloop"
+	"orchestrator/pkg/config"
 	"orchestrator/pkg/effect"
 	"orchestrator/pkg/logx"
 	"orchestrator/pkg/proto"
@@ -338,7 +339,7 @@ Use the todos_add tool NOW to submit your implementation todos.`, plan, taskCont
 		MaxIterations:  2,    // One call + one retry if needed
 		MaxTokens:      4096, // Sufficient for todo list
 		AgentID:        c.GetAgentID(),
-		DebugLogging:   true, // Enable verbose logging for debugging
+		DebugLogging:   config.GetDebugLLMMessages(),
 		Escalation: &toolloop.EscalationConfig{
 			Key:       fmt.Sprintf("todo_collection_%s", utils.GetStateValueOr[string](sm, KeyStoryID, "unknown")),
 			HardLimit: 2,

--- a/pkg/coder/planning.go
+++ b/pkg/coder/planning.go
@@ -169,7 +169,7 @@ func (c *Coder) handlePlanning(ctx context.Context, sm *agent.BaseStateMachine) 
 		MaxIterations:  maxPlanningIterations,
 		MaxTokens:      8192, // Increased for exploration
 		AgentID:        c.GetAgentID(),
-		DebugLogging:   false,
+		DebugLogging:   config.GetDebugLLMMessages(),
 		Escalation: &toolloop.EscalationConfig{
 			Key:       fmt.Sprintf("planning_%s", utils.GetStateValueOr[string](sm, KeyStoryID, "unknown")),
 			SoftLimit: maxPlanningIterations - 2, // Warn 2 iterations before limit

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -677,6 +677,23 @@ func GetContainerTmpfsSize() string {
 	return DefaultTmpfsSize
 }
 
+// GetDebugLLMMessages returns whether debug logging for LLM message formatting is enabled.
+// Returns false by default if config is not loaded or debug is not configured.
+// Must call LoadConfig first to initialize config.
+func GetDebugLLMMessages() bool {
+	cfg, err := GetConfig()
+	if err != nil {
+		return false // Fallback to disabled if config not loaded
+	}
+
+	// Use configured debug setting or default to false
+	if cfg.Debug != nil {
+		return cfg.Debug.LLMMessages
+	}
+
+	return false
+}
+
 // GetConfig returns the current global config BY VALUE (copy, not reference).
 // This prevents external mutation - all updates must go through Update* functions.
 // Must call LoadConfig first to initialize the global config.

--- a/pkg/exec/architect_executor.go
+++ b/pkg/exec/architect_executor.go
@@ -108,8 +108,8 @@ func (a *ArchitectExecutor) Start(ctx context.Context) error {
 		"--cpus", "2",
 		"--memory", "2g",
 		"--pids-limit", "256",
-		// Run as root (architect only reads, no security concerns)
-		"--user", "0:0",
+		// Run as non-privileged user (same as coders for consistency)
+		"--user", "1000:1000",
 	}
 
 	// Network enabled (architect needs to communicate with LLM APIs)

--- a/pkg/exec/pm_executor.go
+++ b/pkg/exec/pm_executor.go
@@ -99,7 +99,8 @@ func (p *PMExecutor) Start(ctx context.Context) error {
 		"--cpus", "2",
 		"--memory", "2g",
 		"--pids-limit", "256",
-		"--user", "0:0",
+		// Run as non-privileged user (same as coders for consistency)
+		"--user", "1000:1000",
 		// Mount PM workspace at /workspace (read-only, same as coders)
 		"--volume", fmt.Sprintf("%s:/workspace:ro", p.pmWorkspace),
 		// Tmpfs mounts for temporary files

--- a/pkg/pm/working.go
+++ b/pkg/pm/working.go
@@ -254,9 +254,9 @@ func (d *Driver) callLLMWithTools(ctx context.Context, prompt string) (string, e
 		GeneralTools:   generalTools,
 		TerminalTool:   terminalTool,
 		MaxIterations:  10,
-		MaxTokens:      agent.ArchitectMaxTokens, // TODO: Add PMMaxTokens constant to config
-		AgentID:        d.GetAgentID(),           // Agent ID for tool context
-		DebugLogging:   true,                     // Enable for debugging: shows messages sent to LLM
+		MaxTokens:      agent.ArchitectMaxTokens,     // TODO: Add PMMaxTokens constant to config
+		AgentID:        d.GetAgentID(),               // Agent ID for tool context
+		DebugLogging:   config.GetDebugLLMMessages(), // Controlled via config.json debug.llm_messages
 		Escalation: &toolloop.EscalationConfig{
 			Key:       fmt.Sprintf("pm_working_%s", d.GetAgentID()),
 			SoftLimit: 8,  // Warn at 8 iterations

--- a/pkg/tools/constants.go
+++ b/pkg/tools/constants.go
@@ -44,6 +44,9 @@ const (
 	ToolSpecSubmit  = "spec_submit"
 	ToolChatAskUser = "chat_ask_user"
 	ToolBootstrap   = "bootstrap"
+
+	// Research tools.
+	// Note: ToolWebSearch is defined in web_search.go to keep tool name with its implementation.
 )
 
 // State-specific tool availability - defines which tools are available in each state.
@@ -124,6 +127,8 @@ var (
 		ToolListFiles,
 		ToolGetDiff,
 		ToolSubmitReply,
+		ToolWebSearch,
+		ToolWebFetch,
 	}
 
 	// PM tools - unified tool set for WORKING state.
@@ -137,6 +142,7 @@ var (
 		ToolBootstrap,
 		ToolSpecSubmit,
 		ToolSubmitStories,
-		// TODO: Add ToolWebBrowser when implemented
+		ToolWebSearch,
+		ToolWebFetch,
 	}
 )

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -554,6 +554,22 @@ func getReviewCompleteSchema() InputSchema {
 	return NewReviewCompleteTool().Definition().InputSchema
 }
 
+func createWebSearchTool(_ *AgentContext) (Tool, error) {
+	return NewWebSearchTool(), nil
+}
+
+func getWebSearchSchema() InputSchema {
+	return NewWebSearchTool().Definition().InputSchema
+}
+
+func createWebFetchTool(_ *AgentContext) (Tool, error) {
+	return NewWebFetchTool(), nil
+}
+
+func getWebFetchSchema() InputSchema {
+	return NewWebFetchTool().Definition().InputSchema
+}
+
 // init registers all tools in the global registry using the factory pattern.
 //
 //nolint:gochecknoinits // Factory pattern requires init() for tool registration
@@ -732,5 +748,18 @@ func init() {
 		Name:        ToolReviewComplete,
 		Description: "Complete a review with decision (APPROVED, NEEDS_CHANGES, or REJECTED) and feedback",
 		InputSchema: getReviewCompleteSchema(),
+	})
+
+	// Register research tools
+	Register(ToolWebSearch, createWebSearchTool, &ToolMeta{
+		Name:        ToolWebSearch,
+		Description: "Search the web for current technical information (API docs, library versions, release notes)",
+		InputSchema: getWebSearchSchema(),
+	})
+
+	Register(ToolWebFetch, createWebFetchTool, &ToolMeta{
+		Name:        ToolWebFetch,
+		Description: "Fetch and read the content of a web page from a URL",
+		InputSchema: getWebFetchSchema(),
 	})
 }

--- a/pkg/tools/web_fetch.go
+++ b/pkg/tools/web_fetch.go
@@ -1,0 +1,245 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ToolWebFetch is the constant name for the web fetch tool.
+const ToolWebFetch = "web_fetch"
+
+// WebFetchTool allows agents to fetch and read web page content.
+// Use this after web_search to read the actual content of pages found in search results.
+type WebFetchTool struct {
+	httpClient   *http.Client
+	maxBodyBytes int64
+}
+
+// NewWebFetchTool creates a new web fetch tool.
+func NewWebFetchTool() *WebFetchTool {
+	return &WebFetchTool{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			// Don't follow too many redirects
+			CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+				if len(via) >= 5 {
+					return fmt.Errorf("too many redirects")
+				}
+				return nil
+			},
+		},
+		maxBodyBytes: 100 * 1024, // 100KB max - enough for most docs but not huge pages
+	}
+}
+
+// Name returns the tool name.
+func (t *WebFetchTool) Name() string {
+	return ToolWebFetch
+}
+
+// PromptDocumentation returns formatted tool documentation for prompts.
+func (t *WebFetchTool) PromptDocumentation() string {
+	return `- **web_fetch** - Fetch and read content from a web page URL
+  - Parameters: url (string, REQUIRED)
+  - Use after web_search to read actual page content from search result URLs
+  - Returns text content extracted from the page (HTML tags stripped)
+  - Best for documentation pages, release notes, API references
+  - Has a 100KB size limit to avoid huge pages`
+}
+
+// Definition returns the tool definition for LLM.
+func (t *WebFetchTool) Definition() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolWebFetch,
+		Description: `Fetch and read the content of a web page. Use this tool after web_search to read the actual content of pages from search results. The tool:
+- Fetches the URL and extracts text content (strips HTML)
+- Works well for documentation, release notes, API references
+- Has a 100KB limit to avoid very large pages
+- Returns the page title and main text content`,
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"url": {
+					Type:        "string",
+					Description: "Full URL to fetch (e.g., 'https://go.dev/doc/go1.22')",
+				},
+			},
+			Required: []string{"url"},
+		},
+	}
+}
+
+// Exec executes the web fetch tool.
+func (t *WebFetchTool) Exec(ctx context.Context, args map[string]any) (*ExecResult, error) {
+	// Extract URL argument
+	urlStr, ok := args["url"].(string)
+	if !ok || urlStr == "" {
+		return nil, fmt.Errorf("url is required and must be a string")
+	}
+
+	// Basic URL validation
+	if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
+		return t.errorResult("URL must start with http:// or https://")
+	}
+
+	// Create request with context
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, http.NoBody)
+	if err != nil {
+		return t.errorResult("failed to create request: " + err.Error())
+	}
+
+	// Set headers to appear as a browser
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; Maestro/1.0; AI Development Tool)")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+
+	// Execute request
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return t.errorResult("fetch request failed: " + err.Error())
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		return t.errorResult(fmt.Sprintf("HTTP error: %d %s", resp.StatusCode, resp.Status))
+	}
+
+	// Check content type - we only want text-based content
+	contentType := resp.Header.Get("Content-Type")
+	if !isTextContent(contentType) {
+		return t.errorResult(fmt.Sprintf("unsupported content type: %s (only text/html and text/plain supported)", contentType))
+	}
+
+	// Read body with size limit
+	limitedReader := io.LimitReader(resp.Body, t.maxBodyBytes)
+	body, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return t.errorResult("failed to read response: " + err.Error())
+	}
+
+	// Extract text content
+	content := string(body)
+	title := extractTitle(content)
+	text := extractText(content)
+
+	// Truncate if still too long after processing
+	const maxOutputChars = 50000 // ~50KB of processed text
+	truncated := false
+	if len(text) > maxOutputChars {
+		text = text[:maxOutputChars]
+		truncated = true
+	}
+
+	// Build response
+	response := map[string]any{
+		"success":   true,
+		"url":       urlStr,
+		"title":     title,
+		"content":   text,
+		"truncated": truncated,
+	}
+
+	resultContent, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	return &ExecResult{Content: string(resultContent)}, nil
+}
+
+// errorResult creates an error result response.
+func (t *WebFetchTool) errorResult(errMsg string) (*ExecResult, error) {
+	response := map[string]any{
+		"success": false,
+		"error":   errMsg,
+	}
+	content, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal error response: %w", err)
+	}
+	return &ExecResult{Content: string(content)}, nil
+}
+
+// isTextContent checks if the content type is text-based.
+func isTextContent(contentType string) bool {
+	ct := strings.ToLower(contentType)
+	return strings.Contains(ct, "text/html") ||
+		strings.Contains(ct, "text/plain") ||
+		strings.Contains(ct, "application/xhtml") ||
+		strings.Contains(ct, "application/xml") ||
+		strings.Contains(ct, "text/xml")
+}
+
+// extractTitle extracts the title from HTML content.
+func extractTitle(html string) string {
+	// Simple regex to extract title
+	titleRegex := regexp.MustCompile(`(?i)<title[^>]*>([^<]+)</title>`)
+	matches := titleRegex.FindStringSubmatch(html)
+	if len(matches) > 1 {
+		return strings.TrimSpace(matches[1])
+	}
+	return ""
+}
+
+// extractText extracts readable text from HTML content.
+func extractText(html string) string {
+	// Remove script and style blocks first
+	scriptRegex := regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
+	html = scriptRegex.ReplaceAllString(html, "")
+
+	styleRegex := regexp.MustCompile(`(?is)<style[^>]*>.*?</style>`)
+	html = styleRegex.ReplaceAllString(html, "")
+
+	// Remove HTML comments
+	commentRegex := regexp.MustCompile(`(?s)<!--.*?-->`)
+	html = commentRegex.ReplaceAllString(html, "")
+
+	// Replace common block elements with newlines
+	blockRegex := regexp.MustCompile(`(?i)</(p|div|h[1-6]|li|tr|br|hr)[^>]*>`)
+	html = blockRegex.ReplaceAllString(html, "\n")
+
+	// Replace br tags
+	brRegex := regexp.MustCompile(`(?i)<br[^>]*>`)
+	html = brRegex.ReplaceAllString(html, "\n")
+
+	// Remove all remaining HTML tags
+	tagRegex := regexp.MustCompile(`<[^>]+>`)
+	text := tagRegex.ReplaceAllString(html, "")
+
+	// Decode common HTML entities
+	text = strings.ReplaceAll(text, "&nbsp;", " ")
+	text = strings.ReplaceAll(text, "&amp;", "&")
+	text = strings.ReplaceAll(text, "&lt;", "<")
+	text = strings.ReplaceAll(text, "&gt;", ">")
+	text = strings.ReplaceAll(text, "&quot;", "\"")
+	text = strings.ReplaceAll(text, "&#39;", "'")
+	text = strings.ReplaceAll(text, "&apos;", "'")
+
+	// Normalize whitespace
+	// Replace multiple spaces with single space
+	spaceRegex := regexp.MustCompile(`[ \t]+`)
+	text = spaceRegex.ReplaceAllString(text, " ")
+
+	// Replace multiple newlines with double newline (paragraph break)
+	newlineRegex := regexp.MustCompile(`\n{3,}`)
+	text = newlineRegex.ReplaceAllString(text, "\n\n")
+
+	// Trim each line
+	lines := strings.Split(text, "\n")
+	var cleanLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			cleanLines = append(cleanLines, trimmed)
+		}
+	}
+
+	return strings.Join(cleanLines, "\n")
+}

--- a/pkg/tools/web_fetch_test.go
+++ b/pkg/tools/web_fetch_test.go
@@ -1,0 +1,304 @@
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWebFetchTool_Definition(t *testing.T) {
+	tool := NewWebFetchTool()
+
+	if tool.Name() != ToolWebFetch {
+		t.Errorf("Name() = %q, want %q", tool.Name(), ToolWebFetch)
+	}
+
+	def := tool.Definition()
+	if def.Name != ToolWebFetch {
+		t.Errorf("Definition().Name = %q, want %q", def.Name, ToolWebFetch)
+	}
+
+	// Check that url parameter is required
+	if len(def.InputSchema.Required) != 1 || def.InputSchema.Required[0] != "url" {
+		t.Errorf("Expected 'url' to be required, got: %v", def.InputSchema.Required)
+	}
+
+	// Check that url property exists
+	if _, ok := def.InputSchema.Properties["url"]; !ok {
+		t.Error("Expected 'url' property in input schema")
+	}
+}
+
+func TestWebFetchTool_PromptDocumentation(t *testing.T) {
+	tool := NewWebFetchTool()
+
+	doc := tool.PromptDocumentation()
+	if doc == "" {
+		t.Error("PromptDocumentation() should not be empty")
+	}
+
+	// Check for key information
+	if !containsString(doc, "web_fetch") {
+		t.Error("PromptDocumentation should mention 'web_fetch'")
+	}
+
+	if !containsString(doc, "url") {
+		t.Error("PromptDocumentation should mention 'url' parameter")
+	}
+}
+
+func TestWebFetchTool_Exec_MissingURL(t *testing.T) {
+	tool := NewWebFetchTool()
+
+	// Test with missing url
+	_, err := tool.Exec(context.Background(), map[string]any{})
+	if err == nil {
+		t.Error("Expected error for missing url parameter")
+	}
+
+	// Test with empty url
+	_, err = tool.Exec(context.Background(), map[string]any{"url": ""})
+	if err == nil {
+		t.Error("Expected error for empty url parameter")
+	}
+
+	// Test with wrong type
+	_, err = tool.Exec(context.Background(), map[string]any{"url": 123})
+	if err == nil {
+		t.Error("Expected error for non-string url parameter")
+	}
+}
+
+func TestWebFetchTool_Exec_InvalidURL(t *testing.T) {
+	tool := NewWebFetchTool()
+
+	// Test with invalid URL (no scheme)
+	result, err := tool.Exec(context.Background(), map[string]any{"url": "example.com"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should return error result, not Go error
+	if !containsString(result.Content, "URL must start with http://") {
+		t.Errorf("Expected URL validation error, got: %s", result.Content)
+	}
+}
+
+func TestWebFetchTool_Exec_Success(t *testing.T) {
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head><title>Test Page</title></head>
+<body>
+<h1>Hello World</h1>
+<p>This is a test paragraph.</p>
+<script>console.log('should be removed');</script>
+<style>.hidden { display: none; }</style>
+</body>
+</html>`))
+	}))
+	defer server.Close()
+
+	tool := NewWebFetchTool()
+
+	result, err := tool.Exec(context.Background(), map[string]any{"url": server.URL})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Check for success
+	if !containsString(result.Content, `"success":true`) {
+		t.Errorf("Expected success:true, got: %s", result.Content)
+	}
+
+	// Check title extraction
+	if !containsString(result.Content, "Test Page") {
+		t.Errorf("Expected title 'Test Page' in result, got: %s", result.Content)
+	}
+
+	// Check content extraction
+	if !containsString(result.Content, "Hello World") {
+		t.Errorf("Expected 'Hello World' in content, got: %s", result.Content)
+	}
+
+	// Verify script content was removed
+	if containsString(result.Content, "should be removed") {
+		t.Errorf("Script content should be removed, got: %s", result.Content)
+	}
+}
+
+func TestWebFetchTool_Exec_HTTPError(t *testing.T) {
+	// Create a test server that returns 404
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	tool := NewWebFetchTool()
+
+	result, err := tool.Exec(context.Background(), map[string]any{"url": server.URL})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should return error result
+	if !containsString(result.Content, `"success":false`) {
+		t.Errorf("Expected success:false for HTTP error, got: %s", result.Content)
+	}
+
+	if !containsString(result.Content, "404") {
+		t.Errorf("Expected 404 error in result, got: %s", result.Content)
+	}
+}
+
+func TestWebFetchTool_Exec_UnsupportedContentType(t *testing.T) {
+	// Create a test server that returns binary content
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{0x00, 0x01, 0x02})
+	}))
+	defer server.Close()
+
+	tool := NewWebFetchTool()
+
+	result, err := tool.Exec(context.Background(), map[string]any{"url": server.URL})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should return error result for unsupported content type
+	if !containsString(result.Content, `"success":false`) {
+		t.Errorf("Expected success:false for unsupported content type, got: %s", result.Content)
+	}
+
+	if !containsString(result.Content, "unsupported content type") {
+		t.Errorf("Expected unsupported content type error, got: %s", result.Content)
+	}
+}
+
+func TestExtractTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		expected string
+	}{
+		{
+			name:     "simple title",
+			html:     "<html><head><title>Test Title</title></head></html>",
+			expected: "Test Title",
+		},
+		{
+			name:     "title with whitespace",
+			html:     "<html><head><title>  Spaced Title  </title></head></html>",
+			expected: "Spaced Title",
+		},
+		{
+			name:     "no title",
+			html:     "<html><head></head></html>",
+			expected: "",
+		},
+		{
+			name:     "title with attributes",
+			html:     `<html><head><title lang="en">English Title</title></head></html>`,
+			expected: "English Title",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractTitle(tt.html)
+			if result != tt.expected {
+				t.Errorf("extractTitle() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractText(t *testing.T) {
+	tests := []struct {
+		name         string
+		html         string
+		shouldHave   []string
+		shouldntHave []string
+	}{
+		{
+			name:         "removes script tags",
+			html:         "<p>Keep this</p><script>remove this</script>",
+			shouldHave:   []string{"Keep this"},
+			shouldntHave: []string{"remove this"},
+		},
+		{
+			name:         "removes style tags",
+			html:         "<p>Keep this</p><style>.hidden { display: none; }</style>",
+			shouldHave:   []string{"Keep this"},
+			shouldntHave: []string{"display", "hidden"},
+		},
+		{
+			name:         "removes HTML comments",
+			html:         "<p>Keep this</p><!-- remove this comment -->",
+			shouldHave:   []string{"Keep this"},
+			shouldntHave: []string{"remove this comment"},
+		},
+		{
+			name:       "decodes HTML entities",
+			html:       "<p>&amp; &lt; &gt; &quot; &#39;</p>",
+			shouldHave: []string{"&", "<", ">", "\"", "'"},
+		},
+		{
+			name:       "handles block elements",
+			html:       "<p>Paragraph 1</p><p>Paragraph 2</p>",
+			shouldHave: []string{"Paragraph 1", "Paragraph 2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractText(tt.html)
+
+			for _, want := range tt.shouldHave {
+				if !containsString(result, want) {
+					t.Errorf("extractText() should contain %q, got: %s", want, result)
+				}
+			}
+
+			for _, unwanted := range tt.shouldntHave {
+				if containsString(result, unwanted) {
+					t.Errorf("extractText() should NOT contain %q, got: %s", unwanted, result)
+				}
+			}
+		})
+	}
+}
+
+func TestIsTextContent(t *testing.T) {
+	tests := []struct {
+		contentType string
+		expected    bool
+	}{
+		{"text/html", true},
+		{"text/html; charset=utf-8", true},
+		{"TEXT/HTML", true},
+		{"text/plain", true},
+		{"application/xhtml+xml", true},
+		{"application/xml", true},
+		{"text/xml", true},
+		{"application/json", false},
+		{"application/octet-stream", false},
+		{"image/png", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.contentType, func(t *testing.T) {
+			result := isTextContent(tt.contentType)
+			if result != tt.expected {
+				t.Errorf("isTextContent(%q) = %v, want %v", tt.contentType, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/tools/web_search.go
+++ b/pkg/tools/web_search.go
@@ -1,0 +1,243 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// ToolWebSearch is the constant name for the web search tool.
+const ToolWebSearch = "web_search"
+
+// WebSearchTool allows agents to search the web for information.
+// Useful for finding current information about APIs, libraries, versions,
+// and other technical details that may be beyond the LLM's training cutoff.
+type WebSearchTool struct {
+	httpClient *http.Client
+	maxResults int
+}
+
+// NewWebSearchTool creates a new web search tool.
+func NewWebSearchTool() *WebSearchTool {
+	return &WebSearchTool{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		maxResults: 5,
+	}
+}
+
+// Name returns the tool name.
+func (t *WebSearchTool) Name() string {
+	return ToolWebSearch
+}
+
+// PromptDocumentation returns formatted tool documentation for prompts.
+func (t *WebSearchTool) PromptDocumentation() string {
+	return `- **web_search** - Search the web for current information
+  - Parameters: query (string, REQUIRED)
+  - Use to find current documentation, API references, library versions, or other technical information
+  - Useful when you need information that may be beyond your training cutoff (e.g., new Go releases, latest library versions)
+  - Returns structured search results with titles, descriptions, and URLs`
+}
+
+// Definition returns the tool definition for LLM.
+func (t *WebSearchTool) Definition() ToolDefinition {
+	return ToolDefinition{
+		Name: ToolWebSearch,
+		Description: `Search the web for current technical information. Use this tool when:
+- You need to verify current versions of programming languages, libraries, or frameworks
+- You need to look up current API documentation or specifications
+- You encounter errors related to deprecated or changed functionality
+- You need information about recent releases or changes that may be beyond your training data
+Returns search results with titles, descriptions, and URLs for further research.`,
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"query": {
+					Type:        "string",
+					Description: "Search query string (e.g., 'Go 1.24 release notes', 'Python 3.12 new features')",
+				},
+			},
+			Required: []string{"query"},
+		},
+	}
+}
+
+// duckDuckGoResponse represents the response from DuckDuckGo's instant answer API.
+type duckDuckGoResponse struct {
+	Abstract       string `json:"Abstract"`
+	AbstractText   string `json:"AbstractText"`
+	AbstractSource string `json:"AbstractSource"`
+	AbstractURL    string `json:"AbstractURL"`
+	Heading        string `json:"Heading"`
+	Answer         string `json:"Answer"`
+	AnswerType     string `json:"AnswerType"`
+	RelatedTopics  []struct {
+		Text     string `json:"Text"`
+		FirstURL string `json:"FirstURL"`
+	} `json:"RelatedTopics"`
+	Results []struct {
+		Text     string `json:"Text"`
+		FirstURL string `json:"FirstURL"`
+	} `json:"Results"`
+}
+
+// searchResult represents a single search result.
+type searchResult struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}
+
+// Exec executes the web search tool.
+func (t *WebSearchTool) Exec(ctx context.Context, args map[string]any) (*ExecResult, error) {
+	// Extract query argument
+	query, ok := args["query"].(string)
+	if !ok || query == "" {
+		return nil, fmt.Errorf("query is required and must be a string")
+	}
+
+	// Fetch search results from DuckDuckGo
+	ddgResp, fetchErr := t.fetchDuckDuckGo(ctx, query)
+	if fetchErr != nil {
+		return fetchErr.result, fetchErr.err
+	}
+
+	// Build results from response
+	results := t.buildResults(ddgResp)
+
+	// Build response
+	response := map[string]any{
+		"success":      true,
+		"query":        query,
+		"result_count": len(results),
+		"results":      results,
+	}
+
+	// Add note if no results found
+	if len(results) == 0 {
+		response["note"] = "No direct results found. Try a more specific search query or rephrase your question."
+	}
+
+	content, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	return &ExecResult{Content: string(content)}, nil
+}
+
+// fetchError holds the result and error from errorResult for clean return handling.
+type fetchError struct {
+	result *ExecResult
+	err    error
+}
+
+// fetchDuckDuckGo performs the HTTP request to DuckDuckGo's API.
+func (t *WebSearchTool) fetchDuckDuckGo(ctx context.Context, query string) (*duckDuckGoResponse, *fetchError) {
+	// Build DuckDuckGo instant answer URL
+	// Using the instant answer API which is free and doesn't require authentication
+	searchURL := fmt.Sprintf("https://api.duckduckgo.com/?q=%s&format=json&no_html=1&skip_disambig=1",
+		url.QueryEscape(query))
+
+	// Create request with context
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchURL, http.NoBody)
+	if err != nil {
+		result, resErr := t.errorResult("failed to create request: " + err.Error())
+		return nil, &fetchError{result, resErr}
+	}
+
+	// Set a user agent to avoid being blocked
+	req.Header.Set("User-Agent", "Maestro/1.0 (AI Development Tool)")
+
+	// Execute request
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		result, resErr := t.errorResult("search request failed: " + err.Error())
+		return nil, &fetchError{result, resErr}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		result, resErr := t.errorResult("failed to read response: " + err.Error())
+		return nil, &fetchError{result, resErr}
+	}
+
+	// Parse DuckDuckGo response
+	var ddgResp duckDuckGoResponse
+	if unmarshalErr := json.Unmarshal(body, &ddgResp); unmarshalErr != nil {
+		result, resErr := t.errorResult("failed to parse search results: " + unmarshalErr.Error())
+		return nil, &fetchError{result, resErr}
+	}
+
+	return &ddgResp, nil
+}
+
+// buildResults extracts search results from the DuckDuckGo response.
+func (t *WebSearchTool) buildResults(ddgResp *duckDuckGoResponse) []searchResult {
+	var results []searchResult
+
+	// Add main answer if available
+	if ddgResp.AbstractText != "" {
+		results = append(results, searchResult{
+			Title:       ddgResp.Heading,
+			Description: ddgResp.AbstractText,
+			URL:         ddgResp.AbstractURL,
+		})
+	}
+
+	// Add instant answer if available
+	if ddgResp.Answer != "" {
+		results = append(results, searchResult{
+			Title:       "Instant Answer",
+			Description: ddgResp.Answer,
+			URL:         "",
+		})
+	}
+
+	// Add related topics
+	for i := range ddgResp.RelatedTopics {
+		topic := &ddgResp.RelatedTopics[i]
+		if topic.Text != "" && len(results) < t.maxResults {
+			results = append(results, searchResult{
+				Title:       "",
+				Description: topic.Text,
+				URL:         topic.FirstURL,
+			})
+		}
+	}
+
+	// Add direct results
+	for i := range ddgResp.Results {
+		ddgResult := &ddgResp.Results[i]
+		if ddgResult.Text != "" && len(results) < t.maxResults {
+			results = append(results, searchResult{
+				Title:       "",
+				Description: ddgResult.Text,
+				URL:         ddgResult.FirstURL,
+			})
+		}
+	}
+
+	return results
+}
+
+// errorResult creates an error result response.
+func (t *WebSearchTool) errorResult(errMsg string) (*ExecResult, error) {
+	response := map[string]any{
+		"success": false,
+		"error":   errMsg,
+	}
+	content, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal error response: %w", err)
+	}
+	return &ExecResult{Content: string(content)}, nil
+}

--- a/pkg/tools/web_search_test.go
+++ b/pkg/tools/web_search_test.go
@@ -1,0 +1,84 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWebSearchTool_Definition(t *testing.T) {
+	tool := NewWebSearchTool()
+
+	if tool.Name() != ToolWebSearch {
+		t.Errorf("Name() = %q, want %q", tool.Name(), ToolWebSearch)
+	}
+
+	def := tool.Definition()
+	if def.Name != ToolWebSearch {
+		t.Errorf("Definition().Name = %q, want %q", def.Name, ToolWebSearch)
+	}
+
+	// Check that query parameter is required
+	if len(def.InputSchema.Required) != 1 || def.InputSchema.Required[0] != "query" {
+		t.Errorf("Expected 'query' to be required, got: %v", def.InputSchema.Required)
+	}
+
+	// Check that query property exists
+	if _, ok := def.InputSchema.Properties["query"]; !ok {
+		t.Error("Expected 'query' property in input schema")
+	}
+}
+
+func TestWebSearchTool_PromptDocumentation(t *testing.T) {
+	tool := NewWebSearchTool()
+
+	doc := tool.PromptDocumentation()
+	if doc == "" {
+		t.Error("PromptDocumentation() should not be empty")
+	}
+
+	// Check for key information
+	if !containsString(doc, "web_search") {
+		t.Error("PromptDocumentation should mention 'web_search'")
+	}
+
+	if !containsString(doc, "query") {
+		t.Error("PromptDocumentation should mention 'query' parameter")
+	}
+}
+
+func TestWebSearchTool_Exec_MissingQuery(t *testing.T) {
+	tool := NewWebSearchTool()
+
+	// Test with missing query
+	_, err := tool.Exec(context.Background(), map[string]any{})
+	if err == nil {
+		t.Error("Expected error for missing query parameter")
+	}
+
+	// Test with empty query
+	_, err = tool.Exec(context.Background(), map[string]any{"query": ""})
+	if err == nil {
+		t.Error("Expected error for empty query parameter")
+	}
+
+	// Test with wrong type
+	_, err = tool.Exec(context.Background(), map[string]any{"query": 123})
+	if err == nil {
+		t.Error("Expected error for non-string query parameter")
+	}
+}
+
+// containsString checks if substr is in str.
+func containsString(str, substr string) bool {
+	return len(str) >= len(substr) && (str == substr ||
+		(len(str) > len(substr) && containsSubstring(str, substr)))
+}
+
+func containsSubstring(str, substr string) bool {
+	for i := 0; i <= len(str)-len(substr); i++ {
+		if str[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Run architect and PM containers as non-privileged user (1000:1000) instead of root for improved security
- Add config-driven debug logging via `GetDebugLLMMessages()` to replace hardcoded debug values
- Add `web_search` tool for agents to search the web via DuckDuckGo API
- Add `web_fetch` tool for agents to read content from URLs found in search results

## Changes

### Security: Non-privileged container execution
- Modified `pkg/exec/architect_executor.go` and `pkg/exec/pm_executor.go` to use `--user 1000:1000`
- Agents now run as non-root user in Docker containers

### Debug logging configuration
- Added `debug.llm_messages` config option in `pkg/config/config.go`
- Updated all toolloop configurations to use `cfg.GetDebugLLMMessages()` instead of hardcoded values
- Affected files: architect, coder, pm drivers and their respective toolloop configs

### Research tools
- **web_search**: Search the web via DuckDuckGo's instant answer API
  - Returns structured results with titles, descriptions, and URLs
  - Available to architect and PM agents
- **web_fetch**: Fetch and extract text content from URLs
  - Strips HTML tags, scripts, and styles
  - Extracts page title and readable text
  - 100KB body limit with 50KB processed text limit
  - Available to architect and PM agents

## Test plan
- [x] All existing tests pass
- [x] New web_search and web_fetch tests pass
- [x] Lint passes (refactored web_search.go to reduce cyclomatic complexity)
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)