### PR TITLE
Fix architect diff visibility: commit in done tool

### DIFF
--- a/pkg/coder/claudecode_coding.go
+++ b/pkg/coder/claudecode_coding.go
@@ -59,7 +59,7 @@ func (c *Coder) handleClaudeCodeCoding(ctx context.Context, sm *agent.BaseStateM
 	// Uses Claude Code-specific provider that includes container_switch (handled via SignalContainerSwitch)
 	if c.codingToolProvider == nil {
 		storyType := utils.GetStateValueOr[string](sm, proto.KeyStoryType, string(proto.StoryTypeApp))
-		c.codingToolProvider = c.createClaudeCodeCodingToolProvider(storyType)
+		c.codingToolProvider = c.createClaudeCodeCodingToolProvider(storyType, storyID)
 		c.logger.Debug("Created Claude Code coding ToolProvider for story type: %s", storyType)
 	}
 

--- a/pkg/coder/coding.go
+++ b/pkg/coder/coding.go
@@ -64,7 +64,8 @@ func (c *Coder) executeCodingWithTemplate(ctx context.Context, sm *agent.BaseSta
 
 	// Create ToolProvider for this coding session
 	if c.codingToolProvider == nil {
-		c.codingToolProvider = c.createCodingToolProvider(storyType, isHotfix)
+		storyID := utils.GetStateValueOr[string](sm, KeyStoryID, "")
+		c.codingToolProvider = c.createCodingToolProvider(storyType, isHotfix, storyID)
 		c.logger.Debug("Created coding ToolProvider for story type: %s, isHotfix: %v", storyType, isHotfix)
 	}
 

--- a/pkg/coder/driver.go
+++ b/pkg/coder/driver.go
@@ -1209,7 +1209,7 @@ func (c *Coder) createPlanningToolProvider(storyType string) *tools.ToolProvider
 
 // createCodingToolProvider creates a ToolProvider for the coding state.
 // If isHotfix is true, todo tools are excluded (hotfix stories skip planning and don't use todos).
-func (c *Coder) createCodingToolProvider(storyType string, isHotfix bool) *tools.ToolProvider {
+func (c *Coder) createCodingToolProvider(storyType string, isHotfix bool, storyID string) *tools.ToolProvider {
 	// Determine coding tools based on story type
 	var codingTools []string
 	if storyType == string(proto.StoryTypeDevOps) {
@@ -1234,6 +1234,7 @@ func (c *Coder) createCodingToolProvider(storyType string, isHotfix bool) *tools
 		NetworkDisabled: false,                 // May need network for builds/tests
 		WorkDir:         c.workDir,
 		AgentID:         c.GetAgentID(), // Required for compose_up project name isolation
+		StoryID:         storyID,        // For done tool commit message prefix
 	}
 
 	return tools.NewProvider(&agentCtx, codingTools)
@@ -1259,7 +1260,7 @@ func filterOutTodoTools(toolList []string) []string {
 // createClaudeCodeCodingToolProvider creates a ToolProvider for Claude Code mode coding.
 // This excludes todo tools (Claude Code has built-in) but INCLUDES container_switch.
 // Container switch is handled via SignalContainerSwitch which triggers container restart with session resume.
-func (c *Coder) createClaudeCodeCodingToolProvider(storyType string) *tools.ToolProvider {
+func (c *Coder) createClaudeCodeCodingToolProvider(storyType, storyID string) *tools.ToolProvider {
 	// Determine coding tools based on story type
 	// Filter out: todo tools (Claude Code has built-in)
 	// NOTE: container_switch is INCLUDED - we handle it via SignalContainerSwitch
@@ -1279,6 +1280,7 @@ func (c *Coder) createClaudeCodeCodingToolProvider(storyType string) *tools.Tool
 		NetworkDisabled: false,                 // May need network for builds/tests
 		WorkDir:         c.workDir,
 		AgentID:         c.GetAgentID(), // Required for chat tools (chat_read needs agent_id)
+		StoryID:         storyID,        // For done tool commit message prefix
 	}
 
 	return tools.NewProvider(&agentCtx, codingTools)

--- a/pkg/coder/state_handlers_test.go
+++ b/pkg/coder/state_handlers_test.go
@@ -1306,7 +1306,7 @@ func TestCreateCodingToolProvider_HotfixExcludesTodoTools(t *testing.T) {
 	coder := createTestCoder(t, &testCoderOptions{})
 
 	// Create tool provider for regular story (should include todo tools)
-	regularProvider := coder.createCodingToolProvider(string(proto.StoryTypeApp), false)
+	regularProvider := coder.createCodingToolProvider(string(proto.StoryTypeApp), false, "test-story")
 	regularTools := regularProvider.List()
 
 	hasTodosAdd := false
@@ -1321,7 +1321,7 @@ func TestCreateCodingToolProvider_HotfixExcludesTodoTools(t *testing.T) {
 	}
 
 	// Create tool provider for hotfix story (should exclude todo tools)
-	hotfixProvider := coder.createCodingToolProvider(string(proto.StoryTypeApp), true)
+	hotfixProvider := coder.createCodingToolProvider(string(proto.StoryTypeApp), true, "test-hotfix")
 	hotfixTools := hotfixProvider.List()
 
 	for _, tool := range hotfixTools {

--- a/pkg/exec/local.go
+++ b/pkg/exec/local.go
@@ -36,6 +36,11 @@ func (e *LocalExec) Run(ctx context.Context, cmd []string, opts *Opts) (Result, 
 
 	startTime := time.Now()
 
+	// Handle nil opts
+	if opts == nil {
+		opts = &Opts{}
+	}
+
 	// Create context with timeout if specified.
 	if opts.Timeout > 0 {
 		var cancel context.CancelFunc

--- a/pkg/tools/done_tool_test.go
+++ b/pkg/tools/done_tool_test.go
@@ -1,0 +1,232 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	execpkg "orchestrator/pkg/exec"
+)
+
+// TestDoneTool_NoExecutor verifies the done tool works when no executor is provided (test/schema mode).
+func TestDoneTool_NoExecutor(t *testing.T) {
+	tool := NewDoneTool(nil, nil, "", "")
+
+	result, err := tool.Exec(context.Background(), map[string]any{
+		"summary": "Implemented feature X",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if result.ProcessEffect == nil {
+		t.Fatal("Expected ProcessEffect to be set")
+	}
+	if result.ProcessEffect.Signal != SignalTesting {
+		t.Errorf("Expected signal %q, got %q", SignalTesting, result.ProcessEffect.Signal)
+	}
+	if !strings.Contains(result.Content, "skipped git operations") {
+		t.Errorf("Expected content to mention skipped git operations, got: %s", result.Content)
+	}
+}
+
+// TestDoneTool_MissingSummary verifies the done tool rejects missing summary.
+func TestDoneTool_MissingSummary(t *testing.T) {
+	tool := NewDoneTool(nil, nil, "", "")
+
+	_, err := tool.Exec(context.Background(), map[string]any{})
+	if err == nil {
+		t.Fatal("Expected error for missing summary")
+	}
+	if !strings.Contains(err.Error(), "summary is required") {
+		t.Errorf("Expected 'summary is required' error, got: %v", err)
+	}
+}
+
+// TestDoneTool_CommitsChanges verifies the done tool commits changes when an executor is available.
+// This is an integration test that uses a real git repo in a temp directory.
+func TestDoneTool_CommitsChanges(t *testing.T) {
+	// Create a temp dir with a real git repo
+	repoDir := initTestGitRepo(t)
+
+	// Write a new file (uncommitted)
+	testFile := filepath.Join(repoDir, "feature.go")
+	if err := os.WriteFile(testFile, []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Verify file is untracked
+	out := gitCmd(t, repoDir, "status", "--porcelain")
+	if !strings.Contains(out, "feature.go") {
+		t.Fatalf("Expected feature.go in git status, got: %s", out)
+	}
+
+	// Create done tool with local executor
+	executor := execpkg.NewLocalExec()
+	tool := NewDoneTool(nil, executor, repoDir, "STORY-42")
+
+	// Execute done tool
+	result, err := tool.Exec(context.Background(), map[string]any{
+		"summary": "Added feature.go with main package",
+	})
+	if err != nil {
+		t.Fatalf("Done tool failed: %v", err)
+	}
+
+	// Verify ProcessEffect
+	if result.ProcessEffect == nil || result.ProcessEffect.Signal != SignalTesting {
+		t.Fatal("Expected TESTING signal in ProcessEffect")
+	}
+
+	// Verify the file was committed
+	out = gitCmd(t, repoDir, "status", "--porcelain")
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("Expected clean working directory after commit, got: %s", out)
+	}
+
+	// Verify commit message includes story ID prefix
+	logOut := gitCmd(t, repoDir, "log", "--oneline", "-1")
+	if !strings.Contains(logOut, "STORY-42") {
+		t.Errorf("Expected commit message to contain 'STORY-42', got: %s", logOut)
+	}
+	if !strings.Contains(logOut, "Added feature.go") {
+		t.Errorf("Expected commit message to contain summary, got: %s", logOut)
+	}
+}
+
+// TestDoneTool_NothingToCommit verifies the done tool handles no changes gracefully.
+func TestDoneTool_NothingToCommit(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+
+	executor := execpkg.NewLocalExec()
+	tool := NewDoneTool(nil, executor, repoDir, "STORY-1")
+
+	result, err := tool.Exec(context.Background(), map[string]any{
+		"summary": "No changes needed",
+	})
+	if err != nil {
+		t.Fatalf("Done tool failed: %v", err)
+	}
+
+	if result.ProcessEffect == nil || result.ProcessEffect.Signal != SignalTesting {
+		t.Fatal("Expected TESTING signal even with no changes")
+	}
+	if !strings.Contains(result.Content, "No changes to commit") {
+		t.Errorf("Expected 'No changes to commit' message, got: %s", result.Content)
+	}
+}
+
+// TestDoneTool_CommitMessageWithoutStoryID verifies commit message when no story ID provided.
+func TestDoneTool_CommitMessageWithoutStoryID(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+
+	// Write a file
+	if err := os.WriteFile(filepath.Join(repoDir, "file.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	executor := execpkg.NewLocalExec()
+	tool := NewDoneTool(nil, executor, repoDir, "") // No story ID
+
+	_, err := tool.Exec(context.Background(), map[string]any{
+		"summary": "Added file.txt",
+	})
+	if err != nil {
+		t.Fatalf("Done tool failed: %v", err)
+	}
+
+	// Verify commit message is just the summary (no story prefix)
+	logOut := gitCmd(t, repoDir, "log", "--oneline", "-1")
+	if strings.Contains(logOut, "Story") {
+		t.Errorf("Expected no story prefix in commit message, got: %s", logOut)
+	}
+	if !strings.Contains(logOut, "Added file.txt") {
+		t.Errorf("Expected summary in commit message, got: %s", logOut)
+	}
+}
+
+// TestDoneTool_Definition verifies the tool definition reflects commit behavior.
+func TestDoneTool_Definition(t *testing.T) {
+	tool := NewDoneTool(nil, nil, "", "")
+	def := tool.Definition()
+
+	if def.Name != "done" {
+		t.Errorf("Expected name 'done', got %q", def.Name)
+	}
+	if !strings.Contains(def.Description, "Commit") {
+		t.Errorf("Expected description to mention committing, got: %s", def.Description)
+	}
+	if !strings.Contains(def.Description, "git") {
+		t.Errorf("Expected description to mention git, got: %s", def.Description)
+	}
+}
+
+// TestDoneTool_PromptDocumentation verifies documentation mentions commit behavior.
+func TestDoneTool_PromptDocumentation(t *testing.T) {
+	tool := NewDoneTool(nil, nil, "", "")
+	doc := tool.PromptDocumentation()
+
+	if !strings.Contains(doc, "git add") {
+		t.Errorf("Expected documentation to mention 'git add', got: %s", doc)
+	}
+	if !strings.Contains(doc, "commit message") {
+		t.Errorf("Expected documentation to mention 'commit message', got: %s", doc)
+	}
+}
+
+// TestIsExecutorUsable verifies the typed-nil safety check.
+func TestIsExecutorUsable(t *testing.T) {
+	// Pure nil
+	if isExecutorUsable(nil) {
+		t.Error("Expected nil executor to be unusable")
+	}
+
+	// Typed nil (the Go gotcha)
+	var typedNil *execpkg.LongRunningDockerExec
+	if isExecutorUsable(typedNil) {
+		t.Error("Expected typed nil executor to be unusable")
+	}
+
+	// Real executor
+	localExec := execpkg.NewLocalExec()
+	if !isExecutorUsable(localExec) {
+		t.Error("Expected real executor to be usable")
+	}
+}
+
+// --- helpers ---
+
+// initTestGitRepo creates a temp directory with an initialized git repo and one initial commit.
+func initTestGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "config", "user.name", "Test")
+
+	// Create initial commit so HEAD exists
+	readmePath := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# Test\n"), 0644); err != nil {
+		t.Fatalf("Failed to write README: %v", err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "Initial commit")
+
+	return dir
+}
+
+// gitCmd runs a git command in the given directory and returns stdout.
+func gitCmd(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\nOutput: %s", strings.Join(args, " "), err, string(out))
+	}
+	return string(out)
+}

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -24,6 +24,7 @@ type AgentContext struct {
 	AgentID         string // Agent identifier for tools that need it
 	Agent           Agent  // Optional agent reference for state-aware tools
 	ProjectDir      string // Project directory for bootstrap detection and config access
+	StoryID         string // Story ID for commit message prefix (used by done tool)
 }
 
 // Agent interface for tools that need access to agent state.
@@ -283,7 +284,7 @@ func createLintTool(ctx *AgentContext) (Tool, error) {
 
 // createDoneTool creates a done tool instance.
 func createDoneTool(ctx *AgentContext) (Tool, error) {
-	return NewDoneTool(ctx.Agent), nil
+	return NewDoneTool(ctx.Agent, ctx.Executor, ctx.WorkDir, ctx.StoryID), nil
 }
 
 // createBackendInfoTool creates a backend info tool instance.
@@ -428,7 +429,7 @@ func getLintSchema() InputSchema {
 }
 
 func getDoneSchema() InputSchema {
-	return NewDoneTool(nil).Definition().InputSchema
+	return NewDoneTool(nil, nil, "", "").Definition().InputSchema
 }
 
 func getBackendInfoSchema() InputSchema {

--- a/tests/harness/mcp_tool_harness.go
+++ b/tests/harness/mcp_tool_harness.go
@@ -84,7 +84,7 @@ func createToolByName(toolName string) (tools.Tool, error) {
 		return tools.NewSubmitPlanTool(), nil
 	case tools.ToolDone:
 		mockAgent := &mockTestAgent{}
-		return tools.NewDoneTool(mockAgent), nil
+		return tools.NewDoneTool(mockAgent, nil, "", ""), nil
 	// Add more tools as needed - CreateMakefile doesn't have a constant yet
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", toolName)


### PR DESCRIPTION
## Summary

- **Move git commit from PREPARE_MERGE into the done tool** to fix a bug where the architect's `get_diff` tool couldn't see coder changes during CODE_REVIEW (because `git diff baseSHA..HEAD` only shows committed changes, and code wasn't committed until after review)
- Done tool now runs `git add -A` + `git commit` using the summary as the commit message, with optional story ID prefix
- PREPARE_MERGE no longer commits — it only pushes. Any uncommitted changes at that point are test artifacts
- Fix `LocalExec.Run()` nil opts panic (several tools pass nil opts)
- Add `isExecutorUsable()` typed-nil safety check for Go interface nil gotcha

## Test plan

- [x] `TestDoneTool_CommitsChanges` — real git repo, verifies commit happens with story ID prefix
- [x] `TestDoneTool_NothingToCommit` — handles clean workspace gracefully
- [x] `TestDoneTool_NoExecutor` — works in test/schema mode with nil executor
- [x] `TestDoneTool_MissingSummary` — rejects empty summary
- [x] `TestGetDiff_UncommittedChangesInvisible` — reproduces original bug: uncommitted files invisible to `get_diff`
- [x] `TestGetDiff_DoneToolThenGetDiff` — end-to-end: done tool commit makes changes visible to architect's `get_diff`
- [x] `TestIsExecutorUsable` — typed-nil interface safety check
- [x] All existing tests pass, lint clean, integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)