### PR TITLE
Fix container leaks from integration tests

### DIFF
--- a/internal/factory/agent_factory_test.go
+++ b/internal/factory/agent_factory_test.go
@@ -8,7 +8,7 @@ import (
 
 // TestNewAgentFactory tests factory construction.
 func TestNewAgentFactory(t *testing.T) {
-	factory := NewAgentFactory(nil, nil, nil, nil)
+	factory := NewAgentFactory(nil, nil, nil, nil, nil)
 
 	if factory == nil {
 		t.Fatal("expected factory, got nil")

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -160,7 +160,7 @@ func NewSupervisor(k *kernel.Kernel) *Supervisor {
 
 	// Create the agent factory with kernel dependencies (lightweight)
 	// Pass the shared LLM factory to ensure proper rate limiting across all agents
-	agentFactory := factory.NewAgentFactory(k.Dispatcher, k.PersistenceChannel, chatService, k.LLMFactory)
+	agentFactory := factory.NewAgentFactory(k.Dispatcher, k.PersistenceChannel, chatService, k.LLMFactory, k.ComposeRegistry)
 
 	supervisor := &Supervisor{
 		Kernel:          k,

--- a/pkg/coder/state_notification_test.go
+++ b/pkg/coder/state_notification_test.go
@@ -86,7 +86,7 @@ func TestCoderStateNotificationWithBaseStateMachine(t *testing.T) {
 	defer llmFactory.Stop()
 
 	// Create real coder
-	coder, err := NewCoder(context.Background(), agentID, workDir, cloneManager, buildService, nil, nil, llmFactory)
+	coder, err := NewCoder(context.Background(), agentID, workDir, cloneManager, buildService, nil, nil, llmFactory, nil)
 	if err != nil {
 		t.Fatalf("Failed to create coder: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestCoderStateNotificationChannelSetup(t *testing.T) {
 	defer llmFactory.Stop()
 
 	// Create real coder
-	coder, err := NewCoder(context.Background(), agentID, workDir, cloneManager, buildService, nil, nil, llmFactory)
+	coder, err := NewCoder(context.Background(), agentID, workDir, cloneManager, buildService, nil, nil, llmFactory, nil)
 	if err != nil {
 		t.Fatalf("Failed to create coder: %v", err)
 	}

--- a/pkg/coder/workspace_path_test.go
+++ b/pkg/coder/workspace_path_test.go
@@ -68,7 +68,7 @@ func TestGetHostWorkspacePath(t *testing.T) {
 	llmFactory := createTestLLMFactoryForWorkspace(t)
 	defer llmFactory.Stop()
 
-	coder, err := NewCoder(context.Background(), agentID, workDir, nil, build.NewBuildService(), nil, nil, llmFactory)
+	coder, err := NewCoder(context.Background(), agentID, workDir, nil, build.NewBuildService(), nil, nil, llmFactory, nil)
 	if err != nil {
 		t.Fatalf("Failed to create coder: %v", err)
 	}

--- a/pkg/tools/compose_tools_test.go
+++ b/pkg/tools/compose_tools_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestComposeUpTool_Definition(t *testing.T) {
-	tool := NewComposeUpTool("/tmp", "test-agent", "")
+	tool := NewComposeUpTool("/tmp", "test-agent", "", nil)
 	def := tool.Definition()
 
 	if def.Name != "compose_up" {
@@ -63,7 +63,7 @@ func TestComposeTools_PromptDocumentation(t *testing.T) {
 		tool     interface{ PromptDocumentation() string }
 		contains string
 	}{
-		{"compose_up", NewComposeUpTool("/tmp", "test-agent", ""), "compose_up"},
+		{"compose_up", NewComposeUpTool("/tmp", "test-agent", "", nil), "compose_up"},
 		{"compose_down", NewComposeDownTool("/tmp"), "compose_down"},
 		{"compose_logs", NewComposeLogsTool("/tmp"), "compose_logs"},
 		{"compose_status", NewComposeStatusTool("/tmp"), "compose_status"},
@@ -81,7 +81,7 @@ func TestComposeTools_PromptDocumentation(t *testing.T) {
 
 func TestComposeUpTool_NoComposeFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewComposeUpTool(tmpDir, "test-agent", "")
+	tool := NewComposeUpTool(tmpDir, "test-agent", "", nil)
 
 	result, err := tool.Exec(t.Context(), nil)
 	if err != nil {
@@ -188,7 +188,7 @@ func TestComposeUpTool_PathValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tool := NewComposeUpTool(tt.workDir, "test-agent", "")
+			tool := NewComposeUpTool(tt.workDir, "test-agent", "", nil)
 			err := tool.validateWorkspacePath()
 
 			if tt.wantError {


### PR DESCRIPTION
## Summary
- **Boot test leak**: `performBootTest` ran `docker run --rm` with the image's default CMD (`sleep infinity`), so when the Go context deadline killed the Docker client process, the container kept running (`--rm` only fires when Docker itself stops the container). Fixed by using explicit `echo boot-ok` command that exits immediately.
- **MCP concurrent test leak**: Cleanup used bare story ID (`mcp-concurrent-0`) but `StartContainer` returns prefixed name (`maestro-story-mcp-concurrent-0`). `StopContainer` lookup missed, returning nil silently. Fixed by storing and using the full container name. Also added fresh context for cleanup defers.
- **Compose registry wiring**: `compose_up` tool created Docker Compose stacks but never registered them with `ComposeRegistry` for shutdown cleanup. Wired registry through: Kernel → Supervisor → AgentFactory → Coder → AgentContext → ComposeUpTool.

## Test plan
- [x] `make build` passes (includes linting)
- [x] `make test` passes (all unit tests)
- [x] `make test-integration` passes (all integration tests)
- [x] `docker ps -a` shows zero leaked containers after integration test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)