### PR TITLE
Fix maintenance story type DB constraint

### DIFF
--- a/pkg/architect/queue.go
+++ b/pkg/architect/queue.go
@@ -9,6 +9,7 @@ import (
 
 	"orchestrator/pkg/logx"
 	"orchestrator/pkg/persistence"
+	"orchestrator/pkg/proto"
 )
 
 // StoryStatus represents the status of a story (canonical source of truth).
@@ -394,7 +395,7 @@ func (q *Queue) AddMaintenanceStory(storyID, specID, title, content string, expr
 			CompletedAt:   nil,
 			LastUpdated:   now,
 			CreatedAt:     now,
-			StoryType:     "maintenance",
+			StoryType:     string(proto.StoryTypeMaintenance),
 		},
 	}
 	_ = queuedStory.SetStatus(StatusPending) // New story, cannot fail

--- a/pkg/proto/message.go
+++ b/pkg/proto/message.go
@@ -58,7 +58,7 @@ const (
 	ConfidenceHigh Confidence = "HIGH"
 )
 
-// StoryType represents the type of story (DevOps or App).
+// StoryType represents the type of story (DevOps, App, or Maintenance).
 type StoryType string
 
 const (
@@ -67,6 +67,10 @@ const (
 
 	// StoryTypeApp represents application development stories.
 	StoryTypeApp StoryType = "app"
+
+	// StoryTypeMaintenance represents maintenance cycle stories (test coverage, cleanup, etc.).
+	// Coders treat these identically to app stories; the distinction exists for tracking/querying.
+	StoryTypeMaintenance StoryType = "maintenance"
 )
 
 // Common payload and metadata keys used in agent messages.
@@ -593,6 +597,7 @@ func ValidStoryTypes() []string {
 	return []string{
 		string(StoryTypeDevOps),
 		string(StoryTypeApp),
+		string(StoryTypeMaintenance),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Maintenance stories were created with `StoryType: "maintenance"` but the `stories` table CHECK constraint only allowed `'devops'` and `'app'`, causing all maintenance story DB upserts to fail silently (fire-and-forget persistence)
- Adds `StoryTypeMaintenance` as a first-class story type in proto, DB schema (migration v18), and validation
- Coders treat maintenance stories identically to app stories (all branching checks `== "devops"` with else fallthrough), so no coder changes needed

Fixes https://github.com/SnapdragonPartners/maestro/issues/125wp2fv2DZ

## Test plan
- [x] `make build` passes (includes lint)
- [x] Unit tests pass (`pkg/persistence`, `pkg/architect`, `pkg/proto`)
- [x] Integration tests pass (pre-push hook)
- [x] Verify maintenance stories persist to DB on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)