### PR TITLE
Fix prompt/tool contract mismatch: fold todos into submit_plan

### DIFF
--- a/docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md
+++ b/docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md
@@ -1,0 +1,666 @@
+# Coder Improvement Research Brief
+
+## Purpose
+
+This document is the updated handoff for the next round of Maestro coder analysis.
+
+It is based on:
+
+- A comparison between Maestro's native coder and an external coding-agent reference architecture
+- Follow-up discussion about where the comparison was most and least relevant to Maestro
+- Engineering review of the first-pass recommendations
+
+The external system should be treated only as an **external reference architecture**.
+
+The goal is **not** to make Maestro copy that system.
+
+The goal is to help Maestro coders answer a narrower question:
+
+> Which specific ideas appear likely to improve Maestro's unattended output quality, and what is the smallest Maestro-native version of each?
+
+## Final Recommendation Summary
+
+### Implement now
+
+1. **Stage 1: Prompt refresh and prompt contract cleanup**
+2. **Stage 4A: Narrow todo modernization**
+3. **Stage 3A: Acceptance-criteria verification in `TESTING`**
+4. **Stage 2: Targeted context/toolloop hardening**
+
+### Prototype only
+
+5. **Stage 3B: Adversarial probing in `TESTING`**
+
+### Skip or defer for now
+
+6. **Stage 5: Lightweight memory subsystem**
+7. **Stage 6: Read-only sidecars and subagents**
+
+## What the External Reference Architecture Got Right
+
+Only the following behavior patterns are relevant for Maestro right now:
+
+### 1. Evidence-oriented verification
+
+The most useful idea was not "use a different review stage."
+
+It was:
+
+- verification should run commands
+- verification should generate evidence
+- verification should not trust code reading alone
+- verification should try to falsify claims, not just confirm happy paths
+
+For Maestro, that insight belongs primarily in `TESTING`, not `CODE_REVIEW`.
+
+### 2. Better recovery when long stories go wrong
+
+The reference architecture is stronger at:
+
+- recovering after context overflow
+- recovering after output truncation
+- preserving critical state after compaction
+- retrying with reconstructed state instead of just dropping context
+
+This matters for Maestro even if context failures are rare, because those failures are expensive.
+
+### 3. Better structured task handling
+
+The useful idea here is not "make todos the source of truth."
+
+The useful idea is:
+
+- reduce redundant todo-generation passes
+- make todo state richer than `completed` vs not
+- keep task progression clearer inside coding
+
+### 4. Better context hygiene
+
+The most interesting sidecar/subagent idea was not speed.
+
+It was:
+
+- keep raw search/test noise out of the main reasoning context
+- return distilled findings instead of artifacts
+
+That remains interesting, but not yet urgent.
+
+## What Maestro Already Does Better
+
+These are strengths to preserve.
+
+### 1. Explicit FSM and operational boundaries
+
+Relevant files:
+
+- `pkg/coder/coder_fsm.go`
+- `pkg/coder/STATES.md`
+
+Maestro's explicit state machine is a feature, not a liability.
+
+### 2. Strong planning/coding separation
+
+Relevant file:
+
+- `pkg/coder/setup.go`
+
+The read-only planning container and read-write coding container are good guardrails.
+
+### 3. Structured blocker escalation
+
+Relevant files:
+
+- `pkg/tools/blocked_tool.go`
+- `pkg/coder/planning.go`
+- `pkg/coder/coding.go`
+
+Maestro's blocked/error handling is already stronger than the external reference's looser loop model.
+
+### 4. Knowledge graph retrieval
+
+Relevant files:
+
+- `pkg/coder/planning.go`
+- `pkg/knowledge/retrieval.go`
+- `docs/DOC_GRAPH.md`
+
+For project architecture and repo truth, Maestro's knowledge graph is likely stronger than the external reference's lightweight memory model.
+
+## Important Local Facts and Constraints
+
+These points should shape the next round of analysis.
+
+### 1. `.maestro` files already exist as a repo-backed instruction mechanism
+
+Relevant files:
+
+- `pkg/utils/maestro_files.go`
+- `pkg/templates/renderer.go`
+- `pkg/tools/spec_submit.go`
+- `pkg/mirror/manager.go`
+
+Current Maestro code already supports:
+
+- `.maestro/MAESTRO.md`
+- `.maestro/COMMON.md`
+- `.maestro/CODER.md`
+- `.maestro/ARCHITECT.md`
+
+`RenderWithUserInstructions` appends the agent-specific instruction files to prompts, and `MAESTRO.md` is loaded into planning and coding prompts. There is also already a repo-backed update path for `MAESTRO.md`.
+
+This means the immediate question is **not** whether Maestro needs an update mechanism at all.
+
+The real questions are:
+
+- Which agent should own updates to `.maestro/MAESTRO.md`, `COMMON.md`, `CODER.md`, and `ARCHITECT.md`?
+- Should bootstrap ingest repo-local files such as `AGENTS.md` into `.maestro` files, or otherwise surface them in prompt construction?
+- Should this be treated as prompt/bootstrap work rather than as a new memory subsystem?
+
+### 2. Context loss is not the same as total data loss
+
+Relevant files:
+
+- `pkg/agent/tool_logging.go`
+- `pkg/agent/toolloop/toolloop.go`
+- `pkg/persistence/schema.go`
+- `pkg/persistence/sessions.go`
+- `pkg/coder/resume.go`
+- `pkg/architect/driver.go`
+
+Current Maestro already persists:
+
+- tool execution records in the database
+- agent context snapshots in `agent_contexts`
+- context checkpoints for some error/debugging flows
+
+So when context is compacted out of memory, that information is not necessarily gone forever.
+
+This matters for Stage 2.
+
+The next analysis should distinguish between:
+
+- what must remain in live in-memory context for output quality
+- what can safely live only in persistence for debugging, resume, or forensic inspection
+
+It is reasonable to explore whether fuller context persistence would help debugging, but only if secrets are sanitized appropriately.
+
+## Recommended Implementation Order
+
+This is the current recommended order for implementation:
+
+1. Stage 1 + Stage 4A: Prompt refresh, contract cleanup, and narrow todo modernization
+2. Stage 2A: Pre-call compaction check (practical prerequisite for Stage 3A)
+3. Stage 3A: Acceptance-criteria verification in `TESTING`
+4. Stage 2B: State re-injection after compaction + tool error circuit breaker
+5. Stage 3B: Bounded adversarial probing in `TESTING`
+6. Revisit Stage 5 or Stage 6 only if operating evidence justifies them
+
+Stage 2A is split out because the new `TESTING` verification loop in Stage 3A will immediately depend on compaction behaving correctly. The rest of Stage 2 can follow afterward.
+
+## Stage 1: Prompt Refresh and Prompt Contract Cleanup
+
+### Status
+
+`implement now`
+
+### Why this is first
+
+This is the cheapest and clearest win.
+
+It fixes a real mismatch in today's system rather than speculating about future architecture.
+
+### Current Maestro areas to inspect
+
+- `pkg/templates/coder/app_planning.tpl.md`
+- `pkg/templates/coder/app_coding.tpl.md`
+- `pkg/templates/architect/code_review.tpl.md`
+- `pkg/templates/coder/code_review_request.tpl.md`
+- `pkg/tools/planning_tools.go`
+- `pkg/coder/todo_collection.go`
+
+### Confirmed issues
+
+#### 1. Plan/todo contract mismatch
+
+The planning prompt currently says `submit_plan` requires todos, but the actual `submit_plan` schema does not include them.
+
+This is a concrete mismatch and should be treated as a bug.
+
+#### 2. `CODE_REVIEW` is not the weakest prompt
+
+The architect review template is already fairly strong.
+
+The weaker prompt link is the coder-side review request, especially its vague evidence section.
+
+That means the highest-value prompt cleanup is likely:
+
+- fix the plan/todo mismatch
+- improve structured evidence expectations in `code_review_request.tpl.md`
+- strengthen truthful verification language in `app_coding.tpl.md`
+
+### What not to do
+
+- Do not rewrite the architect review prompt just because it is a prompt
+- Do not over-rotate on generic "be careful" language
+- Do not defer the plan/todo mismatch because a later stage might also touch todos
+
+### Known live prompt files
+
+The following templates are active in the current runtime path:
+
+- `pkg/templates/coder/app_planning.tpl.md` — planning prompt
+- `pkg/templates/coder/app_coding.tpl.md` — coding prompt
+- `pkg/templates/coder/code_review_request.tpl.md` — coder-side review request
+- `pkg/templates/architect/code_review.tpl.md` — architect-side review
+
+The testing template (`pkg/templates/coder/testing.tpl.md`) exists and is registered in `pkg/templates/renderer.go`, but current `TESTING` behavior is the deterministic flow in `pkg/coder/testing.go`. The template is not rendered or sent to an LLM during normal TESTING execution.
+
+### Questions for coders
+
+1. What exact prompt edits fix the plan/todo mismatch?
+2. How should coder-side review evidence be structured?
+3. What is the smallest wording change that improves truthful reporting without adding noise?
+
+### Expected deliverable
+
+Produce:
+
+- a prompt audit
+- a list of exact prompt/tool mismatches
+- a concrete prompt edit proposal
+- a recommendation: `implement now`
+
+## Stage 4A: Narrow Todo Modernization
+
+### Status
+
+`implement now`
+
+### Why this moved up
+
+This stage is now intentionally narrow because it fixes the same high-value contract problem exposed in Stage 1.
+
+### Current Maestro areas to inspect
+
+- `pkg/tools/planning_tools.go`
+- `pkg/coder/plan_review.go`
+- `pkg/coder/todo_collection.go`
+- `pkg/tools/todo_tools.go`
+- `pkg/coder/todo_handlers.go`
+- `pkg/coder/coding.go`
+
+### Recommended scope
+
+The analysis should assume the likely target is:
+
+1. Add `todos` to `submit_plan`
+2. Carry todos directly out of planning
+3. Eliminate the separate todo-collection LLM pass
+4. Add at least an `in_progress` state to todo items
+
+### Important constraints
+
+Do **not** recommend:
+
+- making verification a todo item
+- elaborate dependency graphs between todos
+- turning todos into the primary coordination mechanism of the whole agent
+
+Maestro's FSM and state keys should remain the real coordination mechanism.
+
+### Questions for coders
+
+1. What changes are needed in `submit_plan` schema and process-effect handling?
+2. What is the simplest todo-state expansion that improves coding behavior?
+3. What logic in `plan_review.go` and `todo_collection.go` becomes unnecessary if todos come directly from planning?
+4. What migration path minimizes disruption to existing tests and state handling?
+
+### Expected deliverable
+
+Produce:
+
+- a current-state map of the todo flow
+- a minimal design for folding todos into `submit_plan`
+- a recommendation: `implement now`
+
+## Stage 3A: Acceptance-Criteria Verification in `TESTING`
+
+### Status
+
+`implement now`
+
+### Why this is the most important medium-complexity change
+
+Right now `TESTING` is primarily deterministic.
+
+It runs backend/build/infrastructure checks and routes pass/fail, but it does not appear to perform acceptance-criteria verification with an LLM in the main runtime path.
+
+That means Maestro can still approve work that:
+
+- compiles
+- passes existing tests
+- does not actually satisfy the story's acceptance criteria
+
+### Current Maestro areas to inspect
+
+- `pkg/coder/testing.go`
+- `pkg/templates/coder/testing.tpl.md`
+- `pkg/coder/code_review.go`
+- `pkg/templates/architect/code_review.tpl.md`
+- `docs/TESTING_STRATEGY.md`
+- `docs/specs/TESTING.md`
+
+### Recommended scope
+
+The likely target is:
+
+1. Keep today's deterministic baseline checks
+2. After baseline checks pass, run a fresh-context verification loop
+3. That loop should read:
+   - story task and acceptance criteria
+   - approved plan
+   - changed files or implementation summary
+   - deterministic test/build results
+   - available project commands
+4. The loop should produce structured evidence for `CODE_REVIEW`
+
+This stage is about:
+
+- "did we actually do what was asked?"
+
+It is not yet about:
+
+- broad adversarial fuzzing
+- infinite attempts to break the system
+
+### Hard bounds
+
+The verification loop in `TESTING` must be explicitly bounded:
+
+- **Max 5 LLM turns** — this is a verification pass, not an open-ended conversation
+- **Read-only verification only** — no code edits, no file writes, no self-healing inside `TESTING`
+- **No self-healing** — verification failures route back to `CODING`, not into a fix loop within `TESTING`
+- **`TESTING` produces evidence, it does not become a second coding loop**
+
+### Strawman evidence schema
+
+To prevent coders from spending excessive time on schema design, start from this structure:
+
+```json
+{
+  "deterministic_results": {
+    "build": "pass|fail|not_run",
+    "tests": "pass|fail|not_run",
+    "lint": "pass|fail|not_run",
+    "summary": "..."
+  },
+  "acceptance_criteria_checked": [
+    {
+      "criterion": "...",
+      "method": "command|inspection",
+      "result": "pass|fail|partial|unverified",
+      "evidence": "command/output or concise rationale"
+    }
+  ],
+  "gaps": ["..."],
+  "confidence": "high|medium|low"
+}
+```
+
+This is a starting point, not a final spec. Coders should refine it based on what information `CODE_REVIEW` actually needs.
+
+### Important architectural guidance
+
+This verification belongs in `TESTING`, not `CODE_REVIEW`.
+
+`CODE_REVIEW` should stay the architect approval gate that consumes better evidence.
+
+### Questions for coders
+
+1. Is `pkg/templates/coder/testing.tpl.md` currently used in the live path, or is it dead/spec-only?
+2. What evidence schema should `TESTING` output for later review?
+3. What is the smallest fresh-context testing loop that materially improves confidence?
+4. What kinds of acceptance criteria can be mapped to commands deterministically vs LLM-guided?
+
+### Expected deliverable
+
+Produce:
+
+- a current-state map of `TESTING`
+- a target-state design for acceptance-criteria verification
+- a structured evidence schema proposal
+- a recommendation: `implement now`
+
+## Stage 2: Targeted Context and Toolloop Hardening
+
+### Status
+
+`implement now`, but with deliberately narrow scope and split into two tranches:
+
+- **Stage 2A** (pre-call compaction check): implement before or alongside Stage 3A
+- **Stage 2B** (state re-injection + tool circuit breaker): implement after Stage 3A
+
+### Important framing
+
+This stage is a robustness play for tail-case failures.
+
+It should not be allowed to expand into a general rewrite of context management.
+
+Also note:
+
+- at least one expensive historical failure was primarily a prompt/completion-criteria problem rather than a context-limit problem
+- that is another reason this stage should stay narrow
+
+### Current Maestro areas to inspect
+
+- `pkg/agent/toolloop/toolloop.go`
+- `pkg/contextmgr/contextmgr.go`
+- `docs/CONTEXT_MANAGEMENT.md`
+- `docs/CONTEXT_ISSUE_NOTES.md`
+- `docs/PROMPT_CACHING_IMPLEMENTATION_PLAN.md`
+- `docs/TOOL_LOOP.md`
+- `pkg/persistence/schema.go`
+- `pkg/persistence/sessions.go`
+
+### Recommended scope
+
+The next analysis should focus on exactly these three items:
+
+#### 1. Pre-LLM-call compaction check
+
+Confirm whether compaction should fire earlier and more predictably before an API call.
+
+#### 2. State-summary re-injection after compaction
+
+When compaction removes messages, inject a synthetic summary that preserves key working state, such as:
+
+- current FSM state
+- approved plan summary
+- current todo status
+- recent architect feedback
+- last test results
+
+#### 3. Tool error circuit breaker
+
+Prevent endless retries on the same failing tool pattern.
+
+At minimum, investigate a cap such as:
+
+- same tool
+- same failure shape
+- repeated several times in a row
+
+### Persistence note
+
+This stage should explicitly account for existing persistence support:
+
+- tool executions are already logged
+- `agent_contexts` snapshots already exist
+- checkpoints already exist for some debugging flows
+
+Coders should evaluate whether those mechanisms are sufficient for debugging, or whether a more complete context event stream would help, provided secrets can be sanitized.
+
+### Explicitly out of scope for now
+
+Do **not** recommend any of the following in this stage unless operating evidence strongly demands it:
+
+- full checkpoint/resume redesign
+- adaptive escalation based on context usage
+- snapshot-plus-delta architecture rewrite
+- full event-sourced context system
+
+### Questions for coders
+
+1. What is the current compaction timing, exactly?
+2. What state is most damaging to lose after compaction?
+3. How should state re-injection be represented in context?
+4. What is the safest error-fingerprint definition for a tool circuit breaker?
+5. How much debugging value would be added by richer persisted context, beyond current snapshots and tool logs?
+
+### Expected deliverable
+
+Produce:
+
+- a narrow design note for the three targeted items
+- an assessment of existing persistence coverage
+- a recommendation: `implement now`
+
+## Stage 3B: Adversarial Probing in `TESTING`
+
+### Status
+
+`prototype`
+
+### Why this is not in the first implementation tranche
+
+This is valuable, but it is easier to overscope than acceptance-criteria verification.
+
+It needs careful limits so it does not become:
+
+- an endless loop of trying edge cases
+- an unbounded source of cost
+- a duplicate of `CODE_REVIEW`
+
+### Recommended scope
+
+Prototype only a bounded version of adversarial checks, for example:
+
+- malformed input
+- boundary values
+- repeated/idempotent operations
+- missing-resource or orphan-operation checks
+
+This should be:
+
+- risk-tiered
+- iteration-limited
+- justified by story type or change type
+
+### Questions for coders
+
+1. Which story types justify adversarial probes?
+2. What iteration or budget cap keeps this safe?
+3. Should adversarial probes be optional or automatically triggered for selected change classes?
+4. How should adversarial findings be represented in the testing evidence packet?
+
+### Expected deliverable
+
+Produce:
+
+- a prototype design
+- explicit scope limits
+- a recommendation: `prototype`
+
+## Stage 5: Lightweight Memory
+
+### Status
+
+`skip for now`
+
+### Why
+
+At present, Maestro already has:
+
+- a knowledge graph
+- `.maestro/MAESTRO.md`
+- `.maestro/COMMON.md`
+- `.maestro/CODER.md`
+- `.maestro/ARCHITECT.md`
+- session persistence
+
+That likely covers the highest-value cases without adding a new subsystem.
+
+If concrete gaps emerge later, they should first be tested against:
+
+- extending `.maestro` files
+- bootstrap ingestion of repo-local instruction files
+- extending the knowledge graph where appropriate
+
+### Revisit condition
+
+Only revisit this if operating evidence shows recurring, high-value context that:
+
+- is not derivable from code
+- does not fit cleanly in `.maestro` files
+- does not belong in the knowledge graph
+
+## Stage 6: Read-Only Sidecars and Subagents
+
+### Status
+
+`skip for now`
+
+### Why
+
+This is the most complex idea and not currently the best ROI.
+
+Most of the likely quality value can probably be captured earlier by:
+
+- stronger `TESTING`
+- better prompt contracts
+- targeted context/toolloop hardening
+
+### Revisit condition
+
+Only revisit this if, after Stages 1, 3A, 4A, and targeted Stage 2 work, operating evidence still shows that:
+
+- context pollution is hurting output quality
+- a fresh-context verification or exploration sidecar would clearly help
+
+If revisited later, start with read-only verifier or explorer roles only.
+
+## Standard Output Expected From Coders
+
+For each stage that is still active, coders should produce the same structured output.
+
+### Required sections
+
+1. **Current Maestro behavior**
+2. **Exact problem statement**
+3. **Smallest Maestro-native change**
+4. **Risks and tradeoffs**
+5. **Recommendation**
+   - `implement now`
+   - `prototype`
+   - `skip`
+
+### Strong preference
+
+Coders should prefer:
+
+- small, testable changes
+- explicit file-level grounding
+- recommendations that reinforce the FSM rather than bypass it
+
+## Final Guidance
+
+The most useful lessons from the external reference architecture are now narrower than the first draft of this brief suggested.
+
+The current recommended implementation sequence is:
+
+1. fix the prompt and plan/todo contract bugs, eliminate the redundant todo-collection pass (Stage 1 + 4A)
+2. land pre-call compaction check as a prerequisite for the new TESTING loop (Stage 2A)
+3. make `TESTING` verify acceptance criteria with a bounded, read-only LLM loop (Stage 3A)
+4. add state re-injection and tool circuit breaker (Stage 2B)
+5. prototype bounded adversarial probing (Stage 3B)
+6. defer memory and subagent work unless operating evidence later proves the need

--- a/docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md
+++ b/docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md
@@ -188,7 +188,7 @@ It is reasonable to explore whether fuller context persistence would help debugg
 
 This is the current recommended order for implementation:
 
-1. Stage 1 + Stage 4A: Prompt refresh, contract cleanup, and narrow todo modernization
+1. ~~Stage 1 + Stage 4A: Prompt refresh, contract cleanup, and narrow todo modernization~~ — **COMPLETE** (PR #183)
 2. Stage 2A: Pre-call compaction check (practical prerequisite for Stage 3A)
 3. Stage 3A: Acceptance-criteria verification in `TESTING`
 4. Stage 2B: State re-injection after compaction + tool error circuit breaker
@@ -201,7 +201,7 @@ Stage 2A is split out because the new `TESTING` verification loop in Stage 3A wi
 
 ### Status
 
-`implement now`
+`complete` — PR #183
 
 ### Why this is first
 
@@ -274,7 +274,7 @@ Produce:
 
 ### Status
 
-`implement now`
+`complete` — PR #183 (combined with Stage 1)
 
 ### Why this moved up
 

--- a/pkg/coder/claude/signals.go
+++ b/pkg/coder/claude/signals.go
@@ -47,9 +47,9 @@ var signalToolNames = map[string]Signal{
 // SignalToolInput represents input to a signal tool call.
 type SignalToolInput struct {
 	// For submit_plan
-	Plan       string `json:"plan,omitempty"`
-	Confidence string `json:"confidence,omitempty"`
-	Risks      string `json:"risks,omitempty"`
+	Plan       string   `json:"plan,omitempty"`
+	Confidence string   `json:"confidence,omitempty"`
+	Todos      []string `json:"todos,omitempty"`
 
 	// For done
 	Summary string `json:"summary,omitempty"`
@@ -119,8 +119,12 @@ func parseSignalInput(input any) *SignalToolInput {
 		if confidence, ok := v["confidence"].(string); ok {
 			result.Confidence = confidence
 		}
-		if risks, ok := v["risks"].(string); ok {
-			result.Risks = risks
+		if todosRaw, ok := v["todos"].([]any); ok {
+			for _, item := range todosRaw {
+				if s, ok := item.(string); ok {
+					result.Todos = append(result.Todos, s)
+				}
+			}
 		}
 		if summary, ok := v["summary"].(string); ok {
 			result.Summary = summary

--- a/pkg/coder/claude/signals_test.go
+++ b/pkg/coder/claude/signals_test.go
@@ -16,7 +16,7 @@ func TestSignalDetector_SubmitPlan(t *testing.T) {
 			Input: map[string]any{
 				"plan":       "1. Do thing A\n2. Do thing B",
 				"confidence": "high",
-				"risks":      "None identified",
+				"todos":      []any{"Create module A", "Add tests for module A"},
 			},
 		},
 	})
@@ -35,8 +35,10 @@ func TestSignalDetector_SubmitPlan(t *testing.T) {
 	if input.Confidence != "high" {
 		t.Errorf("expected confidence 'high', got %q", input.Confidence)
 	}
-	if input.Risks != "None identified" {
-		t.Errorf("unexpected risks: %q", input.Risks)
+	if len(input.Todos) != 2 {
+		t.Errorf("expected 2 todos, got %d", len(input.Todos))
+	} else if input.Todos[0] != "Create module A" {
+		t.Errorf("unexpected first todo: %q", input.Todos[0])
 	}
 }
 

--- a/pkg/coder/driver.go
+++ b/pkg/coder/driver.go
@@ -241,9 +241,7 @@ type stateDataKey string
 const (
 	stateDataKeyPlan                     stateDataKey = KeyPlan
 	stateDataKeyPlanConfidence           stateDataKey = "plan_confidence"
-	stateDataKeyPlanTodos                stateDataKey = "plan_todos"
 	stateDataKeyExplorationSummary       stateDataKey = "exploration_summary"
-	stateDataKeyPlanRisks                stateDataKey = "plan_risks"
 	stateDataKeyKnowledgePack            stateDataKey = "knowledge_pack"
 	stateDataKeyPlanApprovalResult       stateDataKey = KeyPlanApprovalResult
 	stateDataKeyCompletionApprovalResult stateDataKey = "completion_approval_result"
@@ -257,13 +255,6 @@ const (
 
 	// BUDGET_REVIEW and other state keys - removed unused constants.
 )
-
-// PlanTodo represents a single task item in the implementation plan.
-type PlanTodo struct {
-	ID          string `json:"id"`
-	Description string `json:"description"`
-	Completed   bool   `json:"completed"`
-}
 
 // Docker container constants.
 const (

--- a/pkg/coder/plan_review.go
+++ b/pkg/coder/plan_review.go
@@ -120,8 +120,13 @@ func (c *Coder) handlePlanReviewApproval(ctx context.Context, sm *agent.BaseStat
 			c.logger.Info("📋 Skipping todo collection in Claude Code mode (Claude Code manages its own todos)")
 			nextState = StateCoding
 			completed = false
+		} else if c.todoList != nil && len(c.todoList.Items) > 0 {
+			// Todos already populated from submit_plan - skip separate collection
+			c.logger.Info("📋 Todos already populated from submit_plan (%d items), skipping todo collection", len(c.todoList.Items))
+			nextState = StateCoding
+			completed = false
 		} else {
-			// Standard mode - collect todos FIRST (fail-fast principle)
+			// Standard mode fallback - collect todos via separate LLM pass
 			c.logger.Info("📋 [TODO] Requesting todo list from LLM after plan approval")
 			var err error
 			nextState, completed, err = c.requestTodoList(ctx, sm)

--- a/pkg/coder/planning.go
+++ b/pkg/coder/planning.go
@@ -334,6 +334,26 @@ func (c *Coder) processPlanDataFromEffect(sm *agent.BaseStateMachine, effectData
 	sm.SetStateData(string(stateDataKeyExplorationSummary), explorationSummary)
 	sm.SetStateData(KeyPlanningCompletedAt, time.Now().UTC())
 
+	// Extract and store todos from submit_plan if present
+	if todosRaw, ok := effectData["todos"]; ok {
+		if todosArray, ok := todosRaw.([]string); ok && len(todosArray) > 0 {
+			items := make([]TodoItem, len(todosArray))
+			for i, desc := range todosArray {
+				items[i] = TodoItem{
+					Description: desc,
+					Completed:   false,
+				}
+			}
+			todoList := &TodoList{
+				Items:   items,
+				Current: 0,
+			}
+			c.todoList = todoList
+			sm.SetStateData(KeyTodoList, todoList)
+			c.logger.Info("📋 Stored %d todos from submit_plan", len(todosArray))
+		}
+	}
+
 	// Store knowledge pack via persistence if available
 	if knowledgePack != "" {
 		storyID := utils.GetStateValueOr[string](sm, KeyStoryID, "")

--- a/pkg/coder/planning_todos_test.go
+++ b/pkg/coder/planning_todos_test.go
@@ -1,0 +1,176 @@
+package coder
+
+import (
+	"context"
+	"testing"
+
+	"orchestrator/pkg/proto"
+	"orchestrator/pkg/utils"
+)
+
+// TestProcessPlanDataFromEffect_StoresTodosInState verifies that todos provided
+// via submit_plan's ProcessEffect.Data are extracted and stored as a TodoList
+// in both the coder's todoList field and the state machine.
+func TestProcessPlanDataFromEffect_StoresTodosInState(t *testing.T) {
+	coder := createTestCoder(t, nil)
+	sm := coder.BaseStateMachine
+
+	effectData := map[string]any{
+		"plan":       "Implementation plan text",
+		"confidence": "HIGH",
+		"todos":      []string{"Create module", "Add tests", "Update docs"},
+	}
+
+	err := coder.processPlanDataFromEffect(sm, effectData)
+	if err != nil {
+		t.Fatalf("processPlanDataFromEffect returned error: %v", err)
+	}
+
+	// Verify plan stored in state
+	plan := utils.GetStateValueOr[string](sm, KeyPlan, "")
+	if plan != "Implementation plan text" {
+		t.Errorf("expected plan stored in state, got: %q", plan)
+	}
+
+	// Verify todos stored in coder field
+	if coder.todoList == nil {
+		t.Fatal("expected coder.todoList to be set, got nil")
+	}
+	if len(coder.todoList.Items) != 3 {
+		t.Fatalf("expected 3 todo items, got %d", len(coder.todoList.Items))
+	}
+	if coder.todoList.Items[0].Description != "Create module" {
+		t.Errorf("expected first todo 'Create module', got %q", coder.todoList.Items[0].Description)
+	}
+	if coder.todoList.Items[1].Description != "Add tests" {
+		t.Errorf("expected second todo 'Add tests', got %q", coder.todoList.Items[1].Description)
+	}
+	if coder.todoList.Items[2].Description != "Update docs" {
+		t.Errorf("expected third todo 'Update docs', got %q", coder.todoList.Items[2].Description)
+	}
+	if coder.todoList.Current != 0 {
+		t.Errorf("expected Current=0, got %d", coder.todoList.Current)
+	}
+
+	// Verify all items start as not completed
+	for i, item := range coder.todoList.Items {
+		if item.Completed {
+			t.Errorf("todo item %d should not be completed", i)
+		}
+	}
+
+	// Verify todos stored in state machine
+	stateTodoList := utils.GetStateValueOr[*TodoList](sm, KeyTodoList, nil)
+	if stateTodoList == nil {
+		t.Fatal("expected TodoList stored in state machine, got nil")
+	}
+	if len(stateTodoList.Items) != 3 {
+		t.Errorf("expected 3 items in state TodoList, got %d", len(stateTodoList.Items))
+	}
+}
+
+// TestProcessPlanDataFromEffect_NoTodos verifies that when submit_plan does not
+// include todos (legacy path), the coder's todoList remains nil.
+func TestProcessPlanDataFromEffect_NoTodos(t *testing.T) {
+	coder := createTestCoder(t, nil)
+	sm := coder.BaseStateMachine
+
+	effectData := map[string]any{
+		"plan":       "Implementation plan text",
+		"confidence": "HIGH",
+	}
+
+	err := coder.processPlanDataFromEffect(sm, effectData)
+	if err != nil {
+		t.Fatalf("processPlanDataFromEffect returned error: %v", err)
+	}
+
+	if coder.todoList != nil {
+		t.Errorf("expected coder.todoList to be nil when no todos provided, got %+v", coder.todoList)
+	}
+}
+
+// TestProcessPlanDataFromEffect_EmptyTodos verifies that an empty todos array
+// does not create a TodoList.
+func TestProcessPlanDataFromEffect_EmptyTodos(t *testing.T) {
+	coder := createTestCoder(t, nil)
+	sm := coder.BaseStateMachine
+
+	effectData := map[string]any{
+		"plan":       "Implementation plan text",
+		"confidence": "HIGH",
+		"todos":      []string{},
+	}
+
+	err := coder.processPlanDataFromEffect(sm, effectData)
+	if err != nil {
+		t.Fatalf("processPlanDataFromEffect returned error: %v", err)
+	}
+
+	if coder.todoList != nil {
+		t.Errorf("expected coder.todoList to be nil for empty todos, got %+v", coder.todoList)
+	}
+}
+
+// TestHandlePlanReviewApproval_SkipsTodoCollectionWhenTodosExist verifies that
+// when todos are already populated from submit_plan, handlePlanReviewApproval
+// skips the separate requestTodoList() LLM call and transitions directly to CODING.
+func TestHandlePlanReviewApproval_SkipsTodoCollectionWhenTodosExist(t *testing.T) {
+	coder := createTestCoder(t, nil)
+	sm := coder.BaseStateMachine
+
+	// Pre-populate todos as submit_plan would
+	coder.todoList = &TodoList{
+		Items: []TodoItem{
+			{Description: "Create module", Completed: false},
+			{Description: "Add tests", Completed: false},
+		},
+		Current: 0,
+	}
+
+	// Set required state data for the approval handler
+	sm.SetStateData(KeyPlan, "Implementation plan")
+	sm.SetStateData(string(stateDataKeyPlanConfidence), "HIGH")
+
+	ctx := context.Background()
+	nextState, completed, err := coder.handlePlanReviewApproval(ctx, sm, proto.ApprovalTypePlan)
+	if err != nil {
+		t.Fatalf("handlePlanReviewApproval returned error: %v", err)
+	}
+
+	if completed {
+		t.Error("expected completed=false for plan approval")
+	}
+
+	// The key assertion: should transition to CODING, not ERROR.
+	// If it tried to call requestTodoList() without an LLM client, it would error.
+	// Since we pre-populated todos, it should skip that and go to CODING.
+	if nextState != StateCoding {
+		t.Errorf("expected next state %s, got %s", StateCoding, nextState)
+	}
+
+	// Verify todos are still intact
+	if coder.todoList == nil || len(coder.todoList.Items) != 2 {
+		t.Errorf("expected 2 todo items still present, got %v", coder.todoList)
+	}
+}
+
+// TestHandlePlanReviewApproval_CompletionApproval verifies that completion
+// approval still works correctly (not affected by todo changes).
+func TestHandlePlanReviewApproval_CompletionApproval(t *testing.T) {
+	coder := createTestCoder(t, nil)
+	sm := coder.BaseStateMachine
+
+	ctx := context.Background()
+	nextState, completed, err := coder.handlePlanReviewApproval(ctx, sm, proto.ApprovalTypeCompletion)
+	if err != nil {
+		t.Fatalf("handlePlanReviewApproval returned error: %v", err)
+	}
+
+	if !completed {
+		t.Error("expected completed=true for completion approval")
+	}
+	if nextState != proto.StateDone {
+		t.Errorf("expected next state %s, got %s", proto.StateDone, nextState)
+	}
+}

--- a/pkg/coder/todo_handlers.go
+++ b/pkg/coder/todo_handlers.go
@@ -33,11 +33,15 @@ func (c *Coder) getTodoListStatus() string {
 		status += "**Completed**:\n" + strings.Join(completed, "\n") + "\n\n"
 	}
 
-	// Show remaining todos
+	// Show remaining todos (distinguish in-progress from pending)
 	remaining := []string{}
 	for i := range c.todoList.Items {
 		if !c.todoList.Items[i].Completed {
-			remaining = append(remaining, fmt.Sprintf("- ⏸️  %s", c.todoList.Items[i].Description))
+			if i == c.todoList.Current {
+				remaining = append(remaining, fmt.Sprintf("- 🔄 %s", c.todoList.Items[i].Description))
+			} else {
+				remaining = append(remaining, fmt.Sprintf("- ⏸️  %s", c.todoList.Items[i].Description))
+			}
 		}
 	}
 	if len(remaining) > 0 {

--- a/pkg/coder/tool_validation_test.go
+++ b/pkg/coder/tool_validation_test.go
@@ -149,7 +149,7 @@ func TestSubmitPlanToolValidation(t *testing.T) {
 	}
 
 	// Test required parameters.
-	expectedRequired := []string{"plan", "confidence"}
+	expectedRequired := []string{"plan", "confidence", "todos"}
 	if len(def.InputSchema.Required) != len(expectedRequired) {
 		t.Errorf("Expected %d required parameters, got %d", len(expectedRequired), len(def.InputSchema.Required))
 	}
@@ -172,6 +172,7 @@ func TestSubmitPlanToolValidation(t *testing.T) {
 	validArgs := map[string]any{
 		"plan":                "Detailed implementation plan...",
 		"confidence":          string(proto.ConfidenceHigh),
+		"todos":               []any{"Create module", "Add tests"},
 		"exploration_summary": "Explored 15 files, found 3 patterns",
 		"knowledge_pack":      "digraph KG { A -> B; }",
 	}
@@ -265,6 +266,7 @@ func TestSubmitPlanToolErrorHandling(t *testing.T) {
 			args: map[string]any{
 				"plan":       "Minimal valid plan",
 				"confidence": "MEDIUM",
+				"todos":      []any{"First task"},
 			},
 			expectError: false,
 		},

--- a/pkg/coder/toolloop_results.go
+++ b/pkg/coder/toolloop_results.go
@@ -28,8 +28,7 @@ type PlanningResult struct {
 	Plan               string
 	Confidence         string
 	ExplorationSummary string
-	Risks              string
-	Todos              []PlanTodo
+	Todos              []string
 	KnowledgePack      string
 }
 
@@ -80,18 +79,15 @@ func ExtractPlanningResult(calls []agent.ToolCall, results []any) (PlanningResul
 				result.Plan = utils.GetMapFieldOr[string](resultMap, "plan", "")
 				result.Confidence = utils.GetMapFieldOr[string](resultMap, "confidence", "")
 				result.ExplorationSummary = utils.GetMapFieldOr[string](resultMap, "exploration_summary", "")
-				result.Risks = utils.GetMapFieldOr[string](resultMap, "risks", "")
 				result.KnowledgePack = utils.GetMapFieldOr[string](resultMap, "knowledge_pack", "")
 
-				// Extract todos if present
-				todos := utils.GetMapFieldOr[[]any](resultMap, "todos", []any{})
-				result.Todos = make([]PlanTodo, len(todos))
-				for j, todoItem := range todos {
-					if todoMap, ok := utils.SafeAssert[map[string]any](todoItem); ok {
-						result.Todos[j] = PlanTodo{
-							ID:          utils.GetMapFieldOr[string](todoMap, "id", ""),
-							Description: utils.GetMapFieldOr[string](todoMap, "description", ""),
-							Completed:   utils.GetMapFieldOr[bool](todoMap, "completed", false),
+				// Extract todos as []string
+				if todosRaw, ok := resultMap["todos"]; ok {
+					if todosArray, ok := todosRaw.([]any); ok {
+						for _, item := range todosArray {
+							if s, ok := item.(string); ok {
+								result.Todos = append(result.Todos, s)
+							}
 						}
 					}
 				}

--- a/pkg/coder/toolloop_results_test.go
+++ b/pkg/coder/toolloop_results_test.go
@@ -26,20 +26,8 @@ func TestExtractPlanningResult_SubmitPlan(t *testing.T) {
 			"plan":                "Implementation plan here",
 			"confidence":          "high",
 			"exploration_summary": "Explored the codebase",
-			"risks":               "Some risks",
 			"knowledge_pack":      "Key learnings",
-			"todos": []any{
-				map[string]any{
-					"id":          "1",
-					"description": "First task",
-					"completed":   false,
-				},
-				map[string]any{
-					"id":          "2",
-					"description": "Second task",
-					"completed":   true,
-				},
-			},
+			"todos":               []any{"First task", "Second task"},
 		},
 	}
 
@@ -60,20 +48,17 @@ func TestExtractPlanningResult_SubmitPlan(t *testing.T) {
 	if result.ExplorationSummary != "Explored the codebase" {
 		t.Errorf("Expected exploration_summary to be extracted")
 	}
-	if result.Risks != "Some risks" {
-		t.Errorf("Expected risks to be extracted")
-	}
 	if result.KnowledgePack != "Key learnings" {
 		t.Errorf("Expected knowledge_pack to be extracted")
 	}
 	if len(result.Todos) != 2 {
 		t.Errorf("Expected 2 todos, got %d", len(result.Todos))
 	}
-	if result.Todos[0].Description != "First task" {
-		t.Errorf("Expected first todo description 'First task', got: %s", result.Todos[0].Description)
+	if len(result.Todos) >= 1 && result.Todos[0] != "First task" {
+		t.Errorf("Expected first todo 'First task', got: %s", result.Todos[0])
 	}
-	if result.Todos[1].Completed != true {
-		t.Error("Expected second todo to be completed")
+	if len(result.Todos) >= 2 && result.Todos[1] != "Second task" {
+		t.Errorf("Expected second todo 'Second task', got: %s", result.Todos[1])
 	}
 }
 
@@ -421,11 +406,8 @@ func TestPlanningResultStruct(t *testing.T) {
 		Plan:               "Plan text",
 		Confidence:         "high",
 		ExplorationSummary: "Summary",
-		Risks:              "Risks",
-		Todos: []PlanTodo{
-			{ID: "1", Description: "Task", Completed: false},
-		},
-		KnowledgePack: "Knowledge",
+		Todos:              []string{"Task 1", "Task 2"},
+		KnowledgePack:      "Knowledge",
 	}
 
 	if result.Signal != "TEST" {
@@ -440,10 +422,7 @@ func TestPlanningResultStruct(t *testing.T) {
 	if result.ExplorationSummary != "Summary" {
 		t.Error("ExplorationSummary not set correctly")
 	}
-	if result.Risks != "Risks" {
-		t.Error("Risks not set correctly")
-	}
-	if len(result.Todos) != 1 {
+	if len(result.Todos) != 2 {
 		t.Error("Todos not set correctly")
 	}
 	if result.KnowledgePack != "Knowledge" {

--- a/pkg/templates/claude/planning.tpl.md
+++ b/pkg/templates/claude/planning.tpl.md
@@ -9,14 +9,15 @@ As a coder agent, you should:
 2. Explore the codebase to understand existing patterns and architecture
 3. Identify files that need to be created or modified
 4. Create a step-by-step implementation plan
-5. Assess confidence level and identify risks
+5. Assess confidence level and create ordered implementation todos
 
 ## Available Signals
 
 You have access to special signal tools for state transitions:
 
 - **submit_plan**: Call when your implementation plan is ready for architect review
-  - Parameters: plan (string), confidence (string: HIGH/MEDIUM/LOW), exploration_summary (string, optional)
+  - Parameters: plan (string), confidence (string: HIGH/MEDIUM/LOW), todos (array of strings, 1-20 ordered implementation tasks) — all required
+  - Optional: exploration_summary (string)
 
 - **story_complete**: Call when the story is already implemented and requires no changes
   - Parameters: evidence (string), confidence (string: HIGH/MEDIUM/LOW), exploration_summary (string, optional)
@@ -45,7 +46,7 @@ Working directory: {{.WorkspacePath}}
 
 When your analysis is complete, call `submit_plan` with:
 - A detailed plan organized by phase/step
-- Your confidence level (high/medium/low)
-- Any identified risks or concerns
+- Your confidence level (HIGH/MEDIUM/LOW)
+- Ordered implementation todos (1-20 tasks that will track progress during coding)
 
 If you discover the story is already implemented or requires no changes, call `story_complete` with evidence of why no changes are needed. The architect will verify your claim before marking the story complete.

--- a/pkg/templates/coder/app_coding.tpl.md
+++ b/pkg/templates/coder/app_coding.tpl.md
@@ -58,6 +58,8 @@ Key examples:
 
 ### Todo Management
 - **todo_complete**: Call this IMMEDIATELY after finishing the current task. Before calling, verify the work:
+  - Reading code is not verification. You must run a command to confirm the work before marking a todo complete.
+  - If you did not run a verification command, do not mark the todo complete.
 {{- if .TestCommand}}
   - Run tests to confirm functionality works: `shell({{"{"}}{{printf "\"command\": \"%s\"" .TestCommand}}}})`
 {{- else}}

--- a/pkg/templates/coder/app_planning.tpl.md
+++ b/pkg/templates/coder/app_planning.tpl.md
@@ -133,30 +133,31 @@ Create a comprehensive application development plan based on your exploration:
 When submitting your plan with `submit_plan`, you MUST provide:
 
 ### Required Parameters:
-- **`plan`**: Your complete application development implementation plan (JSON format above)
+- **`plan`**: Your complete implementation plan (JSON format above)
 - **`confidence`**: "HIGH", "MEDIUM", or "LOW" based on exploration
+- **`todos`**: Ordered list of implementation tasks (1-20 items, 3-10 recommended for typical stories)
+
+### Optional Parameters:
 - **`exploration_summary`**: Brief summary of files explored and findings
-- **`risks`**: Potential development challenges or risks identified
-- **`todos`**: **REQUIRED** - Ordered list of implementation tasks
 
-### JSON example to follow exactly:
+### Example tool call:
 
-```json
-{
+```
+submit_plan({
+  "plan": "<your implementation plan as JSON string>",
+  "confidence": "HIGH",
   "todos": [
     "Create base module structure in pkg/mymodule/",
-    "Implement core functionality with proper error handling", 
+    "Implement core functionality with proper error handling",
     "Add comprehensive unit tests covering all public functions",
-    "Create integration tests with existing services",
-    "Update documentation and add usage examples",
-    "Integrate with existing service patterns and interfaces"
+    "Update documentation and add usage examples"
   ]
-}
+})
 ```
 
 **Important**: Todos will be used to track progress during implementation. Each todo should be:
 - **Development-focused**: Clear coding, testing, documentation tasks
-- **Ordered**: Dependencies implicit in sequence  
+- **Ordered**: Dependencies implicit in sequence
 - **Complete**: Covers all development work
 - **Testable**: Can be verified when done
 

--- a/pkg/templates/coder/code_review_request.tpl.md
+++ b/pkg/templates/coder/code_review_request.tpl.md
@@ -6,9 +6,11 @@ I have completed the implementation and all tests are passing. Ready for code re
 
 {{.Extra.Summary}}
 
-## Evidence
+## Verification Evidence
 
 {{.Extra.Evidence}}
+
+**Note to reviewer**: This evidence reflects build, test, and lint results plus workspace inspection. Evaluate the implementation against the original story requirements independently.
 
 ## Confidence Level
 

--- a/pkg/templates/coder/devops_planning.tpl.md
+++ b/pkg/templates/coder/devops_planning.tpl.md
@@ -142,22 +142,25 @@ When submitting your plan with `submit_plan`, you MUST provide:
 ### Required Parameters:
 - **`plan`**: Your complete infrastructure implementation plan (JSON format above)
 - **`confidence`**: "HIGH", "MEDIUM", or "LOW" based on exploration
+- **`todos`**: Ordered list of infrastructure implementation tasks (1-20 items, 3-10 recommended for typical stories)
+
+### Optional Parameters:
 - **`exploration_summary`**: Brief summary of infrastructure explored and findings
-- **`risks`**: Potential infrastructure challenges or risks identified
-- **`todos`**: **REQUIRED** - Ordered list of infrastructure implementation tasks
 
-### JSON example to follow exactly:
+### Example tool call:
 
-```json
-{
+```
+submit_plan({
+  "plan": "<your infrastructure implementation plan as JSON string>",
+  "confidence": "HIGH",
   "todos": [
     "Build and validate Docker container with required tools",
-    "Test container functionality and tool availability", 
+    "Test container functionality and tool availability",
     "Setup deployment configuration and scripts",
     "Validate complete infrastructure stack",
     "Document infrastructure setup and usage"
   ]
-}
+})
 ```
 
 **Important**: Todos will be used to track progress during implementation. Each todo should be:

--- a/pkg/tools/planning_tools.go
+++ b/pkg/tools/planning_tools.go
@@ -215,12 +215,21 @@ func (s *SubmitPlanTool) Definition() ToolDefinition {
 			Properties: map[string]Property{
 				"plan": {
 					Type:        "string",
-					Description: "Your implementation plan ready for architect approval (will be broken into todos in next phase)",
+					Description: "Your implementation plan ready for architect approval",
 				},
 				"confidence": {
 					Type:        "string",
 					Description: "Your confidence level based on codebase exploration",
 					Enum:        []string{string(proto.ConfidenceHigh), string(proto.ConfidenceMedium), string(proto.ConfidenceLow)},
+				},
+				"todos": {
+					Type:        "array",
+					Description: "Ordered list of implementation tasks. Each should start with an action verb and have clear completion criteria. Example: [\"Create main.go with basic structure\", \"Implement HTTP server setup\", \"Add error handling and tests\"]",
+					Items: &Property{
+						Type: "string",
+					},
+					MinItems: &[]int{1}[0],
+					MaxItems: &[]int{20}[0],
 				},
 				"exploration_summary": {
 					Type:        "string",
@@ -231,7 +240,7 @@ func (s *SubmitPlanTool) Definition() ToolDefinition {
 					Description: "Relevant knowledge graph subgraph in DOT format (auto-populated, optional)",
 				},
 			},
-			Required: []string{"plan", "confidence"},
+			Required: []string{"plan", "confidence", "todos"},
 		},
 	}
 }
@@ -244,37 +253,22 @@ func (s *SubmitPlanTool) Name() string {
 // PromptDocumentation returns markdown documentation for LLM prompts.
 func (s *SubmitPlanTool) PromptDocumentation() string {
 	return `- **submit_plan** - Submit implementation plan for architect approval
-  - Parameters: plan, confidence (required), exploration_summary (optional)
+  - Parameters: plan, confidence, todos (required), exploration_summary (optional)
+  - Include 1-20 ordered implementation todos that will track progress during coding
   - Advances to PLAN_REVIEW for architect approval
-  - If the story requires no changes, use done with a summary explaining why`
+  - If the story requires no changes, use story_complete with evidence instead`
 }
 
 // Exec executes the submit plan operation.
 func (s *SubmitPlanTool) Exec(_ context.Context, args map[string]any) (*ExecResult, error) {
-	// Validate plan (required)
-	plan, ok := args["plan"]
-	if !ok {
-		return nil, fmt.Errorf("plan parameter is required")
+	planStr, err := extractRequiredString(args, "plan")
+	if err != nil {
+		return nil, err
 	}
 
-	planStr, ok := plan.(string)
-	if !ok {
-		return nil, fmt.Errorf("plan must be a string")
-	}
-
-	if planStr == "" {
-		return nil, fmt.Errorf("plan cannot be empty")
-	}
-
-	// Validate confidence (required)
-	confidence, ok := args["confidence"]
-	if !ok {
-		return nil, fmt.Errorf("confidence parameter is required")
-	}
-
-	confidenceStr, ok := confidence.(string)
-	if !ok {
-		return nil, fmt.Errorf("confidence must be a string")
+	confidenceStr, err := extractRequiredString(args, "confidence")
+	if err != nil {
+		return nil, err
 	}
 
 	// Validate confidence level.
@@ -285,21 +279,13 @@ func (s *SubmitPlanTool) Exec(_ context.Context, args map[string]any) (*ExecResu
 		return nil, fmt.Errorf("confidence must be %s, %s, or %s", proto.ConfidenceHigh, proto.ConfidenceMedium, proto.ConfidenceLow)
 	}
 
-	// Extract optional exploration summary.
-	explorationSummary := ""
-	if expVal, hasExp := args["exploration_summary"]; hasExp {
-		if expStr, ok := expVal.(string); ok {
-			explorationSummary = expStr
-		}
+	validatedTodos, err := extractStringArray(args, "todos", 1, 20)
+	if err != nil {
+		return nil, err
 	}
 
-	// Extract optional knowledge_pack.
-	knowledgePack := ""
-	if packVal, hasPack := args["knowledge_pack"]; hasPack {
-		if packStr, ok := packVal.(string); ok {
-			knowledgePack = packStr
-		}
-	}
+	explorationSummary := extractOptionalString(args, "exploration_summary")
+	knowledgePack := extractOptionalString(args, "knowledge_pack")
 
 	// Return human-readable message for LLM context
 	// Return structured data via ProcessEffect.Data for state machine
@@ -310,9 +296,63 @@ func (s *SubmitPlanTool) Exec(_ context.Context, args map[string]any) (*ExecResu
 			Data: map[string]any{
 				"plan":                planStr,
 				"confidence":          confidenceStr,
+				"todos":               validatedTodos,
 				"exploration_summary": explorationSummary,
 				"knowledge_pack":      knowledgePack,
 			},
 		},
 	}, nil
+}
+
+// extractRequiredString extracts and validates a required string parameter from tool args.
+func extractRequiredString(args map[string]any, key string) (string, error) {
+	val, ok := args[key]
+	if !ok {
+		return "", fmt.Errorf("%s parameter is required", key)
+	}
+	str, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string", key)
+	}
+	if str == "" {
+		return "", fmt.Errorf("%s cannot be empty", key)
+	}
+	return str, nil
+}
+
+// extractOptionalString extracts an optional string parameter from tool args.
+func extractOptionalString(args map[string]any, key string) string {
+	if val, ok := args[key]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+// extractStringArray extracts and validates a required array of strings from tool args.
+func extractStringArray(args map[string]any, key string, minItems, maxItems int) ([]string, error) {
+	raw, ok := args[key]
+	if !ok {
+		return nil, fmt.Errorf("%s parameter is required", key)
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", key)
+	}
+	if len(arr) < minItems || len(arr) > maxItems {
+		return nil, fmt.Errorf("%s must contain %d-%d items (got %d)", key, minItems, maxItems, len(arr))
+	}
+	result := make([]string, len(arr))
+	for i, item := range arr {
+		str, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s item %d must be a string", key, i)
+		}
+		if str == "" {
+			return nil, fmt.Errorf("%s item %d cannot be empty", key, i)
+		}
+		result[i] = str
+	}
+	return result, nil
 }

--- a/pkg/tools/planning_tools.go
+++ b/pkg/tools/planning_tools.go
@@ -253,7 +253,7 @@ func (s *SubmitPlanTool) Name() string {
 // PromptDocumentation returns markdown documentation for LLM prompts.
 func (s *SubmitPlanTool) PromptDocumentation() string {
 	return `- **submit_plan** - Submit implementation plan for architect approval
-  - Parameters: plan, confidence, todos (required), exploration_summary (optional)
+  - Parameters: plan, confidence, todos (required), exploration_summary, knowledge_pack (optional)
   - Include 1-20 ordered implementation todos that will track progress during coding
   - Advances to PLAN_REVIEW for architect approval
   - If the story requires no changes, use story_complete with evidence instead`


### PR DESCRIPTION
## Summary

- **Adds `todos` as a required parameter to the `submit_plan` tool schema**, eliminating the mismatch where the planning template documented todos as required but the tool didn't accept them
- **Stores todos from `submit_plan` directly in state**, bypassing the separate `requestTodoList()` LLM call when todos are already populated (saves one full LLM round-trip per story)
- **Cleans up stale compatibility code**: removes unused `PlanTodo` struct, `Risks` field from signals, and dead `stateDataKeyPlanTodos`/`stateDataKeyPlanRisks` constants

See `docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md` for the research brief driving this work (Stage 1 + 4A).

### Changes by area

**Schema fix** (`pkg/tools/planning_tools.go`):
- `todos` added as required array param (1-20 string items) to `submit_plan` Definition/Exec
- Extracted `extractRequiredString`, `extractOptionalString`, `extractStringArray` helpers to stay under cyclop limit

**State storage** (`pkg/coder/planning.go`):
- `processPlanDataFromEffect()` extracts todos from effect data, builds `TodoList`, stores in both `c.todoList` and state machine

**Skip redundant LLM call** (`pkg/coder/plan_review.go`):
- `handlePlanReviewApproval()` skips `requestTodoList()` when `c.todoList` is already populated from `submit_plan`
- `requestTodoList()` remains as fallback for edge cases

**Compatibility cleanup**:
- `PlanningResult.Todos` changed from `[]PlanTodo` to `[]string`, `Risks` removed
- `SignalToolInput.Risks` replaced with `Todos []string`
- `PlanTodo` struct and stale constants deleted

**Template fixes**:
- Planning template documents actual schema (todos required, risks removed)
- Coding template strengthens verification language for `todo_complete`
- Code review request template reframes evidence section

**Display**: Current todo shows 🔄 (in-progress) instead of ⏸️, derived from existing `Current` index

## Test plan

- [x] `make build` passes
- [x] `make lint` passes  
- [x] `make test` passes (all unit tests)
- [x] `make test-integration` passes (all integration tests)
- [x] New behavioral tests in `planning_todos_test.go`:
  - `TestProcessPlanDataFromEffect_StoresTodosInState` — todos stored in field + state machine
  - `TestProcessPlanDataFromEffect_NoTodos` — nil when absent
  - `TestProcessPlanDataFromEffect_EmptyTodos` — nil for empty array
  - `TestHandlePlanReviewApproval_SkipsTodoCollectionWhenTodosExist` — proves skip works (would error without LLM client)
  - `TestHandlePlanReviewApproval_CompletionApproval` — regression test
- [x] Updated tests in `tool_validation_test.go`, `toolloop_results_test.go`, `signals_test.go`
- [x] Verify no remaining `PlanTodo` references: `grep -r "PlanTodo" pkg/`
- [x] Verify no remaining `"risks"` in templates: `grep -r '"risks"' pkg/templates/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)