### PR TITLE
Add tool failure circuit breaker (Stage 2B)

### DIFF
--- a/docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md
+++ b/docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md
@@ -191,7 +191,7 @@ This is the current recommended order for implementation:
 1. ~~Stage 1 + Stage 4A: Prompt refresh, contract cleanup, and narrow todo modernization~~ — **COMPLETE** (PR #183)
 2. ~~Stage 2A: Pre-call compaction check (practical prerequisite for Stage 3A)~~ — **COMPLETE** (PR #184)
 3. Stage 3A: Acceptance-criteria verification in `TESTING`
-4. Stage 2B: State re-injection after compaction + tool error circuit breaker
+4. ~~Stage 2B: Tool failure circuit breaker~~ — **COMPLETE** (PR #185)
 5. Stage 3B: Bounded adversarial probing in `TESTING`
 6. Revisit Stage 5 or Stage 6 only if operating evidence justifies them
 
@@ -438,7 +438,7 @@ Produce:
 `implement now`, but with deliberately narrow scope and split into two tranches:
 
 - **Stage 2A** (fix pre-call compaction accuracy + state re-injection): `complete` — PR #184
-- **Stage 2B** (tool circuit breaker): implement after Stage 3A
+- **Stage 2B** (tool failure circuit breaker): `complete` — PR #185
 
 ### Important framing
 

--- a/pkg/agent/toolloop/circuit.go
+++ b/pkg/agent/toolloop/circuit.go
@@ -29,8 +29,12 @@ type ToolCircuitBreakerConfig struct {
 }
 
 // classifyToolResult checks tool execution results for both Go errors and semantic
-// failures (JSON "success": false, non-zero exit_code). Returns whether the result
-// represents a failure and a human-readable error detail string.
+// failures (JSON "success": false). Returns whether the result represents a failure
+// and a human-readable error detail string.
+//
+// Only "success": false is treated as a semantic failure. Non-zero exit_code alone
+// is NOT a failure — the shell tool explicitly returns non-zero exit codes as normal
+// data (grep, test -f, git diff --quiet all use non-zero exits for non-error conditions).
 func classifyToolResult(execResult *tools.ExecResult, execErr error) (isFailure bool, errorDetail string) {
 	// Go error is always a failure
 	if execErr != nil {
@@ -48,25 +52,13 @@ func classifyToolResult(execResult *tools.ExecResult, execErr error) (isFailure 
 		return false, ""
 	}
 
-	// Check "success": false
+	// Check "success": false — the canonical semantic failure signal.
+	// Tools like file_edit, read_file, list_files, build, test, lint all use this.
 	if success, ok := result["success"]; ok {
 		if successBool, ok := success.(bool); ok && !successBool {
 			detail := "success: false"
 			if errMsg, ok := result["error"].(string); ok && errMsg != "" {
 				detail = errMsg
-			}
-			return true, detail
-		}
-	}
-
-	// Check non-zero exit_code (shell commands return exit_code in JSON)
-	if exitCode, ok := result["exit_code"]; ok {
-		// JSON numbers unmarshal as float64
-		if exitFloat, ok := exitCode.(float64); ok && exitFloat != 0 {
-			detail := fmt.Sprintf("exit_code: %d", int(exitFloat))
-			if stderr, ok := result["stderr"].(string); ok && stderr != "" {
-				// Use first line of stderr as detail
-				detail = firstLine(stderr, 200)
 			}
 			return true, detail
 		}
@@ -121,9 +113,21 @@ func (t *toolErrorTracker) checkTripped(toolName string, params map[string]any) 
 }
 
 // recordFailure increments the counter for this specific fingerprint (tool+params+error).
+// When the error changes for the same callKey, old fingerprints are cleared so only
+// truly consecutive same-error failures accumulate toward the threshold.
 func (t *toolErrorTracker) recordFailure(toolName string, params map[string]any, errorDetail string) {
 	fp := fullFingerprint(toolName, params, errorDetail)
 	key := callKey(toolName, params)
+
+	// Clear other fingerprints for this callKey — if the error changed, the old
+	// error's count must not persist (A,A,B,A should NOT trip A at 3).
+	keyPrefix := key + ":"
+	for k := range t.counts {
+		if strings.HasPrefix(k, keyPrefix) && k != fp {
+			delete(t.counts, k)
+		}
+	}
+
 	t.counts[fp]++
 	t.lastErr[key] = errorDetail
 
@@ -137,25 +141,18 @@ func (t *toolErrorTracker) recordFailure(toolName string, params map[string]any,
 	}
 }
 
-// recordSuccess resets all failure tracking for the given tool name.
-// Any successful execution means the LLM adapted — clear everything for this tool.
-func (t *toolErrorTracker) recordSuccess(toolName string) {
-	prefix := toolName + ":"
+// recordSuccess resets failure tracking for the specific tool+params combination.
+// A successful shell(cmd=pwd) does NOT clear failures for shell(cmd=make test).
+func (t *toolErrorTracker) recordSuccess(toolName string, params map[string]any) {
+	key := callKey(toolName, params)
+	keyPrefix := key + ":"
 	for k := range t.counts {
-		if strings.HasPrefix(k, prefix) {
+		if strings.HasPrefix(k, keyPrefix) {
 			delete(t.counts, k)
 		}
 	}
-	for k := range t.tripped {
-		if strings.HasPrefix(k, prefix) {
-			delete(t.tripped, k)
-		}
-	}
-	for k := range t.lastErr {
-		if strings.HasPrefix(k, prefix) {
-			delete(t.lastErr, k)
-		}
-	}
+	delete(t.tripped, key)
+	delete(t.lastErr, key)
 }
 
 // hashParams produces a short hex hash of the canonicalized (sorted-key) JSON

--- a/pkg/agent/toolloop/circuit.go
+++ b/pkg/agent/toolloop/circuit.go
@@ -99,8 +99,11 @@ func callKey(toolName string, params map[string]any) string {
 // fullFingerprint builds a breaker-state key from tool name, params, and error.
 // Different errors on the same call produce different fingerprints, so the counter
 // only accumulates when the same call fails the same way repeatedly.
+// The full error is hashed (not truncated) to avoid collisions between errors
+// that share a long common prefix.
 func fullFingerprint(toolName string, params map[string]any, errorDetail string) string {
-	return callKey(toolName, params) + ":" + firstLine(errorDetail, 100)
+	errHash := sha256.Sum256([]byte(errorDetail))
+	return callKey(toolName, params) + ":" + hex.EncodeToString(errHash[:8])
 }
 
 // checkTripped returns true if any fingerprint for this tool+params is tripped.
@@ -129,7 +132,7 @@ func (t *toolErrorTracker) recordFailure(toolName string, params map[string]any,
 	}
 
 	t.counts[fp]++
-	t.lastErr[key] = errorDetail
+	t.lastErr[key] = firstLine(errorDetail, 200)
 
 	if t.counts[fp] >= t.config.MaxConsecutiveFailures && !t.tripped[key] {
 		t.tripped[key] = true

--- a/pkg/agent/toolloop/circuit.go
+++ b/pkg/agent/toolloop/circuit.go
@@ -1,0 +1,208 @@
+package toolloop
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"orchestrator/pkg/logx"
+	"orchestrator/pkg/tools"
+)
+
+// defaultMaxConsecutiveFailures is used when MaxConsecutiveFailures is 0.
+const defaultMaxConsecutiveFailures = 3
+
+// ToolCircuitBreakerConfig configures per-tool failure detection within a toolloop Run.
+//
+//nolint:govet // Function pointer logically grouped with threshold
+type ToolCircuitBreakerConfig struct {
+	// MaxConsecutiveFailures before the breaker trips for a given fingerprint.
+	// Zero value defaults to 3.
+	MaxConsecutiveFailures int
+
+	// OnTrip is called when a tool's circuit breaker trips (optional).
+	// Receives the tool name, human-readable label, and failure count.
+	OnTrip func(toolName, label string, count int)
+}
+
+// classifyToolResult checks tool execution results for both Go errors and semantic
+// failures (JSON "success": false, non-zero exit_code). Returns whether the result
+// represents a failure and a human-readable error detail string.
+func classifyToolResult(execResult *tools.ExecResult, execErr error) (isFailure bool, errorDetail string) {
+	// Go error is always a failure
+	if execErr != nil {
+		return true, execErr.Error()
+	}
+
+	if execResult == nil || execResult.Content == "" {
+		return false, ""
+	}
+
+	// Try to parse content as JSON and check for semantic failure indicators.
+	var result map[string]any
+	if err := json.Unmarshal([]byte(execResult.Content), &result); err != nil {
+		// Not JSON — treat as success (plain text tool output).
+		return false, ""
+	}
+
+	// Check "success": false
+	if success, ok := result["success"]; ok {
+		if successBool, ok := success.(bool); ok && !successBool {
+			detail := "success: false"
+			if errMsg, ok := result["error"].(string); ok && errMsg != "" {
+				detail = errMsg
+			}
+			return true, detail
+		}
+	}
+
+	// Check non-zero exit_code (shell commands return exit_code in JSON)
+	if exitCode, ok := result["exit_code"]; ok {
+		// JSON numbers unmarshal as float64
+		if exitFloat, ok := exitCode.(float64); ok && exitFloat != 0 {
+			detail := fmt.Sprintf("exit_code: %d", int(exitFloat))
+			if stderr, ok := result["stderr"].(string); ok && stderr != "" {
+				// Use first line of stderr as detail
+				detail = firstLine(stderr, 200)
+			}
+			return true, detail
+		}
+	}
+
+	return false, ""
+}
+
+// toolErrorTracker tracks per-tool failure patterns within a single toolloop Run.
+type toolErrorTracker struct {
+	config  *ToolCircuitBreakerConfig
+	counts  map[string]int    // full fingerprint → consecutive failure count
+	lastErr map[string]string // callKey → last error message (for synthetic response)
+	tripped map[string]bool   // callKeys that have tripped
+	logger  *logx.Logger
+}
+
+func newToolErrorTracker(cfg *ToolCircuitBreakerConfig, logger *logx.Logger) *toolErrorTracker {
+	threshold := cfg.MaxConsecutiveFailures
+	if threshold <= 0 {
+		threshold = defaultMaxConsecutiveFailures
+	}
+	return &toolErrorTracker{
+		config:  &ToolCircuitBreakerConfig{MaxConsecutiveFailures: threshold, OnTrip: cfg.OnTrip},
+		counts:  make(map[string]int),
+		lastErr: make(map[string]string),
+		tripped: make(map[string]bool),
+		logger:  logger,
+	}
+}
+
+// callKey builds a key from tool name + hashed params that identifies "what we're
+// trying to do" independent of the error. Used for checking tripped state.
+func callKey(toolName string, params map[string]any) string {
+	return toolName + ":" + hashParams(params)
+}
+
+// fullFingerprint builds a breaker-state key from tool name, params, and error.
+// Different errors on the same call produce different fingerprints, so the counter
+// only accumulates when the same call fails the same way repeatedly.
+func fullFingerprint(toolName string, params map[string]any, errorDetail string) string {
+	return callKey(toolName, params) + ":" + firstLine(errorDetail, 100)
+}
+
+// checkTripped returns true if any fingerprint for this tool+params is tripped.
+func (t *toolErrorTracker) checkTripped(toolName string, params map[string]any) (tripped bool, lastError string) {
+	key := callKey(toolName, params)
+	if t.tripped[key] {
+		return true, t.lastErr[key]
+	}
+	return false, ""
+}
+
+// recordFailure increments the counter for this specific fingerprint (tool+params+error).
+func (t *toolErrorTracker) recordFailure(toolName string, params map[string]any, errorDetail string) {
+	fp := fullFingerprint(toolName, params, errorDetail)
+	key := callKey(toolName, params)
+	t.counts[fp]++
+	t.lastErr[key] = errorDetail
+
+	if t.counts[fp] >= t.config.MaxConsecutiveFailures && !t.tripped[key] {
+		t.tripped[key] = true
+		label := displayLabel(toolName, params)
+		t.logger.Warn("🔌 Circuit breaker tripped for %s after %d consecutive failures", label, t.counts[fp])
+		if t.config.OnTrip != nil {
+			t.config.OnTrip(toolName, label, t.counts[fp])
+		}
+	}
+}
+
+// recordSuccess resets all failure tracking for the given tool name.
+// Any successful execution means the LLM adapted — clear everything for this tool.
+func (t *toolErrorTracker) recordSuccess(toolName string) {
+	prefix := toolName + ":"
+	for k := range t.counts {
+		if strings.HasPrefix(k, prefix) {
+			delete(t.counts, k)
+		}
+	}
+	for k := range t.tripped {
+		if strings.HasPrefix(k, prefix) {
+			delete(t.tripped, k)
+		}
+	}
+	for k := range t.lastErr {
+		if strings.HasPrefix(k, prefix) {
+			delete(t.lastErr, k)
+		}
+	}
+}
+
+// hashParams produces a short hex hash of the canonicalized (sorted-key) JSON
+// representation of tool parameters. This ensures map iteration order doesn't
+// affect the fingerprint.
+func hashParams(params map[string]any) string {
+	if len(params) == 0 {
+		return "empty"
+	}
+	// Sort keys for deterministic ordering
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Build canonical representation
+	ordered := make([]any, 0, len(keys)*2)
+	for _, k := range keys {
+		ordered = append(ordered, k, params[k])
+	}
+	b, err := json.Marshal(ordered)
+	if err != nil {
+		return "unhashable"
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:8]) // 16 hex chars
+}
+
+// displayLabel builds a human-readable label for logging, using the first
+// significant parameter (cmd, command, path) if present.
+func displayLabel(toolName string, params map[string]any) string {
+	for _, key := range []string{"cmd", "command", "path"} {
+		if val, ok := params[key]; ok {
+			return fmt.Sprintf("%s(%s=%v)", toolName, key, val)
+		}
+	}
+	return toolName
+}
+
+// firstLine returns the first line of s, truncated to maxLen characters.
+func firstLine(s string, maxLen int) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		s = s[:idx]
+	}
+	if len(s) > maxLen {
+		s = s[:maxLen]
+	}
+	return s
+}

--- a/pkg/agent/toolloop/circuit_test.go
+++ b/pkg/agent/toolloop/circuit_test.go
@@ -1,0 +1,286 @@
+package toolloop
+
+import (
+	"fmt"
+	"testing"
+
+	"orchestrator/pkg/logx"
+	"orchestrator/pkg/tools"
+)
+
+func testLogger() *logx.Logger {
+	return logx.NewLogger("circuit-test")
+}
+
+func TestClassifyToolResult_GoError(t *testing.T) {
+	isFailure, detail := classifyToolResult(nil, fmt.Errorf("connection refused"))
+	if !isFailure {
+		t.Error("Expected Go error to be classified as failure")
+	}
+	if detail != "connection refused" {
+		t.Errorf("Expected error detail 'connection refused', got %q", detail)
+	}
+}
+
+func TestClassifyToolResult_SuccessFalse(t *testing.T) {
+	result := &tools.ExecResult{Content: `{"success": false, "error": "old_string not found"}`}
+	isFailure, detail := classifyToolResult(result, nil)
+	if !isFailure {
+		t.Error("Expected success:false to be classified as failure")
+	}
+	if detail != "old_string not found" {
+		t.Errorf("Expected error detail from JSON, got %q", detail)
+	}
+}
+
+func TestClassifyToolResult_SuccessFalseNoError(t *testing.T) {
+	result := &tools.ExecResult{Content: `{"success": false}`}
+	isFailure, detail := classifyToolResult(result, nil)
+	if !isFailure {
+		t.Error("Expected success:false to be classified as failure")
+	}
+	if detail != "success: false" {
+		t.Errorf("Expected 'success: false', got %q", detail)
+	}
+}
+
+func TestClassifyToolResult_NonZeroExitCode(t *testing.T) {
+	result := &tools.ExecResult{Content: `{"exit_code": 1, "stderr": "make: *** [test] Error 1", "stdout": ""}`}
+	isFailure, detail := classifyToolResult(result, nil)
+	if !isFailure {
+		t.Error("Expected non-zero exit code to be classified as failure")
+	}
+	if detail != "make: *** [test] Error 1" {
+		t.Errorf("Expected stderr as detail, got %q", detail)
+	}
+}
+
+func TestClassifyToolResult_NonZeroExitCodeNoStderr(t *testing.T) {
+	result := &tools.ExecResult{Content: `{"exit_code": 127, "stderr": "", "stdout": ""}`}
+	isFailure, detail := classifyToolResult(result, nil)
+	if !isFailure {
+		t.Error("Expected non-zero exit code to be classified as failure")
+	}
+	if detail != "exit_code: 127" {
+		t.Errorf("Expected 'exit_code: 127', got %q", detail)
+	}
+}
+
+func TestClassifyToolResult_SuccessTrue(t *testing.T) {
+	result := &tools.ExecResult{Content: `{"success": true, "output": "built ok"}`}
+	isFailure, _ := classifyToolResult(result, nil)
+	if isFailure {
+		t.Error("Expected success:true to NOT be classified as failure")
+	}
+}
+
+func TestClassifyToolResult_ZeroExitCode(t *testing.T) {
+	result := &tools.ExecResult{Content: `{"exit_code": 0, "stdout": "all tests passed"}`}
+	isFailure, _ := classifyToolResult(result, nil)
+	if isFailure {
+		t.Error("Expected exit_code:0 to NOT be classified as failure")
+	}
+}
+
+func TestClassifyToolResult_PlainContent(t *testing.T) {
+	result := &tools.ExecResult{Content: "File written successfully"}
+	isFailure, _ := classifyToolResult(result, nil)
+	if isFailure {
+		t.Error("Expected plain text content to NOT be classified as failure")
+	}
+}
+
+func TestClassifyToolResult_NilResult(t *testing.T) {
+	isFailure, _ := classifyToolResult(nil, nil)
+	if isFailure {
+		t.Error("Expected nil result with nil error to NOT be classified as failure")
+	}
+}
+
+func TestCallFingerprint(t *testing.T) {
+	// Same tool, different params should produce different keys
+	key1 := callKey("file_edit", map[string]any{"path": "main.go", "old_string": "foo"})
+	key2 := callKey("file_edit", map[string]any{"path": "main.go", "old_string": "bar"})
+	if key1 == key2 {
+		t.Error("Different params should produce different call keys")
+	}
+
+	// Same params in different order should produce same key (sorted)
+	key3 := callKey("shell", map[string]any{"a": "1", "b": "2"})
+	key4 := callKey("shell", map[string]any{"b": "2", "a": "1"})
+	if key3 != key4 {
+		t.Error("Same params in different order should produce same key")
+	}
+
+	// Empty params
+	key5 := callKey("tool", nil)
+	key6 := callKey("tool", map[string]any{})
+	if key5 != key6 {
+		t.Error("Nil and empty params should produce same key")
+	}
+}
+
+func TestFullFingerprint_DifferentErrors(t *testing.T) {
+	params := map[string]any{"path": "main.go"}
+	fp1 := fullFingerprint("file_edit", params, "old_string not found")
+	fp2 := fullFingerprint("file_edit", params, "file not found")
+	if fp1 == fp2 {
+		t.Error("Different errors should produce different fingerprints")
+	}
+}
+
+func TestRecordFailureTrips(t *testing.T) {
+	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{MaxConsecutiveFailures: 3}, testLogger())
+	params := map[string]any{"command": "make test"}
+
+	// First two failures: not tripped
+	tracker.recordFailure("shell", params, "exit_code: 1")
+	tracker.recordFailure("shell", params, "exit_code: 1")
+	tripped, _ := tracker.checkTripped("shell", params)
+	if tripped {
+		t.Error("Should not be tripped after 2 failures")
+	}
+
+	// Third failure: trips
+	tracker.recordFailure("shell", params, "exit_code: 1")
+	tripped, lastErr := tracker.checkTripped("shell", params)
+	if !tripped {
+		t.Error("Should be tripped after 3 failures")
+	}
+	if lastErr != "exit_code: 1" {
+		t.Errorf("Expected last error 'exit_code: 1', got %q", lastErr)
+	}
+}
+
+func TestSuccessResetsAllFingerprintsForTool(t *testing.T) {
+	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{MaxConsecutiveFailures: 3}, testLogger())
+	params := map[string]any{"command": "make test"}
+
+	// Two failures
+	tracker.recordFailure("shell", params, "exit_code: 1")
+	tracker.recordFailure("shell", params, "exit_code: 1")
+
+	// Success resets
+	tracker.recordSuccess("shell")
+
+	// Two more failures: should not trip (counter was reset)
+	tracker.recordFailure("shell", params, "exit_code: 1")
+	tracker.recordFailure("shell", params, "exit_code: 1")
+	tripped, _ := tracker.checkTripped("shell", params)
+	if tripped {
+		t.Error("Should not be tripped: success should have reset the counter")
+	}
+}
+
+func TestDifferentToolsDontInterfere(t *testing.T) {
+	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{MaxConsecutiveFailures: 2}, testLogger())
+
+	// Trip tool A
+	tracker.recordFailure("file_edit", map[string]any{"path": "a.go"}, "not found")
+	tracker.recordFailure("file_edit", map[string]any{"path": "a.go"}, "not found")
+	trippedA, _ := tracker.checkTripped("file_edit", map[string]any{"path": "a.go"})
+	if !trippedA {
+		t.Error("file_edit should be tripped")
+	}
+
+	// Tool B should not be tripped
+	trippedB, _ := tracker.checkTripped("shell", map[string]any{"command": "ls"})
+	if trippedB {
+		t.Error("shell should NOT be tripped")
+	}
+}
+
+func TestChangedErrorResetsCounting(t *testing.T) {
+	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{MaxConsecutiveFailures: 3}, testLogger())
+	params := map[string]any{"command": "make test"}
+
+	// Two failures with error A
+	tracker.recordFailure("shell", params, "compilation error on line 42")
+	tracker.recordFailure("shell", params, "compilation error on line 42")
+
+	// One failure with error B (different fingerprint, counter is separate)
+	tracker.recordFailure("shell", params, "test failure in TestFoo")
+
+	// Neither should be tripped (2 of A, 1 of B)
+	tripped, _ := tracker.checkTripped("shell", params)
+	if tripped {
+		t.Error("Should not be tripped: errors changed, so no fingerprint hit threshold")
+	}
+}
+
+func TestDefaultThreshold(t *testing.T) {
+	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{}, testLogger())
+	params := map[string]any{"command": "test"}
+
+	// Default is 3
+	tracker.recordFailure("tool", params, "err")
+	tracker.recordFailure("tool", params, "err")
+	tripped, _ := tracker.checkTripped("tool", params)
+	if tripped {
+		t.Error("Should not trip at 2 with default threshold of 3")
+	}
+
+	tracker.recordFailure("tool", params, "err")
+	tripped, _ = tracker.checkTripped("tool", params)
+	if !tripped {
+		t.Error("Should trip at 3 with default threshold")
+	}
+}
+
+func TestOnTripCallback(t *testing.T) {
+	var tripCalled bool
+	var tripLabel string
+	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{
+		MaxConsecutiveFailures: 2,
+		OnTrip: func(_, label string, _ int) {
+			tripCalled = true
+			tripLabel = label
+		},
+	}, testLogger())
+
+	params := map[string]any{"command": "make build"}
+	tracker.recordFailure("shell", params, "err")
+	tracker.recordFailure("shell", params, "err")
+
+	if !tripCalled {
+		t.Error("OnTrip callback should have been called")
+	}
+	if tripLabel != "shell(command=make build)" {
+		t.Errorf("Expected label 'shell(command=make build)', got %q", tripLabel)
+	}
+}
+
+func TestDisplayLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		params   map[string]any
+		expected string
+	}{
+		{"no params", "build", nil, "build"},
+		{"with cmd", "shell", map[string]any{"cmd": "ls -la"}, "shell(cmd=ls -la)"},
+		{"with command", "shell", map[string]any{"command": "make test"}, "shell(command=make test)"},
+		{"with path", "file_edit", map[string]any{"path": "main.go", "old_string": "foo"}, "file_edit(path=main.go)"},
+		{"cmd takes priority", "shell", map[string]any{"cmd": "ls", "command": "ls"}, "shell(cmd=ls)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := displayLabel(tt.toolName, tt.params)
+			if result != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	if firstLine("hello\nworld", 100) != "hello" {
+		t.Error("Should return first line")
+	}
+	if firstLine("short", 3) != "sho" {
+		t.Error("Should truncate to maxLen")
+	}
+	if firstLine("no newline", 100) != "no newline" {
+		t.Error("Should return full string when no newline")
+	}
+}

--- a/pkg/agent/toolloop/circuit_test.go
+++ b/pkg/agent/toolloop/circuit_test.go
@@ -44,25 +44,25 @@ func TestClassifyToolResult_SuccessFalseNoError(t *testing.T) {
 	}
 }
 
-func TestClassifyToolResult_NonZeroExitCode(t *testing.T) {
+func TestClassifyToolResult_NonZeroExitCodeAlone(t *testing.T) {
+	// Non-zero exit_code WITHOUT success:false is NOT a failure.
+	// Shell tool explicitly returns non-zero as data (grep, test -f, git diff --quiet).
 	result := &tools.ExecResult{Content: `{"exit_code": 1, "stderr": "make: *** [test] Error 1", "stdout": ""}`}
-	isFailure, detail := classifyToolResult(result, nil)
-	if !isFailure {
-		t.Error("Expected non-zero exit code to be classified as failure")
-	}
-	if detail != "make: *** [test] Error 1" {
-		t.Errorf("Expected stderr as detail, got %q", detail)
+	isFailure, _ := classifyToolResult(result, nil)
+	if isFailure {
+		t.Error("Expected non-zero exit_code alone to NOT be classified as failure")
 	}
 }
 
-func TestClassifyToolResult_NonZeroExitCodeNoStderr(t *testing.T) {
-	result := &tools.ExecResult{Content: `{"exit_code": 127, "stderr": "", "stdout": ""}`}
+func TestClassifyToolResult_SuccessFalseWithExitCode(t *testing.T) {
+	// success:false WITH exit_code is a failure (caught by the success check).
+	result := &tools.ExecResult{Content: `{"success": false, "exit_code": 1, "error": "build failed"}`}
 	isFailure, detail := classifyToolResult(result, nil)
 	if !isFailure {
-		t.Error("Expected non-zero exit code to be classified as failure")
+		t.Error("Expected success:false with exit_code to be classified as failure")
 	}
-	if detail != "exit_code: 127" {
-		t.Errorf("Expected 'exit_code: 127', got %q", detail)
+	if detail != "build failed" {
+		t.Errorf("Expected 'build failed', got %q", detail)
 	}
 }
 
@@ -152,23 +152,43 @@ func TestRecordFailureTrips(t *testing.T) {
 	}
 }
 
-func TestSuccessResetsAllFingerprintsForTool(t *testing.T) {
+func TestSuccessResetsCounterForSameCall(t *testing.T) {
 	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{MaxConsecutiveFailures: 3}, testLogger())
 	params := map[string]any{"command": "make test"}
 
 	// Two failures
-	tracker.recordFailure("shell", params, "exit_code: 1")
-	tracker.recordFailure("shell", params, "exit_code: 1")
+	tracker.recordFailure("shell", params, "build error")
+	tracker.recordFailure("shell", params, "build error")
 
-	// Success resets
-	tracker.recordSuccess("shell")
+	// Success on same call resets
+	tracker.recordSuccess("shell", params)
 
 	// Two more failures: should not trip (counter was reset)
-	tracker.recordFailure("shell", params, "exit_code: 1")
-	tracker.recordFailure("shell", params, "exit_code: 1")
+	tracker.recordFailure("shell", params, "build error")
+	tracker.recordFailure("shell", params, "build error")
 	tripped, _ := tracker.checkTripped("shell", params)
 	if tripped {
 		t.Error("Should not be tripped: success should have reset the counter")
+	}
+}
+
+func TestSuccessOnDifferentParamsDoesNotReset(t *testing.T) {
+	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{MaxConsecutiveFailures: 3}, testLogger())
+	failParams := map[string]any{"command": "make test"}
+	okParams := map[string]any{"command": "pwd"}
+
+	// Two failures on make test
+	tracker.recordFailure("shell", failParams, "build error")
+	tracker.recordFailure("shell", failParams, "build error")
+
+	// Success on pwd should NOT reset make test's counter
+	tracker.recordSuccess("shell", okParams)
+
+	// Third failure on make test should trip
+	tracker.recordFailure("shell", failParams, "build error")
+	tripped, _ := tracker.checkTripped("shell", failParams)
+	if !tripped {
+		t.Error("Should be tripped: success on different params should not reset this counter")
 	}
 }
 
@@ -205,6 +225,22 @@ func TestChangedErrorResetsCounting(t *testing.T) {
 	tripped, _ := tracker.checkTripped("shell", params)
 	if tripped {
 		t.Error("Should not be tripped: errors changed, so no fingerprint hit threshold")
+	}
+}
+
+func TestInterleavedErrorsDoNotAccumulate(t *testing.T) {
+	// A,A,B,A should NOT trip A at 3. The B resets A's consecutive count.
+	tracker := newToolErrorTracker(&ToolCircuitBreakerConfig{MaxConsecutiveFailures: 3}, testLogger())
+	params := map[string]any{"command": "make test"}
+
+	tracker.recordFailure("shell", params, "error A") // A=1
+	tracker.recordFailure("shell", params, "error A") // A=2
+	tracker.recordFailure("shell", params, "error B") // B=1, clears A
+	tracker.recordFailure("shell", params, "error A") // A=1 (reset)
+
+	tripped, _ := tracker.checkTripped("shell", params)
+	if tripped {
+		t.Error("Should NOT be tripped: A,A,B,A has only 1 consecutive A at the end")
 	}
 }
 

--- a/pkg/agent/toolloop/toolloop.go
+++ b/pkg/agent/toolloop/toolloop.go
@@ -4,6 +4,7 @@ package toolloop
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -439,6 +440,10 @@ func Run[T any](tl *ToolLoop, ctx context.Context, cfg *Config[T]) Outcome[T] {
 				if tracker != nil {
 					tracker.recordFailure(toolCall.Name, toolCall.Parameters, err.Error())
 				}
+				// Log provider lookup failure to persistence
+				if cfg.PersistenceChannel != nil {
+					agent.LogToolExecution(toolCall, err.Error(), err, 0, cfg.AgentID, cfg.StoryID, cfg.PersistenceChannel)
+				}
 				continue
 			}
 
@@ -452,7 +457,7 @@ func Run[T any](tl *ToolLoop, ctx context.Context, cfg *Config[T]) Outcome[T] {
 			execResult, execErr := tool.Exec(toolCtx, toolCall.Parameters)
 			duration := time.Since(start)
 
-			// Classify result: Go errors AND semantic failures (JSON success:false, exit_code!=0)
+			// Classify result: Go errors AND semantic failures (JSON success:false)
 			isFailure, errorDetail := classifyToolResult(execResult, execErr)
 
 			var content string
@@ -491,16 +496,25 @@ func Run[T any](tl *ToolLoop, ctx context.Context, cfg *Config[T]) Outcome[T] {
 				}
 
 				if tracker != nil {
-					tracker.recordSuccess(toolCall.Name)
+					tracker.recordSuccess(toolCall.Name, toolCall.Parameters)
 				}
 			}
 
 			// Add tool result to context
 			cfg.ContextManager.AddToolResult(toolCall.ID, content, isError)
 
-			// Log tool execution to database if persistence channel is configured
+			// Log tool execution to database if persistence channel is configured.
+			// For semantic failures (execErr == nil but classified as failure),
+			// pass the parsed JSON map so LogToolExecution can extract success/error fields.
 			if cfg.PersistenceChannel != nil {
-				agent.LogToolExecution(toolCall, content, execErr, duration, cfg.AgentID, cfg.StoryID, cfg.PersistenceChannel)
+				var logResult any = content
+				if isFailure && execErr == nil {
+					var parsed map[string]any
+					if json.Unmarshal([]byte(content), &parsed) == nil {
+						logResult = parsed
+					}
+				}
+				agent.LogToolExecution(toolCall, logResult, execErr, duration, cfg.AgentID, cfg.StoryID, cfg.PersistenceChannel)
 			}
 		}
 

--- a/pkg/agent/toolloop/toolloop.go
+++ b/pkg/agent/toolloop/toolloop.go
@@ -115,6 +115,12 @@ type Config[T any] struct {
 	// When provided, enables soft/hard limit tracking with callbacks
 	Escalation *EscalationConfig
 
+	// ToolCircuitBreaker prevents endless retries when the same tool fails repeatedly
+	// with the same error pattern. When a (tool, params, error) fingerprint hits the
+	// threshold, execution is skipped and a synthetic error guides the LLM to try
+	// a different approach. Optional — nil disables the breaker.
+	ToolCircuitBreaker *ToolCircuitBreakerConfig
+
 	// Maximum tool call iterations
 	MaxIterations int
 
@@ -233,6 +239,12 @@ func Run[T any](tl *ToolLoop, ctx context.Context, cfg *Config[T]) Outcome[T] {
 
 	// Track consecutive turns without tool use
 	consecutiveNoToolTurns := 0
+
+	// Initialize per-tool circuit breaker if configured
+	var tracker *toolErrorTracker
+	if cfg.ToolCircuitBreaker != nil {
+		tracker = newToolErrorTracker(cfg.ToolCircuitBreaker, tl.logger)
+	}
 
 	// Main iteration loop
 	for iteration := 0; iteration < cfg.MaxIterations; iteration++ {
@@ -400,12 +412,33 @@ func Run[T any](tl *ToolLoop, ctx context.Context, cfg *Config[T]) Outcome[T] {
 			toolCall := &resp.ToolCalls[i]
 			tl.logger.Info("Executing tool: %s", toolCall.Name)
 
+			// Circuit breaker: skip execution if this tool+params pattern is tripped
+			if tracker != nil {
+				if tripped, lastError := tracker.checkTripped(toolCall.Name, toolCall.Parameters); tripped {
+					label := displayLabel(toolCall.Name, toolCall.Parameters)
+					tl.logger.Warn("🔌 Circuit breaker: skipping %s (tripped)", label)
+					skipContent := fmt.Sprintf(
+						"⚠️ Tool circuit breaker: '%s' has failed %d consecutive times with the same error.\n"+
+							"Execution skipped. Try a different approach or tool.\nLast error: %s",
+						label, tracker.config.MaxConsecutiveFailures, lastError)
+					cfg.ContextManager.AddToolResult(toolCall.ID, skipContent, true)
+					failedTools[toolCall.Name] = true // Terminal tool guard
+					if cfg.PersistenceChannel != nil {
+						agent.LogToolExecution(toolCall, skipContent, fmt.Errorf("circuit breaker: skipped"), 0, cfg.AgentID, cfg.StoryID, cfg.PersistenceChannel)
+					}
+					continue
+				}
+			}
+
 			// Get tool from provider
 			tool, err := toolProvider.Get(toolCall.Name)
 			if err != nil {
 				tl.logger.Error("Failed to get tool %s: %v", toolCall.Name, err)
-				// Add error result to context
 				cfg.ContextManager.AddToolResult(toolCall.ID, err.Error(), true)
+				// Track provider lookup failures in breaker
+				if tracker != nil {
+					tracker.recordFailure(toolCall.Name, toolCall.Parameters, err.Error())
+				}
 				continue
 			}
 
@@ -416,25 +449,35 @@ func Run[T any](tl *ToolLoop, ctx context.Context, cfg *Config[T]) Outcome[T] {
 			}
 
 			start := time.Now()
-			execResult, err := tool.Exec(toolCtx, toolCall.Parameters)
+			execResult, execErr := tool.Exec(toolCtx, toolCall.Parameters)
 			duration := time.Since(start)
 
-			// Generate tool result content for LLM context
+			// Classify result: Go errors AND semantic failures (JSON success:false, exit_code!=0)
+			isFailure, errorDetail := classifyToolResult(execResult, execErr)
+
 			var content string
 			var isError bool
-			if err != nil {
-				tl.logger.Error("Tool %s failed after %.3fs: %v", toolCall.Name, duration.Seconds(), err)
-				content = fmt.Sprintf("Tool failed: %v", err)
+			if isFailure {
+				tl.logger.Error("Tool %s failed after %.3fs: %s", toolCall.Name, duration.Seconds(), errorDetail)
+				if execErr != nil {
+					content = fmt.Sprintf("Tool failed: %v", execErr)
+				} else {
+					// Semantic failure: keep structured JSON content for the LLM
+					content = execResult.Content
+				}
 				isError = true
 				failedTools[toolCall.Name] = true
 				if toolCall.Name == terminalToolName {
-					terminalToolErr = err
+					terminalToolErr = execErr // May be nil for semantic failures
+				}
+				if tracker != nil {
+					tracker.recordFailure(toolCall.Name, toolCall.Parameters, errorDetail)
 				}
 			} else {
 				tl.logger.Info("Tool %s completed in %.3fs", toolCall.Name, duration.Seconds())
 
 				// Use provided content or generate simple acknowledgment
-				if execResult.Content != "" {
+				if execResult != nil && execResult.Content != "" {
 					content = execResult.Content
 				} else {
 					content = "Tool executed successfully"
@@ -442,9 +485,13 @@ func Run[T any](tl *ToolLoop, ctx context.Context, cfg *Config[T]) Outcome[T] {
 				isError = false
 
 				// Check if this tool wants to exit the loop for async effect processing
-				if execResult.ProcessEffect != nil && execResult.ProcessEffect.Signal != "" {
+				if execResult != nil && execResult.ProcessEffect != nil && execResult.ProcessEffect.Signal != "" {
 					tl.logger.Info("🔔 Tool %s returned ProcessEffect with signal: %s", toolCall.Name, execResult.ProcessEffect.Signal)
 					pendingEffect = execResult.ProcessEffect
+				}
+
+				if tracker != nil {
+					tracker.recordSuccess(toolCall.Name)
 				}
 			}
 
@@ -453,7 +500,7 @@ func Run[T any](tl *ToolLoop, ctx context.Context, cfg *Config[T]) Outcome[T] {
 
 			// Log tool execution to database if persistence channel is configured
 			if cfg.PersistenceChannel != nil {
-				agent.LogToolExecution(toolCall, content, err, duration, cfg.AgentID, cfg.StoryID, cfg.PersistenceChannel)
+				agent.LogToolExecution(toolCall, content, execErr, duration, cfg.AgentID, cfg.StoryID, cfg.PersistenceChannel)
 			}
 		}
 

--- a/pkg/agent/toolloop/toolloop_test.go
+++ b/pkg/agent/toolloop/toolloop_test.go
@@ -827,3 +827,295 @@ func TestTerminalToolFailureContinuesLoop(t *testing.T) {
 		t.Errorf("expected terminal tool to be called 2 times, got %d", callCount)
 	}
 }
+
+// TestToolCircuitBreakerSkipsExecution verifies that a tool is skipped after
+// hitting the consecutive failure threshold.
+func TestToolCircuitBreakerSkipsExecution(t *testing.T) {
+	ctx := context.Background()
+	cm := contextmgr.NewContextManager()
+	logger := logx.NewLogger("test")
+
+	execCount := 0
+	failingTool := &mockGeneralTool{
+		name: "shell",
+		execFunc: func(_ context.Context, _ map[string]any) (*tools.ExecResult, error) {
+			execCount++
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+
+	// LLM calls "shell" 5 times across 5 iterations, same params each time.
+	// 6th response: LLM calls terminal tool (adapted).
+	var responses []agent.CompletionResponse
+	for i := range 5 {
+		responses = append(responses, agent.CompletionResponse{
+			Content: "Trying shell",
+			ToolCalls: []agent.ToolCall{
+				{ID: fmt.Sprintf("call%d", i), Name: "shell", Parameters: map[string]any{"command": "make test"}},
+			},
+		})
+	}
+	responses = append(responses, agent.CompletionResponse{
+		Content: "Done",
+		ToolCalls: []agent.ToolCall{
+			{ID: "callfinal", Name: "submit", Parameters: map[string]any{}},
+		},
+	})
+
+	llmClient := &mockLLMClient{responses: responses}
+	terminalTool := &mockTerminalTool{
+		name: "submit",
+		execFunc: func(_ context.Context, _ map[string]any) (*tools.ExecResult, error) {
+			return &tools.ExecResult{
+				Content:       "done",
+				ProcessEffect: &tools.ProcessEffect{Signal: "DONE", Data: map[string]any{}},
+			}, nil
+		},
+	}
+
+	loop := toolloop.New(llmClient, logger)
+	cfg := &toolloop.Config[string]{
+		ContextManager: cm,
+		GeneralTools:   []tools.Tool{failingTool},
+		TerminalTool:   terminalTool,
+		MaxIterations:  10,
+		MaxTokens:      1000,
+		ToolCircuitBreaker: &toolloop.ToolCircuitBreakerConfig{
+			MaxConsecutiveFailures: 3,
+		},
+	}
+
+	out := toolloop.Run(loop, ctx, cfg)
+	if out.Kind != toolloop.OutcomeProcessEffect {
+		t.Fatalf("Expected ProcessEffect outcome, got %s (err: %v)", out.Kind, out.Err)
+	}
+
+	// Tool should have been executed only 3 times (threshold), not 5
+	if execCount != 3 {
+		t.Errorf("Expected tool to be executed 3 times (threshold), got %d", execCount)
+	}
+}
+
+// TestToolCircuitBreakerSemanticFailure verifies that semantic failures (success:false)
+// are detected and trip the breaker even when err == nil.
+func TestToolCircuitBreakerSemanticFailure(t *testing.T) {
+	ctx := context.Background()
+	cm := contextmgr.NewContextManager()
+	logger := logx.NewLogger("test")
+
+	execCount := 0
+	semanticFailTool := &mockGeneralTool{
+		name: "file_edit",
+		execFunc: func(_ context.Context, _ map[string]any) (*tools.ExecResult, error) {
+			execCount++
+			// Returns err == nil but success: false in content
+			return &tools.ExecResult{Content: `{"success": false, "error": "old_string not found"}`}, nil
+		},
+	}
+
+	var responses []agent.CompletionResponse
+	for i := range 4 {
+		responses = append(responses, agent.CompletionResponse{
+			Content: "Editing file",
+			ToolCalls: []agent.ToolCall{
+				{ID: fmt.Sprintf("call%d", i), Name: "file_edit", Parameters: map[string]any{"path": "main.go", "old_string": "foo"}},
+			},
+		})
+	}
+	responses = append(responses, agent.CompletionResponse{
+		Content: "Done",
+		ToolCalls: []agent.ToolCall{
+			{ID: "callfinal", Name: "submit", Parameters: map[string]any{}},
+		},
+	})
+
+	llmClient := &mockLLMClient{responses: responses}
+	terminalTool := &mockTerminalTool{
+		name: "submit",
+		execFunc: func(_ context.Context, _ map[string]any) (*tools.ExecResult, error) {
+			return &tools.ExecResult{
+				Content:       "done",
+				ProcessEffect: &tools.ProcessEffect{Signal: "DONE", Data: map[string]any{}},
+			}, nil
+		},
+	}
+
+	loop := toolloop.New(llmClient, logger)
+	cfg := &toolloop.Config[string]{
+		ContextManager: cm,
+		GeneralTools:   []tools.Tool{semanticFailTool},
+		TerminalTool:   terminalTool,
+		MaxIterations:  10,
+		MaxTokens:      1000,
+		ToolCircuitBreaker: &toolloop.ToolCircuitBreakerConfig{
+			MaxConsecutiveFailures: 3,
+		},
+	}
+
+	out := toolloop.Run(loop, ctx, cfg)
+	if out.Kind != toolloop.OutcomeProcessEffect {
+		t.Fatalf("Expected ProcessEffect outcome, got %s (err: %v)", out.Kind, out.Err)
+	}
+
+	// Semantic failures should trip: only 3 executions, 4th skipped
+	if execCount != 3 {
+		t.Errorf("Expected 3 executions (semantic failure trips at 3), got %d", execCount)
+	}
+}
+
+// TestToolCircuitBreakerTerminalToolGuard verifies that a tripped terminal tool
+// is marked as failed and does NOT auto-wrap as success.
+func TestToolCircuitBreakerTerminalToolGuard(t *testing.T) {
+	ctx := context.Background()
+	cm := contextmgr.NewContextManager()
+	logger := logx.NewLogger("test")
+
+	execCount := 0
+	// Terminal tool that always fails
+	terminalTool := &mockTerminalTool{
+		name: "submit",
+		execFunc: func(_ context.Context, _ map[string]any) (*tools.ExecResult, error) {
+			execCount++
+			return nil, fmt.Errorf("submit failed")
+		},
+	}
+
+	// LLM calls terminal tool 4 times (trips at 3, skipped at 4)
+	responses := make([]agent.CompletionResponse, 4)
+	for i := range responses {
+		responses[i] = agent.CompletionResponse{
+			Content: "Submitting",
+			ToolCalls: []agent.ToolCall{
+				{ID: fmt.Sprintf("call%d", i), Name: "submit", Parameters: map[string]any{}},
+			},
+		}
+	}
+
+	llmClient := &mockLLMClient{responses: responses}
+	loop := toolloop.New(llmClient, logger)
+	cfg := &toolloop.Config[string]{
+		ContextManager: cm,
+		GeneralTools:   []tools.Tool{},
+		TerminalTool:   terminalTool,
+		MaxIterations:  10,
+		MaxTokens:      1000,
+		ToolCircuitBreaker: &toolloop.ToolCircuitBreakerConfig{
+			MaxConsecutiveFailures: 3,
+		},
+	}
+
+	out := toolloop.Run(loop, ctx, cfg)
+
+	// Should NOT be OutcomeProcessEffect (auto-wrap) — terminal tool was failed/skipped
+	if out.Kind == toolloop.OutcomeProcessEffect && out.Signal == "TERMINAL_COMPLETE" {
+		t.Error("Tripped terminal tool should NOT auto-wrap as TERMINAL_COMPLETE")
+	}
+
+	// Terminal tool should have been executed only 3 times
+	if execCount != 3 {
+		t.Errorf("Expected terminal tool executed 3 times, got %d", execCount)
+	}
+}
+
+// TestToolCircuitBreakerChangedError verifies that changing errors don't accumulate
+// toward the same trip threshold.
+func TestToolCircuitBreakerChangedError(t *testing.T) {
+	ctx := context.Background()
+	cm := contextmgr.NewContextManager()
+	logger := logx.NewLogger("test")
+
+	callNum := 0
+	changingErrorTool := &mockGeneralTool{
+		name: "shell",
+		execFunc: func(_ context.Context, _ map[string]any) (*tools.ExecResult, error) {
+			callNum++
+			// Each call returns a different error
+			return nil, fmt.Errorf("error variant %d", callNum)
+		},
+	}
+
+	// 5 calls with different errors each time
+	responses := make([]agent.CompletionResponse, 5)
+	for i := range responses {
+		responses[i] = agent.CompletionResponse{
+			Content: "Trying",
+			ToolCalls: []agent.ToolCall{
+				{ID: fmt.Sprintf("call%d", i), Name: "shell", Parameters: map[string]any{"command": "test"}},
+			},
+		}
+	}
+
+	llmClient := &mockLLMClient{responses: responses}
+	terminalTool := &mockTerminalTool{name: "submit"}
+
+	loop := toolloop.New(llmClient, logger)
+	cfg := &toolloop.Config[string]{
+		ContextManager: cm,
+		GeneralTools:   []tools.Tool{changingErrorTool},
+		TerminalTool:   terminalTool,
+		MaxIterations:  5,
+		MaxTokens:      1000,
+		ToolCircuitBreaker: &toolloop.ToolCircuitBreakerConfig{
+			MaxConsecutiveFailures: 3,
+		},
+	}
+
+	toolloop.Run(loop, ctx, cfg)
+
+	// All 5 calls should have executed (different errors = different fingerprints)
+	if callNum != 5 {
+		t.Errorf("Expected all 5 calls to execute (different errors), got %d", callNum)
+	}
+}
+
+// TestToolCircuitBreakerResetOnSuccess verifies that a success resets the failure counter.
+func TestToolCircuitBreakerResetOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	cm := contextmgr.NewContextManager()
+	logger := logx.NewLogger("test")
+
+	callNum := 0
+	// Fails twice, succeeds once, fails twice more — should never trip (threshold 3)
+	intermittentTool := &mockGeneralTool{
+		name: "shell",
+		execFunc: func(_ context.Context, _ map[string]any) (*tools.ExecResult, error) {
+			callNum++
+			if callNum == 3 { // Third call succeeds
+				return &tools.ExecResult{Content: `{"exit_code": 0, "stdout": "ok"}`}, nil
+			}
+			return nil, fmt.Errorf("failed")
+		},
+	}
+
+	responses := make([]agent.CompletionResponse, 5)
+	for i := range responses {
+		responses[i] = agent.CompletionResponse{
+			Content: "Trying",
+			ToolCalls: []agent.ToolCall{
+				{ID: fmt.Sprintf("call%d", i), Name: "shell", Parameters: map[string]any{"command": "test"}},
+			},
+		}
+	}
+
+	llmClient := &mockLLMClient{responses: responses}
+	terminalTool := &mockTerminalTool{name: "submit"}
+
+	loop := toolloop.New(llmClient, logger)
+	cfg := &toolloop.Config[string]{
+		ContextManager: cm,
+		GeneralTools:   []tools.Tool{intermittentTool},
+		TerminalTool:   terminalTool,
+		MaxIterations:  5,
+		MaxTokens:      1000,
+		ToolCircuitBreaker: &toolloop.ToolCircuitBreakerConfig{
+			MaxConsecutiveFailures: 3,
+		},
+	}
+
+	toolloop.Run(loop, ctx, cfg)
+
+	// All 5 calls should have executed (success at 3 resets counter)
+	if callNum != 5 {
+		t.Errorf("Expected all 5 calls to execute (success resets counter), got %d", callNum)
+	}
+}

--- a/pkg/coder/coding.go
+++ b/pkg/coder/coding.go
@@ -209,6 +209,12 @@ func (c *Coder) executeCodingWithTemplate(ctx context.Context, sm *agent.BaseSta
 		},
 		PersistenceChannel: c.persistenceChannel,
 		StoryID:            utils.GetStateValueOr[string](sm, KeyStoryID, ""),
+		ToolCircuitBreaker: &toolloop.ToolCircuitBreakerConfig{
+			MaxConsecutiveFailures: 3,
+			OnTrip: func(_, label string, count int) {
+				c.logger.Warn("🔌 Tool circuit breaker tripped in CODING: %s (%d failures)", label, count)
+			},
+		},
 	}
 
 	out := toolloop.Run(loop, ctx, cfg)

--- a/pkg/coder/planning.go
+++ b/pkg/coder/planning.go
@@ -208,6 +208,12 @@ func (c *Coder) handlePlanning(ctx context.Context, sm *agent.BaseStateMachine) 
 		},
 		PersistenceChannel: c.persistenceChannel,
 		StoryID:            utils.GetStateValueOr[string](sm, KeyStoryID, ""),
+		ToolCircuitBreaker: &toolloop.ToolCircuitBreakerConfig{
+			MaxConsecutiveFailures: 3,
+			OnTrip: func(_, label string, count int) {
+				c.logger.Warn("🔌 Tool circuit breaker tripped in PLANNING: %s (%d failures)", label, count)
+			},
+		},
 	}
 
 	out := toolloop.Run(loop, ctx, cfg)


### PR DESCRIPTION
## Summary

- Adds a per-tool circuit breaker to the toolloop that detects repeated failures and skips execution after a configurable threshold (default: 3)
- Introduces a unified failure classifier that detects both Go errors AND semantic failures (JSON `success: false`) — fixing the `isError` flag in context for tools like `file_edit`, `read_file`, `shell`
- Uses canonicalized full-param fingerprint (sha256) with error content, so different params or different errors don't accumulate toward the same trip
- Wired in coder CODING and PLANNING states

See `docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md` for Stage 2B context.

## Key design decisions

- **Semantic failure classification**: Many tools return `err == nil` with `{"success": false}`. The classifier catches these and marks them `isError: true` in context
- **Non-zero exit_code is NOT a failure**: Shell tool explicitly returns non-zero as data (grep, test -f, git diff --quiet). Only `success: false` signals semantic failure
- **Full-param fingerprint**: SHA256 hash of sorted params distinguishes `file_edit(old_string="foo")` from `file_edit(old_string="bar")`
- **Truly consecutive**: Interleaved errors (A,A,B,A) don't trip — the B clears A's count
- **Scoped success reset**: `shell(cmd=pwd)` succeeding doesn't clear failures for `shell(cmd=make test)`
- **Terminal tool guard**: Skipped terminal tools are marked in `failedTools` to prevent auto-wrap as success
- **Persistence-aligned**: Semantic failures and breaker skips are logged as failures to DB

## Test plan

- [x] `circuit_test.go`: 21 unit tests covering classifier, fingerprinting, consecutive tracking, interleaved errors, success scope, callback
- [x] `toolloop_test.go`: 5 integration tests covering execution skip, semantic failure trips, terminal tool guard, changed-error no-trip, success-reset no-trip
- [x] `make build` passes
- [x] `make lint` passes
- [x] All existing toolloop and coder tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)