### PR TITLE
Add acceptance-criteria verification to TESTING (Stage 3A)

### DIFF
--- a/docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md
+++ b/docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md
@@ -190,7 +190,7 @@ This is the current recommended order for implementation:
 
 1. ~~Stage 1 + Stage 4A: Prompt refresh, contract cleanup, and narrow todo modernization~~ — **COMPLETE** (PR #183)
 2. ~~Stage 2A: Pre-call compaction check (practical prerequisite for Stage 3A)~~ — **COMPLETE** (PR #184)
-3. Stage 3A: Acceptance-criteria verification in `TESTING`
+3. ~~Stage 3A: Acceptance-criteria verification in `TESTING`~~ — **COMPLETE** (PR #186)
 4. ~~Stage 2B: Tool failure circuit breaker~~ — **COMPLETE** (PR #185)
 5. Stage 3B: Bounded adversarial probing in `TESTING`
 6. Revisit Stage 5 or Stage 6 only if operating evidence justifies them
@@ -327,7 +327,7 @@ Produce:
 
 ### Status
 
-`implement now`
+`complete` — PR #186
 
 ### Why this is the most important medium-complexity change
 

--- a/pkg/coder/code_review.go
+++ b/pkg/coder/code_review.go
@@ -50,6 +50,13 @@ func (c *Coder) handleCodeReview(ctx context.Context, sm *agent.BaseStateMachine
 	// Build comprehensive evidence section
 	evidence := c.buildCompletionEvidence(testsPassed, testOutput, storyType, workResult, headSHA)
 
+	// Append acceptance criteria verification evidence if available
+	if veRaw, exists := sm.GetStateValue(KeyVerificationEvidence); exists && veRaw != nil {
+		if outcome, ok := veRaw.(VerificationOutcome); ok {
+			evidence += formatVerificationEvidence(outcome)
+		}
+	}
+
 	if !workResult.HasWork {
 		// No work detected - request completion approval
 		c.logger.Info("🧑‍💻 No work detected (%s) - requesting completion approval",

--- a/pkg/coder/code_review.go
+++ b/pkg/coder/code_review.go
@@ -50,9 +50,11 @@ func (c *Coder) handleCodeReview(ctx context.Context, sm *agent.BaseStateMachine
 	// Build comprehensive evidence section
 	evidence := c.buildCompletionEvidence(testsPassed, testOutput, storyType, workResult, headSHA)
 
-	// Append acceptance criteria verification evidence if available
+	// Append acceptance criteria verification evidence if available.
+	// Uses rehydrateVerificationOutcome to handle both the direct in-memory path
+	// and the post-resume path where state persistence round-trips through map[string]any.
 	if veRaw, exists := sm.GetStateValue(KeyVerificationEvidence); exists && veRaw != nil {
-		if outcome, ok := veRaw.(VerificationOutcome); ok {
+		if outcome, ok := rehydrateVerificationOutcome(veRaw); ok {
 			evidence += formatVerificationEvidence(outcome)
 		}
 	}

--- a/pkg/coder/coder_fsm.go
+++ b/pkg/coder/coder_fsm.go
@@ -99,6 +99,7 @@ const (
 	KeyContainerSwitchTarget   = "container_switch_target" // string: target container for pending switch (Claude Code mode)
 	KeyNeedsChangesCount       = "needs_changes_count"     // int: consecutive NEEDS_CHANGES from architect (for temperature laddering)
 	KeyFailureInfo             = "failure_info"            // proto.FailureInfo: structured failure context for blocked/error propagation
+	KeyVerificationEvidence    = "verification_evidence"   // VerificationOutcome: acceptance-criteria verification result
 )
 
 // ValidateState checks if a state is valid for coder agents.

--- a/pkg/coder/testing.go
+++ b/pkg/coder/testing.go
@@ -26,6 +26,9 @@ import (
 
 // handleTesting processes the TESTING state.
 func (c *Coder) handleTesting(ctx context.Context, sm *agent.BaseStateMachine) (proto.State, bool, error) {
+	// Clear stale verification evidence from any previous TESTING run
+	sm.SetStateData(KeyVerificationEvidence, nil)
+
 	// Get workspace path for running tests
 	workspacePath, exists := sm.GetStateValue(KeyWorkspacePath)
 	if !exists || workspacePath == "" {
@@ -557,16 +560,43 @@ func (c *Coder) proceedToCodeReview() (proto.State, bool, error) {
 	return StateCodeReview, false, nil
 }
 
-// proceedToCodeReviewWithLintCheck runs loopback lint check before transitioning to code review.
-// Returns to CODING state if loopback references are found in .env or compose files.
+// proceedToCodeReviewWithLintCheck runs loopback lint check and acceptance-criteria
+// verification before transitioning to code review.
+// Returns to CODING state if loopback references or verification gaps are found.
 func (c *Coder) proceedToCodeReviewWithLintCheck(ctx context.Context, sm *agent.BaseStateMachine, workspacePath string) (proto.State, bool, error) {
-	// Run loopback lint check if .env or compose files changed in the branch
+	// Step 1: Loopback lint check (existing)
 	if lintResult := c.runLoopbackLintCheck(workspacePath); lintResult != nil {
 		c.logger.Warn("🔍 Loopback lint check found issues, returning to CODING")
 		return c.executeTestFailureAndTransition(ctx, sm, lintResult)
 	}
 
-	return c.proceedToCodeReview()
+	// Step 2: Acceptance criteria verification (LLM-driven, read-only)
+	outcome := c.runAcceptanceCriteriaVerification(ctx, sm, workspacePath)
+
+	// Always store the outcome (pass, fail, or unavailable)
+	sm.SetStateData(KeyVerificationEvidence, outcome)
+
+	// Check for graceful shutdown (context cancelled during verification)
+	if ctx.Err() != nil {
+		c.logger.Info("🛑 Graceful shutdown during verification, exiting TESTING cleanly")
+		return StateTesting, true, nil //nolint:nilerr // intentional: clean exit on shutdown, matches driver.go pattern
+	}
+
+	switch outcome.Status {
+	case VerificationFail:
+		c.logger.Info("🔍 Verification found acceptance criteria gaps, returning to CODING")
+		gapMessage := buildVerificationFailureMessage(outcome.Evidence)
+		testFailureEff := effect.NewTestFailureEffect("acceptance_criteria_fix", gapMessage)
+		return c.executeTestFailureAndTransition(ctx, sm, testFailureEff)
+
+	case VerificationPass:
+		c.logger.Info("🔍 Verification passed, proceeding to CODE_REVIEW")
+		return c.proceedToCodeReview()
+
+	default: // VerificationUnavailable
+		c.logger.Warn("🔍 Verification unavailable (%s), proceeding to CODE_REVIEW", outcome.Reason)
+		return c.proceedToCodeReview()
+	}
 }
 
 // runLoopbackLintCheck scans for localhost/loopback references in .env and compose files.

--- a/pkg/coder/verification.go
+++ b/pkg/coder/verification.go
@@ -1,0 +1,356 @@
+package coder
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"orchestrator/pkg/agent"
+	"orchestrator/pkg/agent/toolloop"
+	"orchestrator/pkg/config"
+	"orchestrator/pkg/contextmgr"
+	"orchestrator/pkg/templates"
+	"orchestrator/pkg/tools"
+	"orchestrator/pkg/utils"
+)
+
+// VerificationStatus represents the outcome of acceptance-criteria verification.
+type VerificationStatus string
+
+const (
+	// VerificationPass means all acceptance criteria were verified as met.
+	VerificationPass VerificationStatus = "pass"
+	// VerificationFail means one or more acceptance criteria failed verification.
+	VerificationFail VerificationStatus = "fail"
+	// VerificationUnavailable means verification could not complete (LLM error, timeout, etc.).
+	VerificationUnavailable VerificationStatus = "unavailable"
+)
+
+// VerificationOutcome is the result of an acceptance-criteria verification run.
+// Stored in state machine as KeyVerificationEvidence.
+type VerificationOutcome struct {
+	// Status is the overall verification result.
+	Status VerificationStatus
+	// Evidence contains structured verification data from submit_verification tool.
+	// nil when Status is VerificationUnavailable.
+	Evidence map[string]any
+	// Reason explains why verification is unavailable (empty for pass/fail).
+	Reason string
+}
+
+const (
+	maxVerificationIterations = 5
+	verificationTemperature   = 0.2
+	maxFailureMessageLen      = 1500
+
+	// Criterion result values used in evidence processing.
+	criterionResultFail    = "fail"
+	criterionResultPartial = "partial"
+)
+
+// runAcceptanceCriteriaVerification runs a bounded, fresh-context LLM loop to verify
+// that the implementation satisfies the story's acceptance criteria.
+//
+// The loop is read-only (shell only, network disabled) and produces structured evidence.
+// Returns VerificationOutcome with explicit pass/fail/unavailable status.
+func (c *Coder) runAcceptanceCriteriaVerification(
+	ctx context.Context,
+	sm *agent.BaseStateMachine,
+	_ string, // workspacePath — unused, shell tool uses executor's workdir
+) VerificationOutcome {
+	c.logger.Info("🔍 Starting acceptance-criteria verification")
+
+	// Gather context from state machine
+	taskContent := utils.GetStateValueOr[string](sm, string(stateDataKeyTaskContent), "")
+	plan := utils.GetStateValueOr[string](sm, KeyPlan, "")
+	testOutput := utils.GetStateValueOr[string](sm, KeyTestOutput, "")
+	storyID := utils.GetStateValueOr[string](sm, KeyStoryID, "")
+
+	if taskContent == "" {
+		c.logger.Warn("🔍 No task content available for verification, skipping")
+		return VerificationOutcome{
+			Status: VerificationUnavailable,
+			Reason: "no task content available",
+		}
+	}
+
+	// Create fresh context manager (isolated from coder's main context)
+	verificationCM := contextmgr.NewContextManager()
+
+	// Build template data
+	templateData := &templates.TemplateData{
+		TaskContent: taskContent,
+		Plan:        plan,
+		TestResults: truncateOutput(testOutput),
+	}
+
+	// Render verification template with user instructions (includes MAESTRO.md)
+	if c.renderer == nil {
+		c.logger.Warn("🔍 Template renderer not available, skipping verification")
+		return VerificationOutcome{
+			Status: VerificationUnavailable,
+			Reason: "template renderer not available",
+		}
+	}
+
+	prompt, err := c.renderer.RenderWithUserInstructions(
+		templates.TestingVerificationTemplate, templateData, c.workDir, "CODER",
+	)
+	if err != nil {
+		c.logger.Error("🔍 Failed to render verification template: %v", err)
+		return VerificationOutcome{
+			Status: VerificationUnavailable,
+			Reason: fmt.Sprintf("template render error: %v", err),
+		}
+	}
+
+	// Set up fresh context with verification prompt
+	verificationCM.ResetForNewTemplate("testing-verification", prompt)
+
+	// Create verification tool provider (read-only, network disabled, shell only)
+	verificationProvider := c.createVerificationToolProvider()
+
+	// Get shell as the single general tool
+	shellTool, err := verificationProvider.Get(tools.ToolShell)
+	if err != nil {
+		c.logger.Error("🔍 Failed to get shell tool for verification: %v", err)
+		return VerificationOutcome{
+			Status: VerificationUnavailable,
+			Reason: fmt.Sprintf("tool setup error: %v", err),
+		}
+	}
+	generalTools := []tools.Tool{shellTool}
+
+	// Create terminal tool directly (not from provider — follows coding.go pattern)
+	terminalTool := tools.NewSubmitVerificationTool()
+
+	// Configure toolloop
+	loop := toolloop.New(c.LLMClient, c.logger)
+	cfg := &toolloop.Config[struct{}]{
+		ContextManager:     verificationCM,
+		GeneralTools:       generalTools,
+		TerminalTool:       terminalTool,
+		MaxIterations:      maxVerificationIterations,
+		MaxTokens:          4096,
+		Temperature:        verificationTemperature,
+		AgentID:            c.GetAgentID(),
+		DebugLogging:       config.GetDebugLLMMessages(),
+		ActivityTracker:    c.activityTracker,
+		PersistenceChannel: c.persistenceChannel,
+		StoryID:            storyID,
+		ToolCircuitBreaker: &toolloop.ToolCircuitBreakerConfig{
+			MaxConsecutiveFailures: 3,
+			OnTrip: func(_ string, label string, count int) {
+				c.logger.Warn("🔌 Circuit breaker tripped in verification: %s (%d failures)", label, count)
+			},
+		},
+	}
+
+	// Run verification loop
+	out := toolloop.Run[struct{}](loop, ctx, cfg)
+
+	// Process outcome
+	switch out.Kind {
+	case toolloop.OutcomeProcessEffect:
+		evidence, _ := out.EffectData.(map[string]any)
+		switch out.Signal {
+		case tools.SignalVerificationPass:
+			c.logger.Info("🔍 Verification passed (iteration %d)", out.Iteration)
+			return VerificationOutcome{Status: VerificationPass, Evidence: evidence}
+		case tools.SignalVerificationFail:
+			c.logger.Info("🔍 Verification found gaps (iteration %d)", out.Iteration)
+			return VerificationOutcome{Status: VerificationFail, Evidence: evidence}
+		default:
+			c.logger.Warn("🔍 Unexpected verification signal: %s", out.Signal)
+			return VerificationOutcome{
+				Status: VerificationUnavailable,
+				Reason: fmt.Sprintf("unexpected signal: %s", out.Signal),
+			}
+		}
+
+	case toolloop.OutcomeMaxIterations, toolloop.OutcomeNoToolTwice:
+		c.logger.Warn("🔍 Verification loop exhausted without submitting evidence (kind=%s, iteration=%d)", out.Kind, out.Iteration)
+		return VerificationOutcome{
+			Status: VerificationUnavailable,
+			Reason: fmt.Sprintf("verification loop exhausted (%s at iteration %d)", out.Kind, out.Iteration),
+		}
+
+	case toolloop.OutcomeLLMError:
+		c.logger.Error("🔍 LLM error during verification: %v", out.Err)
+		return VerificationOutcome{
+			Status: VerificationUnavailable,
+			Reason: fmt.Sprintf("LLM error: %v", out.Err),
+		}
+
+	case toolloop.OutcomeGracefulShutdown:
+		c.logger.Info("🔍 Graceful shutdown during verification")
+		return VerificationOutcome{
+			Status: VerificationUnavailable,
+			Reason: "graceful shutdown",
+		}
+
+	default:
+		c.logger.Warn("🔍 Unexpected verification outcome: %s", out.Kind)
+		return VerificationOutcome{
+			Status: VerificationUnavailable,
+			Reason: fmt.Sprintf("unexpected outcome: %s", out.Kind),
+		}
+	}
+}
+
+// createVerificationToolProvider creates a read-only, network-disabled ToolProvider
+// with only shell available for acceptance-criteria verification.
+func (c *Coder) createVerificationToolProvider() *tools.ToolProvider {
+	agentCtx := tools.AgentContext{
+		Executor:        c.longRunningExecutor,
+		Agent:           c,
+		ChatService:     c.chatService,
+		ReadOnly:        true,
+		NetworkDisabled: true,
+		WorkDir:         c.workDir,
+		AgentID:         c.GetAgentID(),
+	}
+	return tools.NewProvider(&agentCtx, tools.VerificationTools)
+}
+
+// buildVerificationFailureMessage extracts failed/partial criteria from verification evidence
+// and formats an actionable message for the CODING state. Hard-capped at maxFailureMessageLen.
+func buildVerificationFailureMessage(evidence map[string]any) string {
+	if evidence == nil {
+		return "Acceptance criteria verification failed but no detailed evidence was provided."
+	}
+
+	var b strings.Builder
+	b.WriteString("Acceptance criteria verification found the following gaps:\n\n")
+
+	// Extract failed/partial criteria only
+	if criteria, ok := evidence["acceptance_criteria_checked"].([]any); ok {
+		for _, item := range criteria {
+			cm, ok := item.(map[string]any)
+			if !ok {
+				// Try map[string]string (from validated tool output)
+				if cms, ok := item.(map[string]string); ok {
+					cm = make(map[string]any, len(cms))
+					for k, v := range cms {
+						cm[k] = v
+					}
+				} else {
+					continue
+				}
+			}
+
+			result, _ := cm["result"].(string)
+			if result != criterionResultFail && result != criterionResultPartial {
+				continue
+			}
+
+			criterion, _ := cm["criterion"].(string)
+			evidenceText, _ := cm["evidence"].(string)
+
+			tag := "FAIL"
+			if result == criterionResultPartial {
+				tag = "PARTIAL"
+			}
+
+			line := fmt.Sprintf("- [%s] %s: %s\n", tag, criterion, evidenceText)
+			b.WriteString(line)
+
+			if b.Len() > maxFailureMessageLen {
+				break
+			}
+		}
+	}
+
+	// Add gaps
+	if gaps, ok := evidence["gaps"].([]any); ok && len(gaps) > 0 {
+		b.WriteString("\nAdditional gaps:\n")
+		for _, g := range gaps {
+			if gs, ok := g.(string); ok {
+				b.WriteString(fmt.Sprintf("- %s\n", gs))
+				if b.Len() > maxFailureMessageLen {
+					break
+				}
+			}
+		}
+	}
+
+	b.WriteString("\nPlease address these gaps and call done when ready for re-testing.")
+
+	result := b.String()
+	if len(result) > maxFailureMessageLen {
+		result = result[:maxFailureMessageLen] + "\n\n[... truncated for context management ...]"
+	}
+	return result
+}
+
+// formatVerificationEvidence formats a VerificationOutcome for the CODE_REVIEW evidence section.
+func formatVerificationEvidence(outcome VerificationOutcome) string {
+	var b strings.Builder
+	b.WriteString("\n## Acceptance Criteria Verification\n")
+
+	switch outcome.Status {
+	case VerificationUnavailable:
+		b.WriteString(fmt.Sprintf("⚠️ Verification attempted but unavailable: %s\n", outcome.Reason))
+		return b.String()
+
+	case VerificationPass:
+		b.WriteString("✅ All acceptance criteria verified\n")
+
+	case VerificationFail:
+		b.WriteString("❌ Acceptance criteria gaps found\n")
+	}
+
+	if outcome.Evidence == nil {
+		return b.String()
+	}
+
+	// Format per-criterion results
+	if criteria, ok := outcome.Evidence["acceptance_criteria_checked"].([]any); ok {
+		for _, item := range criteria {
+			cm, ok := item.(map[string]any)
+			if !ok {
+				if cms, ok := item.(map[string]string); ok {
+					cm = make(map[string]any, len(cms))
+					for k, v := range cms {
+						cm[k] = v
+					}
+				} else {
+					continue
+				}
+			}
+
+			result, _ := cm["result"].(string)
+			criterion, _ := cm["criterion"].(string)
+
+			icon := "❓"
+			switch result {
+			case "pass":
+				icon = "✅"
+			case "fail":
+				icon = "❌"
+			case "partial":
+				icon = "⚠️"
+			case "unverified":
+				icon = "❓"
+			}
+			b.WriteString(fmt.Sprintf("  %s %s\n", icon, criterion))
+		}
+	}
+
+	// Add confidence
+	if confidence, ok := outcome.Evidence["confidence"].(string); ok {
+		b.WriteString(fmt.Sprintf("Verification confidence: %s\n", confidence))
+	}
+
+	// Add gaps if any
+	if gaps, ok := outcome.Evidence["gaps"].([]any); ok && len(gaps) > 0 {
+		b.WriteString("Gaps:\n")
+		for _, g := range gaps {
+			if gs, ok := g.(string); ok {
+				b.WriteString(fmt.Sprintf("  - %s\n", gs))
+			}
+		}
+	}
+
+	return b.String()
+}

--- a/pkg/coder/verification.go
+++ b/pkg/coder/verification.go
@@ -86,7 +86,7 @@ func (c *Coder) runAcceptanceCriteriaVerification(
 		TestResults: truncateOutput(testOutput),
 	}
 
-	// Render verification template with user instructions (includes MAESTRO.md)
+	// Render verification template with user instructions from .maestro/*instructions*.md
 	if c.renderer == nil {
 		c.logger.Warn("🔍 Template renderer not available, skipping verification")
 		return VerificationOutcome{
@@ -280,7 +280,8 @@ func buildVerificationFailureMessage(evidence map[string]any) string {
 
 	result := b.String()
 	if len(result) > maxFailureMessageLen {
-		result = result[:maxFailureMessageLen] + "\n\n[... truncated for context management ...]"
+		const truncationSuffix = "\n\n[... truncated for context management ...]"
+		result = result[:maxFailureMessageLen-len(truncationSuffix)] + truncationSuffix
 	}
 	return result
 }

--- a/pkg/coder/verification.go
+++ b/pkg/coder/verification.go
@@ -18,7 +18,9 @@ import (
 type VerificationStatus string
 
 const (
-	// VerificationPass means all acceptance criteria were verified as met.
+	// VerificationPass means no acceptance criteria were found to fail.
+	// Note: partial and unverified criteria also produce this status —
+	// only an explicit "fail" result triggers VerificationFail.
 	VerificationPass VerificationStatus = "pass"
 	// VerificationFail means one or more acceptance criteria failed verification.
 	VerificationFail VerificationStatus = "fail"
@@ -200,6 +202,13 @@ func (c *Coder) runAcceptanceCriteriaVerification(
 
 // createVerificationToolProvider creates a read-only, network-disabled ToolProvider
 // with only shell available for acceptance-criteria verification.
+//
+// LIMITATION: ReadOnly and NetworkDisabled are set on AgentContext and forwarded to
+// exec.Opts by the shell tool, but the long-running Docker executor's `docker exec`
+// path does not currently enforce these flags (it only applies user, workdir, and env).
+// The verification loop's read-only and network-disabled guarantees therefore rely on
+// the LLM following the system prompt constraints until executor-level enforcement
+// is added. See docker_long_running.go Run() for the exec path.
 func (c *Coder) createVerificationToolProvider() *tools.ToolProvider {
 	agentCtx := tools.AgentContext{
 		Executor:        c.longRunningExecutor,
@@ -223,20 +232,13 @@ func buildVerificationFailureMessage(evidence map[string]any) string {
 	var b strings.Builder
 	b.WriteString("Acceptance criteria verification found the following gaps:\n\n")
 
-	// Extract failed/partial criteria only
+	// Extract failed/partial criteria only.
+	// The tool emits []any of map[string]any; JSON roundtrip (resume) preserves this shape.
 	if criteria, ok := evidence["acceptance_criteria_checked"].([]any); ok {
 		for _, item := range criteria {
 			cm, ok := item.(map[string]any)
 			if !ok {
-				// Try map[string]string (from validated tool output)
-				if cms, ok := item.(map[string]string); ok {
-					cm = make(map[string]any, len(cms))
-					for k, v := range cms {
-						cm[k] = v
-					}
-				} else {
-					continue
-				}
+				continue
 			}
 
 			result, _ := cm["result"].(string)
@@ -261,7 +263,7 @@ func buildVerificationFailureMessage(evidence map[string]any) string {
 		}
 	}
 
-	// Add gaps
+	// Add gaps (tool emits []any of string; JSON roundtrip preserves this)
 	if gaps, ok := evidence["gaps"].([]any); ok && len(gaps) > 0 {
 		b.WriteString("\nAdditional gaps:\n")
 		for _, g := range gaps {
@@ -294,7 +296,7 @@ func formatVerificationEvidence(outcome VerificationOutcome) string {
 		return b.String()
 
 	case VerificationPass:
-		b.WriteString("✅ All acceptance criteria verified\n")
+		b.WriteString("✅ No acceptance criteria failures found\n")
 
 	case VerificationFail:
 		b.WriteString("❌ Acceptance criteria gaps found\n")
@@ -304,19 +306,13 @@ func formatVerificationEvidence(outcome VerificationOutcome) string {
 		return b.String()
 	}
 
-	// Format per-criterion results
+	// Format per-criterion results.
+	// The tool emits []any of map[string]any; JSON roundtrip (resume) preserves this shape.
 	if criteria, ok := outcome.Evidence["acceptance_criteria_checked"].([]any); ok {
 		for _, item := range criteria {
 			cm, ok := item.(map[string]any)
 			if !ok {
-				if cms, ok := item.(map[string]string); ok {
-					cm = make(map[string]any, len(cms))
-					for k, v := range cms {
-						cm[k] = v
-					}
-				} else {
-					continue
-				}
+				continue
 			}
 
 			result, _ := cm["result"].(string)
@@ -353,4 +349,33 @@ func formatVerificationEvidence(outcome VerificationOutcome) string {
 	}
 
 	return b.String()
+}
+
+// rehydrateVerificationOutcome converts raw state data back into a VerificationOutcome.
+// Handles both the direct in-memory path (typed struct) and the post-resume path
+// where state persistence round-trips through map[string]any.
+func rehydrateVerificationOutcome(raw any) (VerificationOutcome, bool) {
+	// Direct in-memory path: typed struct survives within a single process lifetime.
+	if outcome, ok := raw.(VerificationOutcome); ok {
+		return outcome, true
+	}
+
+	// Post-resume path: state persistence serializes to JSON and restores as map[string]any.
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return VerificationOutcome{}, false
+	}
+
+	outcome := VerificationOutcome{}
+	if status, ok := m["Status"].(string); ok {
+		outcome.Status = VerificationStatus(status)
+	}
+	if evidence, ok := m["Evidence"].(map[string]any); ok {
+		outcome.Evidence = evidence
+	}
+	if reason, ok := m["Reason"].(string); ok {
+		outcome.Reason = reason
+	}
+
+	return outcome, outcome.Status != ""
 }

--- a/pkg/coder/verification_test.go
+++ b/pkg/coder/verification_test.go
@@ -1,26 +1,30 @@
 package coder
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"orchestrator/pkg/tools"
 )
 
 func TestBuildVerificationFailureMessage_FailedCriteria(t *testing.T) {
+	// Use map[string]any — the shape the tool actually emits
 	evidence := map[string]any{
 		"acceptance_criteria_checked": []any{
-			map[string]string{
+			map[string]any{
 				"criterion": "API returns 200",
 				"method":    "command",
 				"result":    "pass",
 				"evidence":  "curl returned 200",
 			},
-			map[string]string{
+			map[string]any{
 				"criterion": "Input validation present",
 				"method":    "inspection",
 				"result":    "fail",
 				"evidence":  "No validation in handler.go",
 			},
-			map[string]string{
+			map[string]any{
 				"criterion": "Error messages are user-friendly",
 				"method":    "inspection",
 				"result":    "partial",
@@ -62,7 +66,7 @@ func TestBuildVerificationFailureMessage_Truncation(t *testing.T) {
 	// Create evidence with very long entries to trigger truncation
 	criteria := make([]any, 50)
 	for i := range criteria {
-		criteria[i] = map[string]string{
+		criteria[i] = map[string]any{
 			"criterion": strings.Repeat("criterion text ", 10),
 			"method":    "inspection",
 			"result":    "fail",
@@ -83,7 +87,7 @@ func TestBuildVerificationFailureMessage_Truncation(t *testing.T) {
 }
 
 func TestBuildVerificationFailureMessage_MapStringAny(t *testing.T) {
-	// Test with map[string]any (as would come from JSON unmarshaling)
+	// Test with map[string]any (the canonical shape from tool and JSON roundtrip)
 	evidence := map[string]any{
 		"acceptance_criteria_checked": []any{
 			map[string]any{
@@ -106,7 +110,7 @@ func TestFormatVerificationEvidence_Pass(t *testing.T) {
 		Status: VerificationPass,
 		Evidence: map[string]any{
 			"acceptance_criteria_checked": []any{
-				map[string]string{
+				map[string]any{
 					"criterion": "API endpoint works",
 					"result":    "pass",
 				},
@@ -116,7 +120,7 @@ func TestFormatVerificationEvidence_Pass(t *testing.T) {
 	}
 
 	result := formatVerificationEvidence(outcome)
-	if !strings.Contains(result, "All acceptance criteria verified") {
+	if !strings.Contains(result, "No acceptance criteria failures found") {
 		t.Error("Expected pass header")
 	}
 	if !strings.Contains(result, "API endpoint works") {
@@ -132,7 +136,7 @@ func TestFormatVerificationEvidence_Fail(t *testing.T) {
 		Status: VerificationFail,
 		Evidence: map[string]any{
 			"acceptance_criteria_checked": []any{
-				map[string]string{
+				map[string]any{
 					"criterion": "Tests pass",
 					"result":    "fail",
 				},
@@ -222,5 +226,217 @@ func TestVerificationOutcome_StatusValues(t *testing.T) {
 	}
 	if VerificationFail == VerificationUnavailable {
 		t.Error("fail and unavailable should be different")
+	}
+}
+
+// TestRehydrateVerificationOutcome_DirectPath tests that in-memory typed structs
+// pass through rehydration unchanged.
+func TestRehydrateVerificationOutcome_DirectPath(t *testing.T) {
+	original := VerificationOutcome{
+		Status: VerificationPass,
+		Evidence: map[string]any{
+			"acceptance_criteria_checked": []any{
+				map[string]any{"criterion": "A", "result": "pass"},
+			},
+			"confidence": "high",
+		},
+	}
+
+	outcome, ok := rehydrateVerificationOutcome(original)
+	if !ok {
+		t.Fatal("Expected rehydration to succeed for typed struct")
+	}
+	if outcome.Status != VerificationPass {
+		t.Errorf("Expected status %s, got %s", VerificationPass, outcome.Status)
+	}
+	if outcome.Evidence["confidence"] != "high" {
+		t.Errorf("Expected confidence 'high', got %v", outcome.Evidence["confidence"])
+	}
+}
+
+// TestRehydrateVerificationOutcome_ResumedPath tests that map[string]any
+// (as produced by state persistence JSON roundtrip) is correctly rehydrated.
+func TestRehydrateVerificationOutcome_ResumedPath(t *testing.T) {
+	// Simulate what state persistence produces after JSON roundtrip
+	resumed := map[string]any{
+		"Status": "fail",
+		"Evidence": map[string]any{
+			"acceptance_criteria_checked": []any{
+				map[string]any{"criterion": "Tests pass", "result": "fail"},
+			},
+			"gaps":       []any{"Missing tests"},
+			"confidence": "medium",
+		},
+		"Reason": "",
+	}
+
+	outcome, ok := rehydrateVerificationOutcome(resumed)
+	if !ok {
+		t.Fatal("Expected rehydration to succeed for map[string]any")
+	}
+	if outcome.Status != VerificationFail {
+		t.Errorf("Expected status %s, got %s", VerificationFail, outcome.Status)
+	}
+	if outcome.Evidence == nil {
+		t.Fatal("Expected non-nil evidence")
+	}
+	if outcome.Evidence["confidence"] != "medium" {
+		t.Errorf("Expected confidence 'medium', got %v", outcome.Evidence["confidence"])
+	}
+}
+
+// TestRehydrateVerificationOutcome_UnavailableResumed tests unavailable status rehydration.
+func TestRehydrateVerificationOutcome_UnavailableResumed(t *testing.T) {
+	resumed := map[string]any{
+		"Status": "unavailable",
+		"Reason": "LLM error: timeout",
+	}
+
+	outcome, ok := rehydrateVerificationOutcome(resumed)
+	if !ok {
+		t.Fatal("Expected rehydration to succeed")
+	}
+	if outcome.Status != VerificationUnavailable {
+		t.Errorf("Expected status %s, got %s", VerificationUnavailable, outcome.Status)
+	}
+	if outcome.Reason != "LLM error: timeout" {
+		t.Errorf("Expected reason text, got %q", outcome.Reason)
+	}
+	if outcome.Evidence != nil {
+		t.Error("Expected nil evidence for unavailable")
+	}
+}
+
+// TestRehydrateVerificationOutcome_InvalidInput tests that invalid inputs fail gracefully.
+func TestRehydrateVerificationOutcome_InvalidInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{"nil", nil},
+		{"string", "not a struct"},
+		{"int", 42},
+		{"empty map", map[string]any{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := rehydrateVerificationOutcome(tt.input)
+			if ok {
+				t.Error("Expected rehydration to fail for invalid input")
+			}
+		})
+	}
+}
+
+// TestProducerConsumerRoundTrip exercises the full path: tool emits evidence →
+// consumers (buildVerificationFailureMessage, formatVerificationEvidence) process it.
+// This catches type shape mismatches between producer and consumer.
+func TestProducerConsumerRoundTrip(t *testing.T) {
+	tool := tools.NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{
+				"criterion": "API returns 200",
+				"method":    "command",
+				"result":    "pass",
+				"evidence":  "curl OK",
+			},
+			map[string]any{
+				"criterion": "Input validation",
+				"method":    "inspection",
+				"result":    "fail",
+				"evidence":  "No validation found",
+			},
+		},
+		"gaps":       []any{"Missing validation"},
+		"confidence": "medium",
+		"summary":    "One gap found",
+	}
+
+	result, err := tool.Exec(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Tool exec failed: %v", err)
+	}
+
+	evidence, ok := result.ProcessEffect.Data.(map[string]any)
+	if !ok {
+		t.Fatal("Expected map[string]any data from tool")
+	}
+
+	// Feed tool output directly into buildVerificationFailureMessage
+	failMsg := buildVerificationFailureMessage(evidence)
+	if !strings.Contains(failMsg, "[FAIL]") {
+		t.Error("buildVerificationFailureMessage: expected [FAIL] tag from tool output")
+	}
+	if !strings.Contains(failMsg, "Input validation") {
+		t.Error("buildVerificationFailureMessage: expected criterion text from tool output")
+	}
+	if !strings.Contains(failMsg, "Missing validation") {
+		t.Error("buildVerificationFailureMessage: expected gap text from tool output")
+	}
+	// Passing criteria should not appear
+	if strings.Contains(failMsg, "API returns 200") {
+		t.Error("buildVerificationFailureMessage: should not include passing criteria")
+	}
+
+	// Feed tool output directly into formatVerificationEvidence
+	outcome := VerificationOutcome{
+		Status:   VerificationFail,
+		Evidence: evidence,
+	}
+	formatted := formatVerificationEvidence(outcome)
+	if !strings.Contains(formatted, "gaps found") {
+		t.Error("formatVerificationEvidence: expected fail header from tool output")
+	}
+	if !strings.Contains(formatted, "Input validation") {
+		t.Error("formatVerificationEvidence: expected criterion in formatted output")
+	}
+	if !strings.Contains(formatted, "Missing validation") {
+		t.Error("formatVerificationEvidence: expected gap in formatted output")
+	}
+}
+
+// TestProducerConsumerRoundTrip_AllPass verifies the pass path with actual tool output.
+func TestProducerConsumerRoundTrip_AllPass(t *testing.T) {
+	tool := tools.NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{
+				"criterion": "Tests pass",
+				"method":    "command",
+				"result":    "pass",
+				"evidence":  "All green",
+			},
+		},
+		"confidence": "high",
+		"summary":    "All criteria met",
+	}
+
+	result, err := tool.Exec(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Tool exec failed: %v", err)
+	}
+	if result.ProcessEffect.Signal != tools.SignalVerificationPass {
+		t.Errorf("Expected pass signal, got %s", result.ProcessEffect.Signal)
+	}
+
+	evidence, ok := result.ProcessEffect.Data.(map[string]any)
+	if !ok {
+		t.Fatal("Expected map[string]any data from tool")
+	}
+
+	outcome := VerificationOutcome{
+		Status:   VerificationPass,
+		Evidence: evidence,
+	}
+	formatted := formatVerificationEvidence(outcome)
+	if !strings.Contains(formatted, "No acceptance criteria failures found") {
+		t.Error("Expected pass header in formatted output")
+	}
+	if !strings.Contains(formatted, "Tests pass") {
+		t.Error("Expected criterion text in formatted output")
 	}
 }

--- a/pkg/coder/verification_test.go
+++ b/pkg/coder/verification_test.go
@@ -1,0 +1,226 @@
+package coder
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildVerificationFailureMessage_FailedCriteria(t *testing.T) {
+	evidence := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]string{
+				"criterion": "API returns 200",
+				"method":    "command",
+				"result":    "pass",
+				"evidence":  "curl returned 200",
+			},
+			map[string]string{
+				"criterion": "Input validation present",
+				"method":    "inspection",
+				"result":    "fail",
+				"evidence":  "No validation in handler.go",
+			},
+			map[string]string{
+				"criterion": "Error messages are user-friendly",
+				"method":    "inspection",
+				"result":    "partial",
+				"evidence":  "Some errors are raw stack traces",
+			},
+		},
+		"gaps": []any{"Missing validation middleware"},
+	}
+
+	msg := buildVerificationFailureMessage(evidence)
+
+	// Should include failed and partial, not pass
+	if !strings.Contains(msg, "[FAIL]") {
+		t.Error("Expected [FAIL] tag in message")
+	}
+	if !strings.Contains(msg, "[PARTIAL]") {
+		t.Error("Expected [PARTIAL] tag in message")
+	}
+	if !strings.Contains(msg, "Input validation present") {
+		t.Error("Expected failed criterion text")
+	}
+	if !strings.Contains(msg, "Missing validation middleware") {
+		t.Error("Expected gap text")
+	}
+	// Should NOT include passing criteria
+	if strings.Contains(msg, "API returns 200") {
+		t.Error("Should not include passing criteria")
+	}
+}
+
+func TestBuildVerificationFailureMessage_NilEvidence(t *testing.T) {
+	msg := buildVerificationFailureMessage(nil)
+	if msg == "" {
+		t.Error("Expected non-empty fallback message")
+	}
+}
+
+func TestBuildVerificationFailureMessage_Truncation(t *testing.T) {
+	// Create evidence with very long entries to trigger truncation
+	criteria := make([]any, 50)
+	for i := range criteria {
+		criteria[i] = map[string]string{
+			"criterion": strings.Repeat("criterion text ", 10),
+			"method":    "inspection",
+			"result":    "fail",
+			"evidence":  strings.Repeat("evidence text ", 20),
+		}
+	}
+
+	evidence := map[string]any{
+		"acceptance_criteria_checked": criteria,
+	}
+
+	msg := buildVerificationFailureMessage(evidence)
+
+	// Should be within bounds (maxFailureMessageLen + truncation suffix)
+	if len(msg) > maxFailureMessageLen+100 {
+		t.Errorf("Message too long: %d chars (max %d)", len(msg), maxFailureMessageLen)
+	}
+}
+
+func TestBuildVerificationFailureMessage_MapStringAny(t *testing.T) {
+	// Test with map[string]any (as would come from JSON unmarshaling)
+	evidence := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{
+				"criterion": "Test coverage > 80%",
+				"method":    "command",
+				"result":    "fail",
+				"evidence":  "Coverage is 65%",
+			},
+		},
+	}
+
+	msg := buildVerificationFailureMessage(evidence)
+	if !strings.Contains(msg, "Test coverage > 80%") {
+		t.Error("Expected criterion text in message")
+	}
+}
+
+func TestFormatVerificationEvidence_Pass(t *testing.T) {
+	outcome := VerificationOutcome{
+		Status: VerificationPass,
+		Evidence: map[string]any{
+			"acceptance_criteria_checked": []any{
+				map[string]string{
+					"criterion": "API endpoint works",
+					"result":    "pass",
+				},
+			},
+			"confidence": "high",
+		},
+	}
+
+	result := formatVerificationEvidence(outcome)
+	if !strings.Contains(result, "All acceptance criteria verified") {
+		t.Error("Expected pass header")
+	}
+	if !strings.Contains(result, "API endpoint works") {
+		t.Error("Expected criterion text")
+	}
+	if !strings.Contains(result, "high") {
+		t.Error("Expected confidence")
+	}
+}
+
+func TestFormatVerificationEvidence_Fail(t *testing.T) {
+	outcome := VerificationOutcome{
+		Status: VerificationFail,
+		Evidence: map[string]any{
+			"acceptance_criteria_checked": []any{
+				map[string]string{
+					"criterion": "Tests pass",
+					"result":    "fail",
+				},
+			},
+			"gaps":       []any{"Missing test file"},
+			"confidence": "medium",
+		},
+	}
+
+	result := formatVerificationEvidence(outcome)
+	if !strings.Contains(result, "gaps found") {
+		t.Error("Expected fail header")
+	}
+	if !strings.Contains(result, "Missing test file") {
+		t.Error("Expected gap text")
+	}
+}
+
+func TestFormatVerificationEvidence_Unavailable(t *testing.T) {
+	outcome := VerificationOutcome{
+		Status: VerificationUnavailable,
+		Reason: "LLM error: rate limited",
+	}
+
+	result := formatVerificationEvidence(outcome)
+	if !strings.Contains(result, "unavailable") {
+		t.Error("Expected unavailable header")
+	}
+	if !strings.Contains(result, "LLM error: rate limited") {
+		t.Error("Expected reason text")
+	}
+}
+
+func TestFormatVerificationEvidence_Icons(t *testing.T) {
+	outcome := VerificationOutcome{
+		Status: VerificationPass,
+		Evidence: map[string]any{
+			"acceptance_criteria_checked": []any{
+				map[string]any{"criterion": "A", "result": "pass"},
+				map[string]any{"criterion": "B", "result": "fail"},
+				map[string]any{"criterion": "C", "result": "partial"},
+				map[string]any{"criterion": "D", "result": "unverified"},
+			},
+			"confidence": "low",
+		},
+	}
+
+	result := formatVerificationEvidence(outcome)
+	// Each criterion type should get its own icon
+	lines := strings.Split(result, "\n")
+	var foundPass, foundFail, foundPartial, foundUnverified bool
+	for _, line := range lines {
+		if strings.Contains(line, "A") && strings.Contains(line, "\u2705") {
+			foundPass = true
+		}
+		if strings.Contains(line, "B") && strings.Contains(line, "\u274c") {
+			foundFail = true
+		}
+		if strings.Contains(line, "C") && strings.Contains(line, "\u26a0") {
+			foundPartial = true
+		}
+		if strings.Contains(line, "D") && strings.Contains(line, "\u2753") {
+			foundUnverified = true
+		}
+	}
+	if !foundPass {
+		t.Error("Expected pass icon for criterion A")
+	}
+	if !foundFail {
+		t.Error("Expected fail icon for criterion B")
+	}
+	if !foundPartial {
+		t.Error("Expected partial icon for criterion C")
+	}
+	if !foundUnverified {
+		t.Error("Expected unverified icon for criterion D")
+	}
+}
+
+func TestVerificationOutcome_StatusValues(t *testing.T) {
+	// Ensure the status constants are distinct
+	if VerificationPass == VerificationFail {
+		t.Error("pass and fail should be different")
+	}
+	if VerificationPass == VerificationUnavailable {
+		t.Error("pass and unavailable should be different")
+	}
+	if VerificationFail == VerificationUnavailable {
+		t.Error("fail and unavailable should be different")
+	}
+}

--- a/pkg/coder/verification_test.go
+++ b/pkg/coder/verification_test.go
@@ -80,8 +80,8 @@ func TestBuildVerificationFailureMessage_Truncation(t *testing.T) {
 
 	msg := buildVerificationFailureMessage(evidence)
 
-	// Should be within bounds (maxFailureMessageLen + truncation suffix)
-	if len(msg) > maxFailureMessageLen+100 {
+	// Should be strictly within maxFailureMessageLen (truncation reserves space for suffix)
+	if len(msg) > maxFailureMessageLen {
 		t.Errorf("Message too long: %d chars (max %d)", len(msg), maxFailureMessageLen)
 	}
 }

--- a/pkg/templates/coder/testing_verification.tpl.md
+++ b/pkg/templates/coder/testing_verification.tpl.md
@@ -1,0 +1,57 @@
+# Acceptance Criteria Verification
+
+You are a verification agent. Your sole task is to verify that the implementation satisfies each acceptance criterion from the story requirements below.
+
+## CRITICAL RULES
+
+1. You are **READ-ONLY**. Do not suggest or attempt code changes.
+2. You **MUST** call `submit_verification` within 5 tool turns.
+3. Use the `shell` tool to run read-only commands: `cat`, `grep`, `find`, `git diff`, `git log`, `ls`, `wc`, etc.
+4. Do NOT run commands that modify files, build artifacts, or install packages.
+5. Focus on **verification**, not implementation suggestions.
+
+## Story Requirements
+
+{{.TaskContent}}
+
+{{if .Plan}}
+## Approved Plan
+
+{{.Plan}}
+{{end}}
+
+{{if .TestResults}}
+## Deterministic Test Results
+
+The following tests have already passed:
+
+{{.TestResults}}
+{{end}}
+
+## Instructions
+
+1. **Extract acceptance criteria** from the story above. Look for:
+   - `## Acceptance Criteria` section with `- [ ]` checkboxes
+   - Numbered requirements or bullet-point requirements
+   - Any explicit "must", "should", or "shall" statements
+
+2. **For each criterion**, use the shell tool to inspect the implementation:
+   - `git diff --merge-base origin/main HEAD` to see what changed
+   - `cat <file>` to read specific files
+   - `grep -r "pattern" .` to search for implementations
+   - `find . -name "pattern"` to locate files
+   - `ls <dir>` to check directory structure
+
+3. **Call `submit_verification`** with your structured findings.
+
+## Evidence Quality Guide
+
+- **pass**: You confirmed the criterion is met with specific file/code evidence. Cite the file and what you found.
+- **fail**: You confirmed the criterion is NOT met. Cite specifically what is missing or wrong.
+- **partial**: Some aspects are met but others are unclear or incomplete. Explain what works and what doesn't.
+- **unverified**: Cannot determine via static inspection alone (e.g., requires runtime behavior testing). Use sparingly.
+
+## Available Tools
+
+- **shell** - Run read-only shell commands to inspect the workspace
+- **submit_verification** - Submit your structured verification findings (TERMINAL - call this to complete verification)

--- a/pkg/templates/renderer.go
+++ b/pkg/templates/renderer.go
@@ -56,6 +56,8 @@ const (
 	AppCodingTemplate StateTemplate = "coder/app_coding.tpl.md"
 	// TestingTemplate is the template for coder testing state.
 	TestingTemplate StateTemplate = "coder/testing.tpl.md"
+	// TestingVerificationTemplate is the template for acceptance-criteria verification in TESTING.
+	TestingVerificationTemplate StateTemplate = "coder/testing_verification.tpl.md"
 	// ApprovalTemplate is the template for code approval requests.
 	ApprovalTemplate StateTemplate = "coder/approval.tpl.md"
 	// AppCompletionApprovalTemplate is the template for app story completion approval.
@@ -171,6 +173,7 @@ func NewRenderer() (*Renderer, error) {
 		DevOpsCodingTemplate,
 		AppCodingTemplate,
 		TestingTemplate,
+		TestingVerificationTemplate,
 		ApprovalTemplate,
 		AppCompletionApprovalTemplate,
 		DevOpsCompletionApprovalTemplate,

--- a/pkg/tools/constants.go
+++ b/pkg/tools/constants.go
@@ -42,6 +42,9 @@ const (
 	ToolTodoComplete = "todo_complete"
 	ToolTodoUpdate   = "todo_update"
 
+	// Verification tools.
+	ToolSubmitVerification = "submit_verification"
+
 	// Architect read tools.
 	ToolReadFile       = "read_file"
 	ToolListFiles      = "list_files"
@@ -164,6 +167,12 @@ var (
 		ToolTest,
 		ToolLint,
 		ToolBackendInfo,
+	}
+
+	// Verification tools - read-only shell for acceptance-criteria verification in TESTING.
+	// submit_verification is the terminal tool and is wired separately.
+	VerificationTools = []string{
+		ToolShell,
 	}
 
 	// Architect read tools - read-only access to coder workspaces.

--- a/pkg/tools/mcp.go
+++ b/pkg/tools/mcp.go
@@ -90,12 +90,14 @@ const (
 	SignalStoryEditComplete    = "STORY_EDIT_COMPLETE"   // story_edit tool annotated story before requeue
 
 	// Coder signals.
-	SignalPlanReview    = "PLAN_REVIEW"    // submit_plan tool ready for architect review
-	SignalStoryComplete = "STORY_COMPLETE" // done tool empty-diff - story already implemented, no work needed
-	SignalCoding        = "CODING"         // todos_add tool ready to start coding
-	SignalTesting       = "TESTING"        // done tool ready for testing phase
-	SignalTodoComplete  = "TODO_COMPLETE"  // todo_complete tool marked a todo as done
-	SignalBlocked       = "BLOCKED"        // report_blocked tool: coder blocked by infrastructure or invalid story
+	SignalPlanReview       = "PLAN_REVIEW"       // submit_plan tool ready for architect review
+	SignalStoryComplete    = "STORY_COMPLETE"    // done tool empty-diff - story already implemented, no work needed
+	SignalCoding           = "CODING"            // todos_add tool ready to start coding
+	SignalTesting          = "TESTING"           // done tool ready for testing phase
+	SignalTodoComplete     = "TODO_COMPLETE"     // todo_complete tool marked a todo as done
+	SignalBlocked          = "BLOCKED"           // report_blocked tool: coder blocked by infrastructure or invalid story
+	SignalVerificationPass = "VERIFICATION_PASS" // submit_verification tool: all acceptance criteria verified
+	SignalVerificationFail = "VERIFICATION_FAIL" // submit_verification tool: acceptance criteria gaps found
 )
 
 // ExecResult is the result of executing a tool.

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -428,6 +428,15 @@ func getStoryCompleteSchema() InputSchema {
 	return NewStoryCompleteTool().Definition().InputSchema
 }
 
+// createSubmitVerificationTool creates a submit verification tool instance.
+func createSubmitVerificationTool(_ *AgentContext) (Tool, error) {
+	return NewSubmitVerificationTool(), nil
+}
+
+func getSubmitVerificationSchema() InputSchema {
+	return NewSubmitVerificationTool().Definition().InputSchema
+}
+
 func getBuildSchema() InputSchema {
 	buildSvc := build.NewBuildService()
 	return NewBuildTool(buildSvc).Definition().InputSchema
@@ -817,6 +826,13 @@ func init() {
 		Name:        ToolTodoUpdate,
 		Description: "Update or remove a todo by index",
 		InputSchema: getTodoUpdateSchema(),
+	})
+
+	// Register verification tools
+	Register(ToolSubmitVerification, createSubmitVerificationTool, &ToolMeta{
+		Name:        ToolSubmitVerification,
+		Description: "Submit structured acceptance-criteria verification evidence",
+		InputSchema: getSubmitVerificationSchema(),
 	})
 
 	// Register architect read tools

--- a/pkg/tools/submit_verification.go
+++ b/pkg/tools/submit_verification.go
@@ -118,9 +118,11 @@ func (s *SubmitVerificationTool) Exec(_ context.Context, args map[string]any) (*
 		return nil, fmt.Errorf("acceptance_criteria_checked must contain at least 1 item")
 	}
 
-	// Validate each criterion and determine pass/fail signal
+	// Validate each criterion and determine pass/fail signal.
+	// Emit []any of map[string]any so consumers see the same shape
+	// whether they receive data directly or after JSON-roundtrip (resume).
 	hasFail := false
-	validatedCriteria := make([]map[string]string, 0, len(criteriaArr))
+	validatedCriteria := make([]any, 0, len(criteriaArr))
 
 	for i, item := range criteriaArr {
 		criterion, ok := item.(map[string]any)
@@ -137,11 +139,16 @@ func (s *SubmitVerificationTool) Exec(_ context.Context, args map[string]any) (*
 			hasFail = true
 		}
 
-		validatedCriteria = append(validatedCriteria, validated)
+		// Convert map[string]string → map[string]any for consumer compatibility
+		criterionMap := make(map[string]any, len(validated))
+		for k, v := range validated {
+			criterionMap[k] = v
+		}
+		validatedCriteria = append(validatedCriteria, criterionMap)
 	}
 
-	// Extract optional gaps
-	var gaps []string
+	// Extract optional gaps as []any for consumer compatibility
+	var gaps []any
 	if gapsRaw, ok := args["gaps"]; ok {
 		if gapsArr, ok := gapsRaw.([]any); ok {
 			for _, g := range gapsArr {

--- a/pkg/tools/submit_verification.go
+++ b/pkg/tools/submit_verification.go
@@ -1,0 +1,217 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+)
+
+// SubmitVerificationTool is the terminal tool for the TESTING verification toolloop.
+// The LLM calls this to submit structured acceptance-criteria verification evidence.
+type SubmitVerificationTool struct{}
+
+// NewSubmitVerificationTool creates a new submit verification tool instance.
+func NewSubmitVerificationTool() *SubmitVerificationTool {
+	return &SubmitVerificationTool{}
+}
+
+// Name returns the tool identifier.
+func (s *SubmitVerificationTool) Name() string {
+	return ToolSubmitVerification
+}
+
+// Definition returns the tool's definition in Claude API format.
+func (s *SubmitVerificationTool) Definition() ToolDefinition {
+	minItems := 1
+	return ToolDefinition{
+		Name:        ToolSubmitVerification,
+		Description: "Submit structured acceptance-criteria verification evidence. Call this once you have inspected the implementation against each acceptance criterion.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"acceptance_criteria_checked": {
+					Type:        "array",
+					Description: "Results for each acceptance criterion checked",
+					Items: &Property{
+						Type: "object",
+						Properties: map[string]*Property{
+							"criterion": {
+								Type:        "string",
+								Description: "The acceptance criterion being verified",
+							},
+							"method": {
+								Type:        "string",
+								Description: "How the criterion was verified",
+								Enum:        []string{"command", "inspection"},
+							},
+							"result": {
+								Type:        "string",
+								Description: "Verification result",
+								Enum:        []string{"pass", "fail", "partial", "unverified"},
+							},
+							"evidence": {
+								Type:        "string",
+								Description: "Specific evidence supporting the result (file paths, command output, etc.)",
+							},
+						},
+						Required: []string{"criterion", "method", "result", "evidence"},
+					},
+					MinItems: &minItems,
+				},
+				"gaps": {
+					Type:        "array",
+					Description: "Any gaps or missing items found during verification",
+					Items: &Property{
+						Type: "string",
+					},
+				},
+				"confidence": {
+					Type:        "string",
+					Description: "Overall confidence in the verification",
+					Enum:        []string{"high", "medium", "low"},
+				},
+				"summary": {
+					Type:        "string",
+					Description: "Brief summary of verification findings",
+				},
+			},
+			Required: []string{"acceptance_criteria_checked", "confidence", "summary"},
+		},
+	}
+}
+
+// PromptDocumentation returns markdown documentation for LLM prompts.
+func (s *SubmitVerificationTool) PromptDocumentation() string {
+	return `- **submit_verification** - Submit acceptance-criteria verification evidence
+  - Parameters: acceptance_criteria_checked (required array), confidence (required), summary (required), gaps (optional)
+  - Each criterion needs: criterion, method (command|inspection), result (pass|fail|partial|unverified), evidence
+  - Call this after inspecting the implementation against each acceptance criterion`
+}
+
+// Exec validates and processes the verification submission.
+//
+//nolint:cyclop // Validation logic is inherently sequential; splitting would reduce clarity
+func (s *SubmitVerificationTool) Exec(_ context.Context, args map[string]any) (*ExecResult, error) {
+	// Validate required fields
+	summary, err := extractRequiredString(args, "summary")
+	if err != nil {
+		return nil, err
+	}
+
+	confidence, err := extractRequiredString(args, "confidence")
+	if err != nil {
+		return nil, err
+	}
+	if !isValidConfidence(confidence) {
+		return nil, fmt.Errorf("confidence must be high, medium, or low")
+	}
+
+	// Validate acceptance_criteria_checked
+	criteriaRaw, ok := args["acceptance_criteria_checked"]
+	if !ok {
+		return nil, fmt.Errorf("acceptance_criteria_checked parameter is required")
+	}
+	criteriaArr, ok := criteriaRaw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("acceptance_criteria_checked must be an array")
+	}
+	if len(criteriaArr) == 0 {
+		return nil, fmt.Errorf("acceptance_criteria_checked must contain at least 1 item")
+	}
+
+	// Validate each criterion and determine pass/fail signal
+	hasFail := false
+	validatedCriteria := make([]map[string]string, 0, len(criteriaArr))
+
+	for i, item := range criteriaArr {
+		criterion, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("acceptance_criteria_checked item %d must be an object", i)
+		}
+
+		validated, err := validateCriterion(i, criterion)
+		if err != nil {
+			return nil, err
+		}
+
+		if validated["result"] == "fail" {
+			hasFail = true
+		}
+
+		validatedCriteria = append(validatedCriteria, validated)
+	}
+
+	// Extract optional gaps
+	var gaps []string
+	if gapsRaw, ok := args["gaps"]; ok {
+		if gapsArr, ok := gapsRaw.([]any); ok {
+			for _, g := range gapsArr {
+				if gs, ok := g.(string); ok {
+					gaps = append(gaps, gs)
+				}
+			}
+		}
+	}
+
+	// Determine signal based on results
+	signal := SignalVerificationPass
+	if hasFail {
+		signal = SignalVerificationFail
+	}
+
+	return &ExecResult{
+		Content: "Verification evidence submitted",
+		ProcessEffect: &ProcessEffect{
+			Signal: signal,
+			Data: map[string]any{
+				"acceptance_criteria_checked": validatedCriteria,
+				"gaps":                        gaps,
+				"confidence":                  confidence,
+				"summary":                     summary,
+			},
+		},
+	}, nil
+}
+
+func isValidMethod(s string) bool {
+	return s == "command" || s == "inspection"
+}
+
+func isValidResult(s string) bool {
+	return s == "pass" || s == "fail" || s == "partial" || s == "unverified"
+}
+
+func isValidConfidence(s string) bool {
+	return s == "high" || s == "medium" || s == "low"
+}
+
+// validateCriterion validates a single criterion object and returns validated fields.
+func validateCriterion(index int, criterion map[string]any) (map[string]string, error) {
+	prefix := fmt.Sprintf("acceptance_criteria_checked item %d", index)
+
+	criterionText, ok := criterion["criterion"].(string)
+	if !ok || criterionText == "" {
+		return nil, fmt.Errorf("%s: criterion field is required and must be a non-empty string", prefix)
+	}
+
+	method, ok := criterion["method"].(string)
+	if !ok || !isValidMethod(method) {
+		return nil, fmt.Errorf("%s: method must be 'command' or 'inspection'", prefix)
+	}
+
+	result, ok := criterion["result"].(string)
+	if !ok || !isValidResult(result) {
+		return nil, fmt.Errorf("%s: result must be 'pass', 'fail', 'partial', or 'unverified'", prefix)
+	}
+
+	evidence, ok := criterion["evidence"].(string)
+	if !ok || evidence == "" {
+		return nil, fmt.Errorf("%s: evidence field is required and must be a non-empty string", prefix)
+	}
+
+	return map[string]string{
+		"criterion": criterionText,
+		"method":    method,
+		"result":    result,
+		"evidence":  evidence,
+	}, nil
+}

--- a/pkg/tools/submit_verification.go
+++ b/pkg/tools/submit_verification.go
@@ -147,15 +147,21 @@ func (s *SubmitVerificationTool) Exec(_ context.Context, args map[string]any) (*
 		validatedCriteria = append(validatedCriteria, criterionMap)
 	}
 
-	// Extract optional gaps as []any for consumer compatibility
+	// Extract optional gaps as []any for consumer compatibility.
+	// If provided, gaps must be an array of strings — fail fast on invalid shapes.
 	var gaps []any
 	if gapsRaw, ok := args["gaps"]; ok {
-		if gapsArr, ok := gapsRaw.([]any); ok {
-			for _, g := range gapsArr {
-				if gs, ok := g.(string); ok {
-					gaps = append(gaps, gs)
-				}
+		gapsArr, ok := gapsRaw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("gaps must be an array")
+		}
+		gaps = make([]any, 0, len(gapsArr))
+		for i, g := range gapsArr {
+			gs, ok := g.(string)
+			if !ok {
+				return nil, fmt.Errorf("gaps item %d must be a string", i)
 			}
+			gaps = append(gaps, gs)
 		}
 	}
 

--- a/pkg/tools/submit_verification_test.go
+++ b/pkg/tools/submit_verification_test.go
@@ -272,6 +272,35 @@ func TestSubmitVerification_MalformedCriterionObject(t *testing.T) {
 	}
 }
 
+func TestSubmitVerification_InvalidGaps(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	tests := []struct {
+		name string
+		gaps any
+	}{
+		{"non-array gaps", "not an array"},
+		{"non-string gap item", []any{42}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := map[string]any{
+				"acceptance_criteria_checked": []any{
+					map[string]any{"criterion": "A", "method": "command", "result": "pass", "evidence": "ok"},
+				},
+				"gaps":       tt.gaps,
+				"confidence": "high",
+				"summary":    "done",
+			}
+			_, err := tool.Exec(context.Background(), args)
+			if err == nil {
+				t.Errorf("Expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
 func TestSubmitVerification_NonObjectCriterion(t *testing.T) {
 	tool := NewSubmitVerificationTool()
 

--- a/pkg/tools/submit_verification_test.go
+++ b/pkg/tools/submit_verification_test.go
@@ -1,0 +1,287 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSubmitVerification_AllPass(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{
+				"criterion": "API endpoint returns 200",
+				"method":    "command",
+				"result":    "pass",
+				"evidence":  "curl returned 200 OK",
+			},
+			map[string]any{
+				"criterion": "Tests cover edge cases",
+				"method":    "inspection",
+				"result":    "pass",
+				"evidence":  "Found 5 test cases covering edge cases in test_foo.go",
+			},
+		},
+		"confidence": "high",
+		"summary":    "All criteria verified",
+	}
+
+	result, err := tool.Exec(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if result.ProcessEffect == nil {
+		t.Fatal("Expected ProcessEffect")
+	}
+	if result.ProcessEffect.Signal != SignalVerificationPass {
+		t.Errorf("Expected %s, got %s", SignalVerificationPass, result.ProcessEffect.Signal)
+	}
+
+	data, ok := result.ProcessEffect.Data.(map[string]any)
+	if !ok {
+		t.Fatal("Expected map[string]any data")
+	}
+	if data["confidence"] != "high" {
+		t.Errorf("Expected confidence 'high', got %v", data["confidence"])
+	}
+}
+
+func TestSubmitVerification_OneFail(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{
+				"criterion": "API endpoint returns 200",
+				"method":    "command",
+				"result":    "pass",
+				"evidence":  "curl returned 200 OK",
+			},
+			map[string]any{
+				"criterion": "Error handling for invalid input",
+				"method":    "inspection",
+				"result":    "fail",
+				"evidence":  "No validation found in handler.go",
+			},
+		},
+		"gaps":       []any{"Missing input validation"},
+		"confidence": "medium",
+		"summary":    "One criterion failed",
+	}
+
+	result, err := tool.Exec(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if result.ProcessEffect.Signal != SignalVerificationFail {
+		t.Errorf("Expected %s, got %s", SignalVerificationFail, result.ProcessEffect.Signal)
+	}
+
+	data, ok := result.ProcessEffect.Data.(map[string]any)
+	if !ok {
+		t.Fatal("Expected map[string]any data")
+	}
+	gaps, _ := data["gaps"].([]string)
+	if len(gaps) != 1 || gaps[0] != "Missing input validation" {
+		t.Errorf("Expected gaps to contain 'Missing input validation', got %v", gaps)
+	}
+}
+
+func TestSubmitVerification_MixedResults(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{"criterion": "A", "method": "command", "result": "pass", "evidence": "ok"},
+			map[string]any{"criterion": "B", "method": "inspection", "result": "partial", "evidence": "half done"},
+			map[string]any{"criterion": "C", "method": "command", "result": "unverified", "evidence": "needs runtime"},
+		},
+		"confidence": "low",
+		"summary":    "Mixed results",
+	}
+
+	result, err := tool.Exec(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	// No "fail" results → should be pass signal
+	if result.ProcessEffect.Signal != SignalVerificationPass {
+		t.Errorf("Expected %s (no fails), got %s", SignalVerificationPass, result.ProcessEffect.Signal)
+	}
+}
+
+func TestSubmitVerification_MissingSummary(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{"criterion": "A", "method": "command", "result": "pass", "evidence": "ok"},
+		},
+		"confidence": "high",
+	}
+
+	_, err := tool.Exec(context.Background(), args)
+	if err == nil {
+		t.Fatal("Expected error for missing summary")
+	}
+}
+
+func TestSubmitVerification_MissingConfidence(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{"criterion": "A", "method": "command", "result": "pass", "evidence": "ok"},
+		},
+		"summary": "done",
+	}
+
+	_, err := tool.Exec(context.Background(), args)
+	if err == nil {
+		t.Fatal("Expected error for missing confidence")
+	}
+}
+
+func TestSubmitVerification_InvalidConfidence(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{"criterion": "A", "method": "command", "result": "pass", "evidence": "ok"},
+		},
+		"confidence": "very_high",
+		"summary":    "done",
+	}
+
+	_, err := tool.Exec(context.Background(), args)
+	if err == nil {
+		t.Fatal("Expected error for invalid confidence")
+	}
+}
+
+func TestSubmitVerification_EmptyCriteria(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{},
+		"confidence":                  "high",
+		"summary":                     "done",
+	}
+
+	_, err := tool.Exec(context.Background(), args)
+	if err == nil {
+		t.Fatal("Expected error for empty criteria array")
+	}
+}
+
+func TestSubmitVerification_MissingCriteria(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"confidence": "high",
+		"summary":    "done",
+	}
+
+	_, err := tool.Exec(context.Background(), args)
+	if err == nil {
+		t.Fatal("Expected error for missing criteria")
+	}
+}
+
+func TestSubmitVerification_InvalidMethod(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{"criterion": "A", "method": "magic", "result": "pass", "evidence": "ok"},
+		},
+		"confidence": "high",
+		"summary":    "done",
+	}
+
+	_, err := tool.Exec(context.Background(), args)
+	if err == nil {
+		t.Fatal("Expected error for invalid method")
+	}
+}
+
+func TestSubmitVerification_InvalidResult(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{
+			map[string]any{"criterion": "A", "method": "command", "result": "maybe", "evidence": "ok"},
+		},
+		"confidence": "high",
+		"summary":    "done",
+	}
+
+	_, err := tool.Exec(context.Background(), args)
+	if err == nil {
+		t.Fatal("Expected error for invalid result enum")
+	}
+}
+
+func TestSubmitVerification_MalformedCriterionObject(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	tests := []struct {
+		name string
+		item map[string]any
+	}{
+		{"missing criterion", map[string]any{"method": "command", "result": "pass", "evidence": "ok"}},
+		{"missing method", map[string]any{"criterion": "A", "result": "pass", "evidence": "ok"}},
+		{"missing result", map[string]any{"criterion": "A", "method": "command", "evidence": "ok"}},
+		{"missing evidence", map[string]any{"criterion": "A", "method": "command", "result": "pass"}},
+		{"empty criterion", map[string]any{"criterion": "", "method": "command", "result": "pass", "evidence": "ok"}},
+		{"empty evidence", map[string]any{"criterion": "A", "method": "command", "result": "pass", "evidence": ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := map[string]any{
+				"acceptance_criteria_checked": []any{tt.item},
+				"confidence":                  "high",
+				"summary":                     "done",
+			}
+			_, err := tool.Exec(context.Background(), args)
+			if err == nil {
+				t.Errorf("Expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestSubmitVerification_NonObjectCriterion(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	args := map[string]any{
+		"acceptance_criteria_checked": []any{"not an object"},
+		"confidence":                  "high",
+		"summary":                     "done",
+	}
+
+	_, err := tool.Exec(context.Background(), args)
+	if err == nil {
+		t.Fatal("Expected error for non-object criterion")
+	}
+}
+
+func TestSubmitVerification_ToolMetadata(t *testing.T) {
+	tool := NewSubmitVerificationTool()
+
+	if tool.Name() != ToolSubmitVerification {
+		t.Errorf("Expected name %q, got %q", ToolSubmitVerification, tool.Name())
+	}
+
+	def := tool.Definition()
+	if def.Name != ToolSubmitVerification {
+		t.Errorf("Expected definition name %q, got %q", ToolSubmitVerification, def.Name)
+	}
+
+	doc := tool.PromptDocumentation()
+	if doc == "" {
+		t.Error("Expected non-empty prompt documentation")
+	}
+}

--- a/pkg/tools/submit_verification_test.go
+++ b/pkg/tools/submit_verification_test.go
@@ -45,6 +45,22 @@ func TestSubmitVerification_AllPass(t *testing.T) {
 	if data["confidence"] != "high" {
 		t.Errorf("Expected confidence 'high', got %v", data["confidence"])
 	}
+
+	// Verify emitted criteria are []any of map[string]any (not []map[string]string)
+	criteria, ok := data["acceptance_criteria_checked"].([]any)
+	if !ok {
+		t.Fatal("Expected acceptance_criteria_checked to be []any")
+	}
+	if len(criteria) != 2 {
+		t.Fatalf("Expected 2 criteria, got %d", len(criteria))
+	}
+	firstCriterion, ok := criteria[0].(map[string]any)
+	if !ok {
+		t.Fatal("Expected criterion item to be map[string]any")
+	}
+	if firstCriterion["criterion"] != "API endpoint returns 200" {
+		t.Errorf("Expected criterion text, got %v", firstCriterion["criterion"])
+	}
 }
 
 func TestSubmitVerification_OneFail(t *testing.T) {
@@ -82,9 +98,12 @@ func TestSubmitVerification_OneFail(t *testing.T) {
 	if !ok {
 		t.Fatal("Expected map[string]any data")
 	}
-	gaps, _ := data["gaps"].([]string)
-	if len(gaps) != 1 || gaps[0] != "Missing input validation" {
-		t.Errorf("Expected gaps to contain 'Missing input validation', got %v", gaps)
+	gaps, ok := data["gaps"].([]any)
+	if !ok || len(gaps) != 1 {
+		t.Fatalf("Expected gaps []any with 1 element, got %v", data["gaps"])
+	}
+	if gs, ok := gaps[0].(string); !ok || gs != "Missing input validation" {
+		t.Errorf("Expected gaps[0] to be 'Missing input validation', got %v", gaps[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a bounded, read-only LLM verification loop to TESTING that checks whether the implementation satisfies the story's acceptance criteria before proceeding to CODE_REVIEW
- After deterministic checks (build/test/lint) pass, a fresh-context verifier inspects changed files via shell tool and produces structured evidence (per-criterion pass/fail/partial/unverified)
- Verification failures route back to CODING with actionable gap messages; unavailable results (LLM error, timeout) proceed to CODE_REVIEW with explicit "unavailable" status

### Key design choices
- **Shell-only verifier**: avoids container path issues with read_file/get_diff (built for architect, not coder)
- **Three-state result**: explicit pass/fail/unavailable (not bool), stored in state every run
- **Fresh ContextManager**: isolated from coder's main context
- **Network disabled, max 5 iterations, temperature 0.2**
- **Resume-safe**: `rehydrateVerificationOutcome()` handles both typed struct and map[string]any after state persistence roundtrip
- **Producer-consumer type alignment**: tool emits []any of map[string]any matching JSON roundtrip shape
- **Executor limitation documented**: docker exec doesn't enforce ReadOnly/NetworkDisabled flags yet

### Files changed
| File | Change |
|---|---|
| `pkg/tools/submit_verification.go` | New terminal tool with structured evidence schema |
| `pkg/tools/submit_verification_test.go` | 13 test cases + type shape assertions |
| `pkg/tools/constants.go` | `ToolSubmitVerification` constant + `VerificationTools` list |
| `pkg/tools/mcp.go` | `SignalVerificationPass` / `SignalVerificationFail` |
| `pkg/tools/registry.go` | Register submit_verification |
| `pkg/templates/coder/testing_verification.tpl.md` | Verification system prompt template |
| `pkg/templates/renderer.go` | `TestingVerificationTemplate` constant + registration |
| `pkg/coder/verification.go` | Verification loop, status types, rehydration, evidence formatting |
| `pkg/coder/verification_test.go` | 15 tests: formatting, rehydration, producer→consumer round-trip |
| `pkg/coder/coder_fsm.go` | `KeyVerificationEvidence` state key |
| `pkg/coder/testing.go` | Clear stale evidence, wire verification into `proceedToCodeReviewWithLintCheck` |
| `pkg/coder/code_review.go` | Consume verification evidence with resume-safe rehydration |
| `docs/CODER_EXTERNAL_REFERENCE_ARCHITECTURE_RESEARCH_BRIEF.md` | Mark Stage 3A complete |

## Test plan

- [x] `make build` — compiles clean
- [x] `make lint` — no linting issues
- [x] `make test` — all unit tests pass
- [x] Integration tests pass (pre-push hook)
- [x] Producer→consumer round-trip tests verify tool output flows correctly to both consumers
- [x] Rehydration tests verify evidence survives state persistence roundtrip
- [x] All submit_verification validation edge cases covered (malformed objects, invalid enums, empty arrays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)