### PR TITLE
Fix interview chat scroll bleed-through (#182)

### DIFF
--- a/pkg/webui/web/templates/pm_pane.html
+++ b/pkg/webui/web/templates/pm_pane.html
@@ -62,7 +62,7 @@
 
             <!-- Interview Chat (shown when session is active) -->
             <div id="interview-chat-section" class="hidden">
-                <div class="border border-gray-200 rounded-lg p-4 mb-3 overflow-y-auto" style="height: 300px;">
+                <div class="border border-gray-200 rounded-lg p-4 mb-3 overflow-y-auto" style="height: 300px; overscroll-behavior: contain;">
                     <div id="interview-messages" class="space-y-3">
                         <!-- Dynamic interview messages -->
                     </div>


### PR DESCRIPTION
## Summary
- Add `overscroll-behavior: contain` to the PM interview chat scroll container to prevent scroll events from propagating to the page when reaching the top/bottom boundary

Closes #182

## Test plan
- [ ] Start a PM interview session
- [ ] Scroll to the bottom of the chat container — page should not scroll
- [ ] Scroll to the top of the chat container — page should not scroll
- [ ] Scroll outside the chat container — page scrolls normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)