### PR TITLE
Fix budget review feedback loop: inject APPROVED guidance into coder context

### DIFF
--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -542,7 +542,10 @@ func (d *Driver) buildApprovalResponseFromReviewComplete(ctx context.Context, re
 		d.logger.Warn("Unknown status %s, defaulting to NEEDS_CHANGES", statusStr)
 	}
 
-	if feedback == "" {
+	// For budget reviews, preserve empty feedback so the coder-side empty check works
+	// (non-empty feedback gets injected into coder context; empty = no-op).
+	// For all other review types, use a generic placeholder to avoid empty responses.
+	if feedback == "" && approvalType != proto.ApprovalTypeBudgetReview {
 		feedback = "Review completed via single-turn review"
 	}
 

--- a/pkg/architect/request_budget_test.go
+++ b/pkg/architect/request_budget_test.go
@@ -1,0 +1,118 @@
+package architect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"orchestrator/pkg/proto"
+)
+
+// TestBuildApprovalResponse_BudgetReview_PreservesEmptyFeedback verifies that budget reviews
+// with empty feedback keep it empty (so the coder-side no-op check works).
+func TestBuildApprovalResponse_BudgetReview_PreservesEmptyFeedback(t *testing.T) {
+	driver := newTestDriver()
+
+	// Create a request message with budget review payload
+	requestMsg := proto.NewAgentMsg(proto.MsgTypeREQUEST, "coder-001", "architect-001")
+	proto.SetStoryID(requestMsg, "story-123")
+	approvalPayload := &proto.ApprovalRequestPayload{
+		ApprovalType: proto.ApprovalTypeBudgetReview,
+		Content:      "Budget review request",
+	}
+	requestMsg.SetTypedPayload(proto.NewApprovalRequestPayload(approvalPayload))
+
+	response, err := driver.buildApprovalResponseFromReviewComplete(
+		context.Background(), requestMsg, approvalPayload, reviewStatusApproved, "")
+	require.NoError(t, err)
+
+	// Extract the approval result from the response
+	typedPayload := response.GetTypedPayload()
+	require.NotNil(t, typedPayload)
+	approvalResponse, err := typedPayload.ExtractApprovalResponse()
+	require.NoError(t, err)
+
+	// Empty feedback should be preserved for budget reviews
+	assert.Empty(t, approvalResponse.Feedback, "budget review empty feedback should be preserved as empty")
+}
+
+// TestBuildApprovalResponse_CodeReview_FillsPlaceholder verifies that non-budget reviews
+// with empty feedback get the generic placeholder.
+func TestBuildApprovalResponse_CodeReview_FillsPlaceholder(t *testing.T) {
+	driver := newTestDriver()
+
+	requestMsg := proto.NewAgentMsg(proto.MsgTypeREQUEST, "coder-001", "architect-001")
+	proto.SetStoryID(requestMsg, "story-123")
+	approvalPayload := &proto.ApprovalRequestPayload{
+		ApprovalType: proto.ApprovalTypeCode,
+		Content:      "Code review request",
+	}
+	requestMsg.SetTypedPayload(proto.NewApprovalRequestPayload(approvalPayload))
+
+	response, err := driver.buildApprovalResponseFromReviewComplete(
+		context.Background(), requestMsg, approvalPayload, reviewStatusApproved, "")
+	require.NoError(t, err)
+
+	typedPayload := response.GetTypedPayload()
+	require.NotNil(t, typedPayload)
+	approvalResponse, err := typedPayload.ExtractApprovalResponse()
+	require.NoError(t, err)
+
+	assert.Equal(t, "Review completed via single-turn review", approvalResponse.Feedback,
+		"non-budget review empty feedback should get placeholder")
+}
+
+// TestBuildApprovalResponse_BudgetReview_NonEmptyFeedbackPreserved verifies that budget reviews
+// with non-empty feedback pass it through unchanged.
+func TestBuildApprovalResponse_BudgetReview_NonEmptyFeedbackPreserved(t *testing.T) {
+	driver := newTestDriver()
+
+	requestMsg := proto.NewAgentMsg(proto.MsgTypeREQUEST, "coder-001", "architect-001")
+	proto.SetStoryID(requestMsg, "story-123")
+	approvalPayload := &proto.ApprovalRequestPayload{
+		ApprovalType: proto.ApprovalTypeBudgetReview,
+		Content:      "Budget review request",
+	}
+	requestMsg.SetTypedPayload(proto.NewApprovalRequestPayload(approvalPayload))
+
+	feedback := "The work is complete. Call the done tool now."
+	response, err := driver.buildApprovalResponseFromReviewComplete(
+		context.Background(), requestMsg, approvalPayload, reviewStatusApproved, feedback)
+	require.NoError(t, err)
+
+	typedPayload := response.GetTypedPayload()
+	require.NotNil(t, typedPayload)
+	approvalResponse, err := typedPayload.ExtractApprovalResponse()
+	require.NoError(t, err)
+
+	assert.Equal(t, feedback, approvalResponse.Feedback,
+		"budget review non-empty feedback should be passed through")
+}
+
+// TestBuildApprovalResponse_CompletionReview_FillsPlaceholder verifies that completion reviews
+// also get the placeholder on empty feedback.
+func TestBuildApprovalResponse_CompletionReview_FillsPlaceholder(t *testing.T) {
+	driver := newTestDriver()
+
+	requestMsg := proto.NewAgentMsg(proto.MsgTypeREQUEST, "coder-001", "architect-001")
+	proto.SetStoryID(requestMsg, "story-123")
+	approvalPayload := &proto.ApprovalRequestPayload{
+		ApprovalType: proto.ApprovalTypeCompletion,
+		Content:      "Completion request",
+	}
+	requestMsg.SetTypedPayload(proto.NewApprovalRequestPayload(approvalPayload))
+
+	response, err := driver.buildApprovalResponseFromReviewComplete(
+		context.Background(), requestMsg, approvalPayload, reviewStatusApproved, "")
+	require.NoError(t, err)
+
+	typedPayload := response.GetTypedPayload()
+	require.NotNil(t, typedPayload)
+	approvalResponse, err := typedPayload.ExtractApprovalResponse()
+	require.NoError(t, err)
+
+	assert.Equal(t, "Review completed via single-turn review", approvalResponse.Feedback,
+		"completion review empty feedback should get placeholder")
+}

--- a/pkg/coder/budget_review.go
+++ b/pkg/coder/budget_review.go
@@ -66,9 +66,22 @@ func (c *Coder) processBudgetReviewStatus(sm *agent.BaseStateMachine, status pro
 		// CONTINUE/PIVOT - return to origin state and reset counters.
 		c.logger.Info("🧑‍💻 Budget review approved, returning to origin state: %s", originStr)
 
-		// Note: We do NOT add architect messages here, as they add noise to the conversation
-		// and can confuse the LLM. The empty response validator will provide appropriate
-		// guidance if the LLM continues to have issues with tool usage.
+		// Inject architect feedback if non-empty (e.g., "call done", "submit plan").
+		// Empty feedback is preserved as empty by the architect response builder for budget reviews,
+		// so this only fires when the architect has explicit guidance.
+		if feedback != "" && c.renderer != nil {
+			templateData := map[string]any{
+				"Status":   status.String(),
+				"Feedback": feedback,
+			}
+			renderedMessage, err := c.renderer.RenderSimple(templates.BudgetReviewApprovedFeedbackTemplate, templateData)
+			if err != nil {
+				c.logger.Error("Failed to render approved budget review feedback: %v", err)
+				renderedMessage = feedback // Fallback to raw feedback
+			}
+			c.contextManager.AddMessage("architect", renderedMessage)
+			c.logger.Debug("🧑‍💻 Injected architect approved feedback into coder context")
+		}
 
 		// Reset NEEDS_CHANGES counter on approval
 		sm.SetStateData(KeyNeedsChangesCount, 0)

--- a/pkg/coder/budget_review.go
+++ b/pkg/coder/budget_review.go
@@ -2,6 +2,7 @@ package coder
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"orchestrator/pkg/agent"
@@ -69,7 +70,7 @@ func (c *Coder) processBudgetReviewStatus(sm *agent.BaseStateMachine, status pro
 		// Inject architect feedback if non-empty (e.g., "call done", "submit plan").
 		// Empty feedback is preserved as empty by the architect response builder for budget reviews,
 		// so this only fires when the architect has explicit guidance.
-		if feedback != "" && c.renderer != nil {
+		if strings.TrimSpace(feedback) != "" && c.renderer != nil {
 			templateData := map[string]any{
 				"Status":   status.String(),
 				"Feedback": feedback,

--- a/pkg/coder/budget_review_test.go
+++ b/pkg/coder/budget_review_test.go
@@ -482,6 +482,124 @@ func TestFormatMessageForBudgetReview_MultipleToolCalls(t *testing.T) {
 	}
 }
 
+// TestBudgetReviewApproved_NonEmptyFeedbackInjected verifies that APPROVED with non-empty
+// feedback injects the architect's guidance into the coder's context.
+func TestBudgetReviewApproved_NonEmptyFeedbackInjected(t *testing.T) {
+	logger := logx.NewLogger("coder-test")
+	sm := agent.NewBaseStateMachine("test-coder", StateBudgetReview, nil, CoderTransitions)
+	sm.SetStateData(KeyOrigin, string(StateCoding))
+
+	renderer, rendererErr := templates.NewRenderer()
+	if rendererErr != nil {
+		t.Fatalf("Failed to create renderer: %v", rendererErr)
+	}
+	cm := contextmgr.NewContextManager()
+	cm.ResetSystemPrompt("You are a coding agent.")
+
+	c := &Coder{
+		BaseStateMachine: sm,
+		logger:           logger,
+		contextManager:   cm,
+		renderer:         renderer,
+	}
+
+	// Flush initial state to get a baseline message count
+	if flushErr := cm.FlushUserBuffer(context.Background()); flushErr != nil {
+		t.Fatalf("FlushUserBuffer failed: %v", flushErr)
+	}
+	baselineCount := cm.GetMessageCount()
+
+	// Process APPROVED with non-empty feedback
+	result := &effect.BudgetReviewResult{
+		Status:   proto.ApprovalStatusApproved,
+		Feedback: "The work is complete. Call the done tool now.",
+	}
+
+	nextState, _, err := c.processBudgetReviewResult(context.Background(), sm, result)
+	if err != nil {
+		t.Fatalf("processBudgetReviewResult failed: %v", err)
+	}
+
+	if nextState != StateCoding {
+		t.Errorf("Expected StateCoding, got %s", nextState)
+	}
+
+	// Flush the buffer so the injected message lands in messages
+	if flushErr := cm.FlushUserBuffer(context.Background()); flushErr != nil {
+		t.Fatalf("FlushUserBuffer failed: %v", flushErr)
+	}
+
+	// Verify a message was added (feedback was injected)
+	newCount := cm.GetMessageCount()
+	if newCount <= baselineCount {
+		t.Errorf("Expected message count to increase (feedback injection), got %d -> %d", baselineCount, newCount)
+	}
+
+	// Verify the injected message contains the feedback
+	messages := cm.GetMessages()
+	lastMsg := messages[len(messages)-1]
+	if !strings.Contains(lastMsg.Content, "Call the done tool now") {
+		t.Errorf("Injected message should contain feedback, got: %s", lastMsg.Content)
+	}
+	if !strings.Contains(lastMsg.Content, "ARCHITECT GUIDANCE") {
+		t.Errorf("Injected message should use approved template framing, got: %s", lastMsg.Content)
+	}
+}
+
+// TestBudgetReviewApproved_EmptyFeedbackNoOp verifies that APPROVED with empty feedback
+// does NOT inject anything into the coder's context.
+func TestBudgetReviewApproved_EmptyFeedbackNoOp(t *testing.T) {
+	logger := logx.NewLogger("coder-test")
+	sm := agent.NewBaseStateMachine("test-coder", StateBudgetReview, nil, CoderTransitions)
+	sm.SetStateData(KeyOrigin, string(StateCoding))
+
+	renderer, rendererErr := templates.NewRenderer()
+	if rendererErr != nil {
+		t.Fatalf("Failed to create renderer: %v", rendererErr)
+	}
+	cm := contextmgr.NewContextManager()
+	cm.ResetSystemPrompt("You are a coding agent.")
+
+	c := &Coder{
+		BaseStateMachine: sm,
+		logger:           logger,
+		contextManager:   cm,
+		renderer:         renderer,
+	}
+
+	// Flush initial state to get a baseline message count
+	if flushErr := cm.FlushUserBuffer(context.Background()); flushErr != nil {
+		t.Fatalf("FlushUserBuffer failed: %v", flushErr)
+	}
+	baselineCount := cm.GetMessageCount()
+
+	// Process APPROVED with empty feedback
+	result := &effect.BudgetReviewResult{
+		Status:   proto.ApprovalStatusApproved,
+		Feedback: "",
+	}
+
+	nextState, _, err := c.processBudgetReviewResult(context.Background(), sm, result)
+	if err != nil {
+		t.Fatalf("processBudgetReviewResult failed: %v", err)
+	}
+
+	if nextState != StateCoding {
+		t.Errorf("Expected StateCoding, got %s", nextState)
+	}
+
+	// Flush the buffer
+	if err := cm.FlushUserBuffer(context.Background()); err != nil {
+		t.Fatalf("FlushUserBuffer failed: %v", err)
+	}
+
+	// Verify NO message was added
+	newCount := cm.GetMessageCount()
+	if newCount != baselineCount {
+		t.Errorf("Expected no new messages (empty feedback), but count changed: %d -> %d", baselineCount, newCount)
+	}
+}
+
 // getMapKeys returns the keys of a map for debugging.
 func getMapKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))

--- a/pkg/templates/architect/budget_review_coding.tpl.md
+++ b/pkg/templates/architect/budget_review_coding.tpl.md
@@ -45,9 +45,9 @@ The request above contains all context including budget details, recent messages
 - **IMPORTANT**: Do NOT use REJECTED for work that is genuinely complete. REJECTED means "abandon the story" — use it only for stories that are impossible or fundamentally blocked.
 
 **Issue**: Work appears complete but agent hasn't called 'done' tool
-- **Pattern**: Agent has created all required files, code compiles/runs successfully, but continues refining or rewriting working code
-- **Correct Response**: Use APPROVED status with empty feedback field. The budget approval message will automatically remind the agent to call 'done' if work is substantially complete.
-- **Why**: This lets the architect validate completion without micromanaging. The agent should recognize when requirements are met.
+- **Pattern**: Agent has created all required files, code compiles/runs successfully, but has not called `done`
+- **Correct Response**: Use APPROVED status with explicit feedback: "The work is complete and meets acceptance criteria. Call the `done` tool now to mark the story complete."
+- **Why**: Empty feedback is not forwarded to the agent. Always provide explicit instructions so the agent knows what to do next.
 
 **Issue**: Not following approved plan
 - **Wrong**: Deviating from planned implementation approach
@@ -62,6 +62,12 @@ The request above contains all context including budget details, recent messages
 - **Wrong**: Telling the coder to ignore the failures or accusing them of getting distracted
 - **Correct**: All tests must pass before a story can be merged, regardless of whether the failures originated from the current story. The coder should fix them. Provide guidance if the fix is obvious.
 - **Why**: The codebase must remain in a passing state. Pre-existing failures that slip through indicate a gap in prior validation, but the current coder is responsible for leaving the codebase green.
+
+**Issue**: Repeated budget reviews with the same guidance being ignored
+- **Pattern**: You have previously approved or given NEEDS_CHANGES to this agent with specific guidance (e.g., "call `done`", "submit your plan"), but the agent continues the same behavior without acting on it
+- **Detection**: The conversation context shows 2-3 prior budget review responses where you gave the same or equivalent feedback that was not acted upon
+- **Correct Response**: Use REJECTED status. If your guidance has been given multiple times and ignored, the agent is stuck in a loop it cannot break out of. Rejecting allows the system to reassign or escalate the story rather than burning tokens indefinitely.
+- **IMPORTANT**: Do not continue approving an agent that is ignoring your guidance. Repeated approval of a stuck agent wastes budget and risks crashing the system.
 
 **Issue**: Incomplete implementation
 - **Wrong**: Stopping before all requirements are met

--- a/pkg/templates/architect/budget_review_planning.tpl.md
+++ b/pkg/templates/architect/budget_review_planning.tpl.md
@@ -51,6 +51,12 @@ The request above contains all context including budget details, recent messages
 - **Wrong**: Endless exploration without creating implementation plan
 - **Correct**: After 5-8 exploration commands, submit comprehensive plan
 
+**Issue**: Repeated budget reviews with the same guidance being ignored
+- **Pattern**: You have previously approved or given NEEDS_CHANGES to this agent with specific guidance (e.g., "submit your plan", "call `done`"), but the agent continues the same behavior without acting on it
+- **Detection**: The conversation context shows 2-3 prior budget review responses where you gave the same or equivalent feedback that was not acted upon
+- **Correct Response**: Use REJECTED status. If your guidance has been given multiple times and ignored, the agent is stuck in a loop it cannot break out of. Rejecting allows the system to reassign or escalate the story rather than burning tokens indefinitely.
+- **IMPORTANT**: Do not continue approving an agent that is ignoring your guidance. Repeated approval of a stuck agent wastes budget and risks crashing the system.
+
 ## Automated Pattern Analysis
 
 The budget review request includes automated detection of universal failure patterns:

--- a/pkg/templates/coder/budget_review_approved_feedback.tpl.md
+++ b/pkg/templates/coder/budget_review_approved_feedback.tpl.md
@@ -1,0 +1,18 @@
+**ARCHITECT GUIDANCE - Budget Review Approved**
+
+The architect approved continuation but provided the following guidance:
+
+```
+{{- if isMap .Extra.Data -}}
+{{.Extra.Data.Feedback}}
+{{- else -}}
+{{.Extra.Data}}
+{{- end -}}
+```
+
+**Next Steps:**
+1. **Read the guidance above carefully**
+2. **If the architect says work is complete, call the `done` tool immediately**
+3. **Otherwise, continue with the suggested approach**
+
+The architect's guidance is based on reviewing your recent activity. Follow it to avoid further budget reviews.

--- a/pkg/templates/renderer.go
+++ b/pkg/templates/renderer.go
@@ -70,8 +70,10 @@ const (
 	TestFailureInstructionsTemplate StateTemplate = "coder/test_failure_instructions.tpl.md"
 	// DevOpsTestFailureInstructionsTemplate is the mini-template for devops test failure instructions.
 	DevOpsTestFailureInstructionsTemplate StateTemplate = "coder/devops_test_failure_instructions.tpl.md"
-	// BudgetReviewFeedbackTemplate is the mini-template for budget review feedback.
+	// BudgetReviewFeedbackTemplate is the mini-template for budget review feedback (NEEDS_CHANGES).
 	BudgetReviewFeedbackTemplate StateTemplate = "coder/budget_review_feedback.tpl.md"
+	// BudgetReviewApprovedFeedbackTemplate is the mini-template for budget review approved guidance.
+	BudgetReviewApprovedFeedbackTemplate StateTemplate = "coder/budget_review_approved_feedback.tpl.md"
 	// MergeFailureFeedbackTemplate is the mini-template for merge failure feedback.
 	MergeFailureFeedbackTemplate StateTemplate = "coder/merge_failure_feedback.tpl.md"
 	// GitCommitFailureTemplate is the mini-template for git commit failures.
@@ -183,6 +185,7 @@ func NewRenderer() (*Renderer, error) {
 		TestFailureInstructionsTemplate,
 		DevOpsTestFailureInstructionsTemplate,
 		BudgetReviewFeedbackTemplate,
+		BudgetReviewApprovedFeedbackTemplate,
 		MergeFailureFeedbackTemplate,
 		GitCommitFailureTemplate,
 		GitPushFailureTemplate,

--- a/pkg/templates/renderer_test.go
+++ b/pkg/templates/renderer_test.go
@@ -321,6 +321,15 @@ func TestRenderSimpleMiniTemplates(t *testing.T) {
 			expectedText: "ARCHITECT GUIDANCE",
 		},
 		{
+			name:     "Budget Review Approved Feedback",
+			template: BudgetReviewApprovedFeedbackTemplate,
+			data: map[string]any{
+				"Status":   "APPROVED",
+				"Feedback": "The work is complete. Call the done tool now.",
+			},
+			expectedText: "ARCHITECT GUIDANCE",
+		},
+		{
 			name:         "Git Push Failure",
 			template:     GitPushFailureTemplate,
 			data:         "fatal: could not read from remote repository",

--- a/pkg/templates/renderer_test.go
+++ b/pkg/templates/renderer_test.go
@@ -27,6 +27,7 @@ func TestNewRenderer(t *testing.T) {
 		TestFailureInstructionsTemplate,
 		DevOpsTestFailureInstructionsTemplate,
 		BudgetReviewFeedbackTemplate,
+		BudgetReviewApprovedFeedbackTemplate,
 		MergeFailureFeedbackTemplate,
 		GitCommitFailureTemplate,
 		GitPushFailureTemplate,


### PR DESCRIPTION
## Summary

Fixes a production failure where coder-003 got stuck in a 50+ iteration budget review loop, eventually crashing the architect (270K token context, gpt-5.2 empty responses, fatal shutdown).

**Root cause:** Three interacting bugs:
- APPROVED budget reviews explicitly discarded the architect's feedback before it reached the coder's context — so "call `done`" guidance was never seen
- The architect prompt instructed APPROVED with empty feedback for completed work, but empty feedback was silently replaced with a useless placeholder in the response builder
- No prompt guidance told the architect to REJECT when its guidance was repeatedly ignored

**Fixes:**
- Preserve empty feedback for budget reviews in `buildApprovalResponseFromReviewComplete` (skip the generic placeholder so coder-side empty check works)
- Inject non-empty architect feedback on APPROVED budget reviews via new template, mirroring the existing NEEDS_CHANGES injection pattern
- Fix architect budget review coding prompt to require explicit feedback when work is complete
- Add reject-on-ignored-guidance instruction to both coding and planning budget review prompts

## Test plan

- [x] `buildApprovalResponseFromReviewComplete` preserves empty feedback for budget reviews
- [x] `buildApprovalResponseFromReviewComplete` fills placeholder for non-budget review types
- [x] APPROVED with non-empty feedback is injected into coder context
- [x] APPROVED with empty feedback remains a no-op (no context pollution)
- [x] `make build` passes (including lint)
- [x] `make test` passes (all unit tests)
- [x] Integration tests pass (pre-push hook)
- [ ] Production test: coder sees "call done" on APPROVED budget review and breaks the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)