### PR TITLE
Add architect dev-chat listener for development channel

### DIFF
--- a/internal/factory/agent_factory.go
+++ b/internal/factory/agent_factory.go
@@ -127,8 +127,9 @@ func (f *AgentFactory) createArchitect(ctx context.Context, agentID string) (dis
 		f.dispatcher,
 		workDir,
 		f.persistenceChannel,
-		f.llmFactory, // Shared factory for rate limiting
-		chatAdapter,  // Chat service for escalations
+		f.llmFactory,  // Shared factory for rate limiting
+		chatAdapter,   // Chat service for escalations
+		f.chatService, // Dev chat service for channel-scoped reads
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create architect: %w", err)

--- a/pkg/architect/dev_chat.go
+++ b/pkg/architect/dev_chat.go
@@ -60,15 +60,23 @@ func (d *Driver) processDevChatMessage(ctx context.Context, msg *persistence.Cha
 
 	d.logger.Info("Dev-chat: processing message %d from %s: %.100s", msg.ID, agentID, msg.Text)
 
-	// Scope context to the agent's current story (if any)
+	// Scope context to the agent's current story (if any).
+	// On failure, reset to a clean architect prompt to avoid stale/uninitialized context.
 	storyID := d.dispatcher.GetStoryForAgent(agentID)
 	if storyID != "" {
 		if _, err := d.ensureContextForStory(ctx, agentID, storyID); err != nil {
-			d.logger.Warn("Dev-chat: failed to scope context for %s story %s: %v", agentID, storyID, err)
+			d.logger.Warn("Dev-chat: failed to scope context for %s story %s: %v — resetting to clean state", agentID, storyID, err)
+			cm := d.getContextForAgent(agentID)
+			cm.ResetForNewTemplate("", "You are the architect agent. Respond to the following dev-chat message.")
+			d.clearReviewStreaks(agentID)
 		}
+	} else {
+		// No active story lease — ensure context has at least a minimal system prompt
+		cm := d.getContextForAgent(agentID)
+		cm.ResetForNewTemplate("", "You are the architect agent. Respond to the following dev-chat message.")
 	}
 
-	// Get agent-specific context
+	// Get agent-specific context (now guaranteed to have a system prompt)
 	cm := d.getContextForAgent(agentID)
 
 	// Build prompt from the chat message
@@ -123,9 +131,9 @@ Keep your response concise and actionable.`, agentID, msg.Text)
 	}
 
 	if replyText == "" {
-		// Fallback: LLM didn't produce a submit_reply — use a generic acknowledgment
-		replyText = "I've reviewed your message. Let me know if you need specific guidance."
-		d.logger.Warn("Dev-chat: no submit_reply produced for message %d, using fallback", msg.ID)
+		// Fallback: be honest that we couldn't process the message
+		replyText = "I received your message but wasn't able to fully process it. If you need help, please use the ask_question tool for a reliable response."
+		d.logger.Warn("Dev-chat: no submit_reply produced for message %d, using honest fallback", msg.ID)
 	}
 
 	// Post threaded reply back to development chat

--- a/pkg/architect/dev_chat.go
+++ b/pkg/architect/dev_chat.go
@@ -1,0 +1,149 @@
+package architect
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"orchestrator/pkg/agent"
+	"orchestrator/pkg/agent/toolloop"
+	"orchestrator/pkg/chat"
+	"orchestrator/pkg/config"
+	"orchestrator/pkg/persistence"
+	"orchestrator/pkg/tools"
+)
+
+// handleDevChat processes pending development channel chat messages.
+// Each message gets its own LLM turn with context scoped to the sending agent's story.
+// Replies are posted back as threaded messages.
+func (d *Driver) handleDevChat(ctx context.Context) error {
+	if d.devChatService == nil {
+		return fmt.Errorf("dev chat service not configured")
+	}
+
+	// Fetch unread development-channel messages
+	resp, err := d.devChatService.GetNewForChannel(ctx, d.GetAgentID(), chat.ChannelDevelopment)
+	if err != nil {
+		return fmt.Errorf("failed to get dev-chat messages: %w", err)
+	}
+
+	if len(resp.Messages) == 0 {
+		return nil // Nothing to process
+	}
+
+	d.logger.Info("Dev-chat: processing %d new development messages", len(resp.Messages))
+
+	// Process each message individually
+	for _, msg := range resp.Messages {
+		if err := d.processDevChatMessage(ctx, msg); err != nil {
+			d.logger.Error("Dev-chat: failed to process message %d from %s: %v", msg.ID, msg.Author, err)
+			// Continue processing remaining messages even if one fails
+		}
+	}
+
+	// Update development channel cursor (leave product cursor untouched)
+	if err := d.devChatService.UpdateCursorForChannel(ctx, d.GetAgentID(), chat.ChannelDevelopment, resp.NewPointer); err != nil {
+		d.logger.Error("Dev-chat: failed to update cursor: %v", err)
+	}
+
+	return nil
+}
+
+// processDevChatMessage handles a single development chat message with an LLM turn.
+func (d *Driver) processDevChatMessage(ctx context.Context, msg *persistence.ChatMessage) error {
+	// Extract agent ID from author (strip @ prefix)
+	agentID := strings.TrimPrefix(msg.Author, "@")
+	if agentID == "" || agentID == "human" {
+		// Human messages get a simple acknowledgment — no workspace to inspect
+		return d.postDevChatReply(ctx, msg.ID, "Acknowledged. Let me know if you need anything specific.")
+	}
+
+	d.logger.Info("Dev-chat: processing message %d from %s: %.100s", msg.ID, agentID, msg.Text)
+
+	// Scope context to the agent's current story (if any)
+	storyID := d.dispatcher.GetStoryForAgent(agentID)
+	if storyID != "" {
+		if _, err := d.ensureContextForStory(ctx, agentID, storyID); err != nil {
+			d.logger.Warn("Dev-chat: failed to scope context for %s story %s: %v", agentID, storyID, err)
+		}
+	}
+
+	// Get agent-specific context
+	cm := d.getContextForAgent(agentID)
+
+	// Build prompt from the chat message
+	prompt := fmt.Sprintf(`A developer (%s) posted in the development chat:
+
+%s
+
+Read the message, inspect their workspace if needed, then provide a helpful response using submit_reply.
+Keep your response concise and actionable.`, agentID, msg.Text)
+
+	cm.AddMessage("dev-chat-message", prompt)
+
+	// Create tool provider with read tools for this agent's workspace
+	toolProvider := d.createQuestionToolProviderForCoder(agentID)
+
+	// Get submit_reply as terminal tool
+	submitReplyTool, err := toolProvider.Get(tools.ToolSubmitReply)
+	if err != nil {
+		return fmt.Errorf("failed to get submit_reply tool: %w", err)
+	}
+
+	// Get general read tools
+	var generalTools []tools.Tool
+	for _, toolName := range []string{tools.ToolReadFile, tools.ToolListFiles} {
+		if tool, toolErr := toolProvider.Get(toolName); toolErr == nil {
+			generalTools = append(generalTools, tool)
+		}
+	}
+
+	// Run toolloop — shorter limits than questions since chat replies should be quick
+	out := toolloop.Run(d.toolLoop, ctx, &toolloop.Config[SubmitReplyResult]{
+		ContextManager:     cm,
+		GeneralTools:       generalTools,
+		TerminalTool:       submitReplyTool,
+		MaxIterations:      10,
+		MaxTokens:          agent.ArchitectMaxTokens,
+		Temperature:        config.GetTemperature(config.TempRoleArchitect),
+		AgentID:            d.GetAgentID(),
+		DebugLogging:       config.GetDebugLLMMessages(),
+		PersistenceChannel: d.persistenceChannel,
+		StoryID:            storyID,
+	})
+
+	// Extract response
+	var replyText string
+	if out.Kind == toolloop.OutcomeProcessEffect && out.Signal == tools.SignalReplySubmitted {
+		if effectData, ok := out.EffectData.(map[string]any); ok {
+			if r, ok := effectData["response"].(string); ok {
+				replyText = r
+			}
+		}
+	}
+
+	if replyText == "" {
+		// Fallback: LLM didn't produce a submit_reply — use a generic acknowledgment
+		replyText = "I've reviewed your message. Let me know if you need specific guidance."
+		d.logger.Warn("Dev-chat: no submit_reply produced for message %d, using fallback", msg.ID)
+	}
+
+	// Post threaded reply back to development chat
+	return d.postDevChatReply(ctx, msg.ID, replyText)
+}
+
+// postDevChatReply posts a threaded reply to a development chat message.
+func (d *Driver) postDevChatReply(ctx context.Context, replyToID int64, text string) error {
+	_, err := d.devChatService.Post(ctx, &chat.PostRequest{
+		Author:   chat.FormatAuthor(d.GetAgentID()),
+		Text:     text,
+		Channel:  chat.ChannelDevelopment,
+		ReplyTo:  &replyToID,
+		PostType: chat.PostTypeReply,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to post dev-chat reply: %w", err)
+	}
+	d.logger.Info("Dev-chat: posted reply to message %d", replyToID)
+	return nil
+}

--- a/pkg/architect/dev_chat_test.go
+++ b/pkg/architect/dev_chat_test.go
@@ -1,0 +1,232 @@
+package architect
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"orchestrator/pkg/agent"
+	"orchestrator/pkg/chat"
+	"orchestrator/pkg/config"
+	"orchestrator/pkg/contextmgr"
+	"orchestrator/pkg/dispatch"
+	"orchestrator/pkg/logx"
+	"orchestrator/pkg/persistence"
+)
+
+// newTestChatService creates a chat.Service for testing without database.
+func newTestChatService() *chat.Service {
+	return chat.NewService(nil, nil)
+}
+
+// newTestDriverWithDevChat creates a test driver wired with a dev chat service.
+func newTestDriverWithDevChat(chatSvc *chat.Service) *Driver {
+	persistCh := make(chan<- *persistence.Request, 10)
+	baseSM := agent.NewBaseStateMachine("test-arch", StateWaiting, nil, architectTransitions)
+
+	// Create minimal dispatcher with config
+	cfg := &config.Config{
+		Agents: &config.AgentConfig{MaxCoders: 2},
+	}
+	disp, _ := dispatch.NewDispatcher(cfg)
+
+	d := &Driver{
+		BaseStateMachine:   baseSM,
+		agentContexts:      make(map[string]*contextmgr.ContextManager),
+		contextMutex:       sync.RWMutex{},
+		logger:             logx.NewLogger("test-arch"),
+		queue:              NewQueue(nil),
+		escalationHandler:  NewEscalationHandler(NewQueue(nil)),
+		persistenceChannel: persistCh,
+		workDir:            "/tmp/test-workspace",
+		devChatService:     chatSvc,
+		reviewStreaks:      make(map[string]map[string]int),
+		dispatcher:         disp,
+	}
+
+	return d
+}
+
+func TestHandleDevChat_NoServiceReturnsError(t *testing.T) {
+	driver := newTestDriver()
+	// devChatService is nil
+	err := driver.handleDevChat(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestHandleDevChat_NoMessagesIsNoop(t *testing.T) {
+	chatSvc := newTestChatService()
+	chatSvc.RegisterAgent("test-arch", []string{"development", "product"})
+
+	driver := newTestDriverWithDevChat(chatSvc)
+
+	err := driver.handleDevChat(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestHandleDevChat_UpdatesCursorAfterProcessing(t *testing.T) {
+	chatSvc := newTestChatService()
+	chatSvc.RegisterAgent("test-arch", []string{"development", "product"})
+
+	// Post a message from a human (doesn't need LLM/toolloop — handled with simple ack)
+	ctx := context.Background()
+	resp, err := chatSvc.Post(ctx, &chat.PostRequest{
+		Author:   "@human",
+		Text:     "Hello architect",
+		Channel:  "development",
+		PostType: "chat",
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+
+	driver := newTestDriverWithDevChat(chatSvc)
+
+	err = driver.handleDevChat(ctx)
+	assert.NoError(t, err)
+
+	// Cursor should be advanced — no new messages remaining
+	assert.False(t, chatSvc.HaveNewMessagesForChannel("test-arch", "development"))
+}
+
+func TestHandleDevChat_ProductCursorUntouched(t *testing.T) {
+	chatSvc := newTestChatService()
+	chatSvc.RegisterAgent("test-arch", []string{"development", "product"})
+
+	ctx := context.Background()
+
+	// Post to both channels
+	_, err := chatSvc.Post(ctx, &chat.PostRequest{
+		Author:  "@human",
+		Text:    "dev message",
+		Channel: "development",
+	})
+	require.NoError(t, err)
+
+	_, err = chatSvc.Post(ctx, &chat.PostRequest{
+		Author:  "@pm-001",
+		Text:    "product message",
+		Channel: "product",
+	})
+	require.NoError(t, err)
+
+	driver := newTestDriverWithDevChat(chatSvc)
+
+	err = driver.handleDevChat(ctx)
+	assert.NoError(t, err)
+
+	// Development should be consumed
+	assert.False(t, chatSvc.HaveNewMessagesForChannel("test-arch", "development"))
+
+	// Product cursor should be untouched
+	assert.True(t, chatSvc.HaveNewMessagesForChannel("test-arch", "product"))
+}
+
+func TestHandleDevChat_PostsThreadedReply(t *testing.T) {
+	chatSvc := newTestChatService()
+	chatSvc.RegisterAgent("test-arch", []string{"development"})
+
+	ctx := context.Background()
+
+	// Post a human message
+	postResp, err := chatSvc.Post(ctx, &chat.PostRequest{
+		Author:  "@human",
+		Text:    "How's the build going?",
+		Channel: "development",
+	})
+	require.NoError(t, err)
+	originalMsgID := postResp.ID
+
+	driver := newTestDriverWithDevChat(chatSvc)
+	err = driver.handleDevChat(ctx)
+	assert.NoError(t, err)
+
+	// Check that a threaded reply was posted
+	allMsgs := chatSvc.GetAllMessages()
+	var reply *persistence.ChatMessage
+	for _, m := range allMsgs {
+		if m.ReplyTo != nil && *m.ReplyTo == originalMsgID {
+			reply = m
+			break
+		}
+	}
+
+	require.NotNil(t, reply, "expected a threaded reply to the original message")
+	assert.Equal(t, chat.FormatAuthor("test-arch"), reply.Author)
+	assert.Equal(t, "development", reply.Channel)
+	assert.Equal(t, chat.PostTypeReply, reply.PostType)
+}
+
+func TestHandleDevChat_ExcludesOwnMessages(t *testing.T) {
+	chatSvc := newTestChatService()
+	chatSvc.RegisterAgent("test-arch", []string{"development"})
+
+	ctx := context.Background()
+
+	// Post a message from the architect itself
+	_, err := chatSvc.Post(ctx, &chat.PostRequest{
+		Author:  chat.FormatAuthor("test-arch"),
+		Text:    "My own message",
+		Channel: "development",
+	})
+	require.NoError(t, err)
+
+	driver := newTestDriverWithDevChat(chatSvc)
+	err = driver.handleDevChat(ctx)
+	assert.NoError(t, err)
+
+	// Should be no replies posted (only the original message exists)
+	allMsgs := chatSvc.GetAllMessages()
+	assert.Equal(t, 1, len(allMsgs), "no replies should be posted for own messages")
+}
+
+func TestMonitoring_DevChatWakesState(t *testing.T) {
+	chatSvc := newTestChatService()
+	chatSvc.RegisterAgent("test-arch", []string{"development"})
+
+	ctx := context.Background()
+
+	// Post a message from a coder
+	_, err := chatSvc.Post(ctx, &chat.PostRequest{
+		Author:  "@coder-001",
+		Text:    "Need help with this test",
+		Channel: "development",
+	})
+	require.NoError(t, err)
+
+	// Verify HaveNewMessagesForChannel returns true (this is what MONITORING checks)
+	assert.True(t, chatSvc.HaveNewMessagesForChannel("test-arch", "development"))
+}
+
+func TestDevChatPending_RoutedInRequest(t *testing.T) {
+	chatSvc := newTestChatService()
+	chatSvc.RegisterAgent("test-arch", []string{"development"})
+
+	ctx := context.Background()
+
+	// Post a human message to dev chat
+	_, err := chatSvc.Post(ctx, &chat.PostRequest{
+		Author:  "@human",
+		Text:    "status update please",
+		Channel: "development",
+	})
+	require.NoError(t, err)
+
+	driver := newTestDriverWithDevChat(chatSvc)
+
+	// Set the dev-chat pending flag (as MONITORING would)
+	driver.SetStateData(StateKeyDevChatPending, true)
+
+	// Call handleRequest — it should route to dev-chat handler and return to MONITORING
+	nextState, err := driver.handleRequest(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, StateMonitoring, nextState)
+
+	// Flag should be cleared
+	stateData := driver.GetStateData()
+	pending, _ := stateData[StateKeyDevChatPending].(bool)
+	assert.False(t, pending)
+}

--- a/pkg/architect/driver.go
+++ b/pkg/architect/driver.go
@@ -11,6 +11,7 @@ import (
 
 	"orchestrator/pkg/agent"
 	"orchestrator/pkg/agent/toolloop"
+	"orchestrator/pkg/chat"
 	"orchestrator/pkg/config"
 	"orchestrator/pkg/contextmgr"
 	"orchestrator/pkg/dispatch"
@@ -104,6 +105,7 @@ type Driver struct {
 	logger                  *logx.Logger                          // Logger with proper agent prefixing
 	executor                *execpkg.ArchitectExecutor            // Container executor for file access tools
 	chatService             ChatServiceInterface                  // Chat service for escalations (nil check required)
+	devChatService          *chat.Service                         // Chat service for dev-chat listener (channel-scoped reads)
 	gitHubClient            GitHubMergeClient                     // GitHub client for merge operations (nil = create from config)
 	shutdownCtx             context.Context                       //nolint:containedctx // Driver-level context for graceful shutdown of background tasks
 	shutdownCancel          context.CancelFunc                    // Cancel function for shutdownCtx
@@ -206,7 +208,7 @@ func NewDriver(architectID, _ string, dispatcher *dispatch.Dispatcher, workDir s
 
 // NewArchitect creates a new architect with LLM integration.
 // Uses shared LLM factory for proper rate limiting across all agents.
-func NewArchitect(ctx context.Context, architectID string, dispatcher *dispatch.Dispatcher, workDir string, persistenceChannel chan<- *persistence.Request, llmFactory *agent.LLMClientFactory, chatService ChatServiceInterface) (*Driver, error) {
+func NewArchitect(ctx context.Context, architectID string, dispatcher *dispatch.Dispatcher, workDir string, persistenceChannel chan<- *persistence.Request, llmFactory *agent.LLMClientFactory, chatService ChatServiceInterface, devChatService *chat.Service) (*Driver, error) {
 	// Check for context cancellation before starting construction
 	select {
 	case <-ctx.Done():
@@ -230,6 +232,8 @@ func NewArchitect(ctx context.Context, architectID string, dispatcher *dispatch.
 
 	// Set chat service for escalations (may be nil in tests)
 	architect.chatService = chatService
+	// Set dev chat service for development channel listener (may be nil in tests)
+	architect.devChatService = devChatService
 
 	// NOTE: Workspace cloning is deferred to SETUP state.
 	// The architect boots in WAITING state with just a mountable directory (already created at startup).

--- a/pkg/architect/monitoring.go
+++ b/pkg/architect/monitoring.go
@@ -42,7 +42,12 @@ func (d *Driver) handleMonitoring(ctx context.Context) (proto.State, error) {
 		return StateRequest, nil
 
 	case <-time.After(HeartbeatInterval):
-		// Heartbeat debug logging.
+		// Check for unread developer chat messages
+		if d.devChatService != nil && d.devChatService.HaveNewMessagesForChannel(d.GetAgentID(), "development") {
+			d.logger.Info("Dev-chat: new development messages detected, transitioning to REQUEST")
+			d.SetStateData(StateKeyDevChatPending, true)
+			return StateRequest, nil
+		}
 		return StateMonitoring, nil
 
 	case <-ctx.Done():

--- a/pkg/architect/monitoring.go
+++ b/pkg/architect/monitoring.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"orchestrator/pkg/chat"
 	"orchestrator/pkg/proto"
 )
 
@@ -43,7 +44,7 @@ func (d *Driver) handleMonitoring(ctx context.Context) (proto.State, error) {
 
 	case <-time.After(HeartbeatInterval):
 		// Check for unread developer chat messages
-		if d.devChatService != nil && d.devChatService.HaveNewMessagesForChannel(d.GetAgentID(), "development") {
+		if d.devChatService != nil && d.devChatService.HaveNewMessagesForChannel(d.GetAgentID(), chat.ChannelDevelopment) {
 			d.logger.Info("Dev-chat: new development messages detected, transitioning to REQUEST")
 			d.SetStateData(StateKeyDevChatPending, true)
 			return StateRequest, nil

--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -34,6 +34,16 @@ func (d *Driver) handleRequest(ctx context.Context) (proto.State, error) {
 	// Get state data
 	stateData := d.GetStateData()
 
+	// Check for dev-chat pending (set by MONITORING heartbeat)
+	if pending, ok := stateData[StateKeyDevChatPending].(bool); ok && pending {
+		d.SetStateData(StateKeyDevChatPending, false) // Clear the flag
+		if err := d.handleDevChat(ctx); err != nil {
+			d.logger.Error("Dev-chat handler error: %v", err)
+			// Non-fatal: return to monitoring even on error
+		}
+		return StateMonitoring, nil
+	}
+
 	// Get the current request from state data.
 	requestMsg, exists := stateData[StateKeyCurrentRequest].(*proto.AgentMsg)
 	if !exists || requestMsg == nil {

--- a/pkg/architect/state_keys.go
+++ b/pkg/architect/state_keys.go
@@ -44,6 +44,9 @@ const (
 	StateKeyStoriesGenerated = "stories_generated" // bool - stories have been generated
 	StateKeyStoriesCount     = "stories_count"     // int - number of stories generated
 
+	// Dev-chat tracking.
+	StateKeyDevChatPending = "dev_chat_pending" // bool - dev-chat messages waiting to be processed
+
 	// Lifecycle tracking.
 	StateKeyStartedAt = "started_at" // time.Time - when architect started
 )

--- a/pkg/chat/service.go
+++ b/pkg/chat/service.go
@@ -211,11 +211,12 @@ func (s *Service) Post(ctx context.Context, req *PostRequest) (*PostResponse, er
 	}
 
 	// 7. Async persist to database (fire-and-forget)
+	// Use msg fields (not req) to avoid races if caller mutates req after Post returns.
 	if s.dbOps != nil {
 		go func() {
-			_, err := s.dbOps.PostChatMessageWithType(req.Author, text, timestamp, req.Channel, req.ReplyTo, postType)
+			_, err := s.dbOps.PostChatMessageWithType(msg.Author, msg.Text, msg.Timestamp, msg.Channel, msg.ReplyTo, msg.PostType)
 			if err != nil {
-				s.logger.Warn("Failed to persist chat message to DB (id=%d): %v", msgID, err)
+				s.logger.Warn("Failed to persist chat message to DB (id=%d): %v", msg.ID, err)
 			}
 		}()
 	}
@@ -357,13 +358,19 @@ func (s *Service) UpdateCursor(_ context.Context, agentID string, newPointer int
 
 	s.logger.Debug("Updated cursor for %s to %d (all channels)", agentID, newPointer)
 
+	// Snapshot channel keys before releasing lock to avoid race in goroutine
+	channels := make([]string, 0, len(channelCursors))
+	for ch := range channelCursors {
+		channels = append(channels, ch)
+	}
+
 	// Async persist to database (fire-and-forget)
 	if s.dbOps != nil {
 		go func() {
-			for channel := range channelCursors {
-				err := s.dbOps.UpdateChatCursor(agentID, channel, newPointer)
+			for _, ch := range channels {
+				err := s.dbOps.UpdateChatCursor(agentID, ch, newPointer)
 				if err != nil {
-					s.logger.Warn("Failed to persist cursor for %s channel %s: %v", agentID, channel, err)
+					s.logger.Warn("Failed to persist cursor for %s channel %s: %v", agentID, ch, err)
 				}
 			}
 		}()
@@ -395,10 +402,7 @@ func (s *Service) GetNewForChannel(_ context.Context, agentID, channel string) (
 
 	cursor, hasAccess := channelCursors[channel]
 	if !hasAccess {
-		return &GetNewResponse{
-			Messages:   []*persistence.ChatMessage{},
-			NewPointer: cursor,
-		}, nil
+		return nil, fmt.Errorf("agent %s not registered for channel %s", agentID, channel)
 	}
 
 	var newMessages []*persistence.ChatMessage

--- a/pkg/chat/service.go
+++ b/pkg/chat/service.go
@@ -211,12 +211,14 @@ func (s *Service) Post(ctx context.Context, req *PostRequest) (*PostResponse, er
 	}
 
 	// 7. Async persist to database (fire-and-forget)
-	go func() {
-		_, err := s.dbOps.PostChatMessageWithType(req.Author, text, timestamp, req.Channel, req.ReplyTo, postType)
-		if err != nil {
-			s.logger.Warn("Failed to persist chat message to DB (id=%d): %v", msgID, err)
-		}
-	}()
+	if s.dbOps != nil {
+		go func() {
+			_, err := s.dbOps.PostChatMessageWithType(req.Author, text, timestamp, req.Channel, req.ReplyTo, postType)
+			if err != nil {
+				s.logger.Warn("Failed to persist chat message to DB (id=%d): %v", msgID, err)
+			}
+		}()
+	}
 
 	return &PostResponse{
 		ID:      msgID,
@@ -356,14 +358,146 @@ func (s *Service) UpdateCursor(_ context.Context, agentID string, newPointer int
 	s.logger.Debug("Updated cursor for %s to %d (all channels)", agentID, newPointer)
 
 	// Async persist to database (fire-and-forget)
-	go func() {
-		for channel := range channelCursors {
-			err := s.dbOps.UpdateChatCursor(agentID, channel, newPointer)
-			if err != nil {
-				s.logger.Warn("Failed to persist cursor for %s channel %s: %v", agentID, channel, err)
+	if s.dbOps != nil {
+		go func() {
+			for channel := range channelCursors {
+				err := s.dbOps.UpdateChatCursor(agentID, channel, newPointer)
+				if err != nil {
+					s.logger.Warn("Failed to persist cursor for %s channel %s: %v", agentID, channel, err)
+				}
+			}
+		}()
+	}
+
+	return nil
+}
+
+// GetNewForChannel retrieves new messages for an agent from a specific channel only.
+// Unlike GetNew, this does not advance cursors — call UpdateCursorForChannel separately.
+func (s *Service) GetNewForChannel(_ context.Context, agentID, channel string) (*GetNewResponse, error) {
+	if agentID == "" {
+		return nil, fmt.Errorf("agent_id is required")
+	}
+	if channel == "" {
+		return nil, fmt.Errorf("channel is required")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	channelCursors, ok := s.agentCursors[agentID]
+	if !ok {
+		return &GetNewResponse{
+			Messages:   []*persistence.ChatMessage{},
+			NewPointer: 0,
+		}, nil
+	}
+
+	cursor, hasAccess := channelCursors[channel]
+	if !hasAccess {
+		return &GetNewResponse{
+			Messages:   []*persistence.ChatMessage{},
+			NewPointer: cursor,
+		}, nil
+	}
+
+	var newMessages []*persistence.ChatMessage
+	maxCursor := cursor
+	expectedAuthor := FormatAuthor(agentID)
+
+	for _, msg := range s.messages {
+		if msg.Channel != channel {
+			continue
+		}
+		if msg.Author == expectedAuthor {
+			if msg.ID > maxCursor {
+				maxCursor = msg.ID
+			}
+			continue
+		}
+		if msg.ID > cursor {
+			newMessages = append(newMessages, msg)
+			if msg.ID > maxCursor {
+				maxCursor = msg.ID
 			}
 		}
-	}()
+	}
+
+	s.logger.Debug("GetNewForChannel %s/%s: %d new messages (pointer: %d)", agentID, channel, len(newMessages), maxCursor)
+
+	return &GetNewResponse{
+		Messages:   newMessages,
+		NewPointer: maxCursor,
+	}, nil
+}
+
+// HaveNewMessagesForChannel checks if an agent has new messages in a specific channel
+// without retrieving them or updating cursors.
+func (s *Service) HaveNewMessagesForChannel(agentID, channel string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	channelCursors, ok := s.agentCursors[agentID]
+	if !ok {
+		return false
+	}
+
+	cursor, hasAccess := channelCursors[channel]
+	if !hasAccess {
+		return false
+	}
+
+	expectedAuthor := FormatAuthor(agentID)
+
+	for _, msg := range s.messages {
+		if msg.Channel != channel {
+			continue
+		}
+		if msg.Author == expectedAuthor {
+			continue
+		}
+		if msg.ID > cursor {
+			return true
+		}
+	}
+
+	return false
+}
+
+// UpdateCursorForChannel updates an agent's cursor for a specific channel only.
+// Other channel cursors are left untouched.
+func (s *Service) UpdateCursorForChannel(_ context.Context, agentID, channel string, newPointer int64) error {
+	if agentID == "" {
+		return fmt.Errorf("agent_id is required")
+	}
+	if channel == "" {
+		return fmt.Errorf("channel is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	channelCursors, ok := s.agentCursors[agentID]
+	if !ok {
+		return fmt.Errorf("agent %s not registered", agentID)
+	}
+
+	if _, hasAccess := channelCursors[channel]; !hasAccess {
+		return fmt.Errorf("agent %s not registered for channel %s", agentID, channel)
+	}
+
+	channelCursors[channel] = newPointer
+
+	s.logger.Debug("Updated cursor for %s channel %s to %d", agentID, channel, newPointer)
+
+	// Async persist to database (fire-and-forget)
+	if s.dbOps != nil {
+		go func() {
+			if err := s.dbOps.UpdateChatCursor(agentID, channel, newPointer); err != nil {
+				s.logger.Warn("Failed to persist cursor for %s channel %s: %v", agentID, channel, err)
+			}
+		}()
+	}
 
 	return nil
 }

--- a/pkg/chat/service_test.go
+++ b/pkg/chat/service_test.go
@@ -29,12 +29,7 @@ func addTestMessage(s *Service, id int64, author, channel, text string) {
 }
 
 func newTestService() *Service {
-	return &Service{
-		messages:            make([]*persistence.ChatMessage, 0),
-		agentCursors:        make(map[string]map[string]int64),
-		nextID:              1,
-		confirmationWaiters: make(map[int64]chan *persistence.ChatMessage),
-	}
+	return NewService(nil, nil)
 }
 
 func TestGetNewForChannel_OnlyReturnsRequestedChannel(t *testing.T) {

--- a/pkg/chat/service_test.go
+++ b/pkg/chat/service_test.go
@@ -1,0 +1,272 @@
+package chat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"orchestrator/pkg/persistence"
+)
+
+// addTestMessage adds a message directly to in-memory state, bypassing Post (no DB needed).
+func addTestMessage(s *Service, id int64, author, channel, text string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	msg := &persistence.ChatMessage{
+		ID:        id,
+		SessionID: "test",
+		Channel:   channel,
+		Author:    author,
+		Text:      text,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		PostType:  PostTypeChat,
+	}
+	s.messages = append(s.messages, msg)
+	if id >= s.nextID {
+		s.nextID = id + 1
+	}
+}
+
+func newTestService() *Service {
+	return &Service{
+		messages:            make([]*persistence.ChatMessage, 0),
+		agentCursors:        make(map[string]map[string]int64),
+		nextID:              1,
+		confirmationWaiters: make(map[int64]chan *persistence.ChatMessage),
+	}
+}
+
+func TestGetNewForChannel_OnlyReturnsRequestedChannel(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment, ChannelProduct})
+
+	// Add messages to both channels from a coder
+	addTestMessage(svc, 1, "@coder-001", ChannelDevelopment, "dev message 1")
+	addTestMessage(svc, 2, "@coder-001", ChannelProduct, "product message 1")
+	addTestMessage(svc, 3, "@coder-001", ChannelDevelopment, "dev message 2")
+
+	ctx := context.Background()
+	resp, err := svc.GetNewForChannel(ctx, "architect-001", ChannelDevelopment)
+	if err != nil {
+		t.Fatalf("GetNewForChannel failed: %v", err)
+	}
+
+	if len(resp.Messages) != 2 {
+		t.Fatalf("expected 2 development messages, got %d", len(resp.Messages))
+	}
+	for _, msg := range resp.Messages {
+		if msg.Channel != ChannelDevelopment {
+			t.Errorf("expected channel %s, got %s", ChannelDevelopment, msg.Channel)
+		}
+	}
+}
+
+func TestGetNewForChannel_ExcludesOwnMessages(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment})
+
+	// Message from the architect itself (uses FormatAuthor)
+	addTestMessage(svc, 1, FormatAuthor("architect-001"), ChannelDevelopment, "my own message")
+	// Message from a coder
+	addTestMessage(svc, 2, "@coder-001", ChannelDevelopment, "coder message")
+
+	ctx := context.Background()
+	resp, err := svc.GetNewForChannel(ctx, "architect-001", ChannelDevelopment)
+	if err != nil {
+		t.Fatalf("GetNewForChannel failed: %v", err)
+	}
+
+	if len(resp.Messages) != 1 {
+		t.Fatalf("expected 1 message (excluding own), got %d", len(resp.Messages))
+	}
+	if resp.Messages[0].Author != "@coder-001" {
+		t.Errorf("expected message from @coder-001, got %s", resp.Messages[0].Author)
+	}
+}
+
+func TestGetNewForChannel_RespectsChannelCursor(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment})
+
+	addTestMessage(svc, 1, "@coder-001", ChannelDevelopment, "old message")
+	addTestMessage(svc, 2, "@coder-001", ChannelDevelopment, "new message")
+
+	// Advance cursor past message 1
+	ctx := context.Background()
+	if err := svc.UpdateCursorForChannel(ctx, "architect-001", ChannelDevelopment, 1); err != nil {
+		t.Fatalf("UpdateCursorForChannel failed: %v", err)
+	}
+
+	resp, err := svc.GetNewForChannel(ctx, "architect-001", ChannelDevelopment)
+	if err != nil {
+		t.Fatalf("GetNewForChannel failed: %v", err)
+	}
+
+	if len(resp.Messages) != 1 {
+		t.Fatalf("expected 1 new message after cursor, got %d", len(resp.Messages))
+	}
+	if resp.Messages[0].ID != 2 {
+		t.Errorf("expected message ID 2, got %d", resp.Messages[0].ID)
+	}
+}
+
+func TestGetNewForChannel_UnregisteredAgent(t *testing.T) {
+	svc := newTestService()
+
+	ctx := context.Background()
+	resp, err := svc.GetNewForChannel(ctx, "unknown-agent", ChannelDevelopment)
+	if err != nil {
+		t.Fatalf("GetNewForChannel failed: %v", err)
+	}
+
+	if len(resp.Messages) != 0 {
+		t.Errorf("expected 0 messages for unregistered agent, got %d", len(resp.Messages))
+	}
+}
+
+func TestUpdateCursorForChannel_OnlyAdvancesSpecifiedChannel(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment, ChannelProduct})
+
+	addTestMessage(svc, 1, "@coder-001", ChannelDevelopment, "dev msg")
+	addTestMessage(svc, 2, "@pm-001", ChannelProduct, "product msg")
+
+	ctx := context.Background()
+
+	// Update only the development cursor
+	if err := svc.UpdateCursorForChannel(ctx, "architect-001", ChannelDevelopment, 5); err != nil {
+		t.Fatalf("UpdateCursorForChannel failed: %v", err)
+	}
+
+	// Development channel should have no new messages
+	if svc.HaveNewMessagesForChannel("architect-001", ChannelDevelopment) {
+		t.Error("expected no new development messages after cursor update")
+	}
+
+	// Product channel cursor should be untouched — message 2 should still be new
+	if !svc.HaveNewMessagesForChannel("architect-001", ChannelProduct) {
+		t.Error("expected product messages to still be new (cursor untouched)")
+	}
+
+	// Verify via GetNewForChannel that product still returns the message
+	prodResp, err := svc.GetNewForChannel(ctx, "architect-001", ChannelProduct)
+	if err != nil {
+		t.Fatalf("GetNewForChannel for product failed: %v", err)
+	}
+	if len(prodResp.Messages) != 1 {
+		t.Fatalf("expected 1 product message, got %d", len(prodResp.Messages))
+	}
+}
+
+func TestUpdateCursorForChannel_ErrorOnUnregisteredAgent(t *testing.T) {
+	svc := newTestService()
+
+	ctx := context.Background()
+	err := svc.UpdateCursorForChannel(ctx, "unknown-agent", ChannelDevelopment, 5)
+	if err == nil {
+		t.Error("expected error for unregistered agent")
+	}
+}
+
+func TestUpdateCursorForChannel_ErrorOnUnregisteredChannel(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment})
+
+	ctx := context.Background()
+	err := svc.UpdateCursorForChannel(ctx, "architect-001", ChannelProduct, 5)
+	if err == nil {
+		t.Error("expected error for unregistered channel")
+	}
+}
+
+func TestHaveNewMessagesForChannel_OnlyChecksSpecifiedChannel(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment, ChannelProduct})
+
+	// Only add a message to the product channel
+	addTestMessage(svc, 1, "@pm-001", ChannelProduct, "product msg")
+
+	// Development should have no new messages
+	if svc.HaveNewMessagesForChannel("architect-001", ChannelDevelopment) {
+		t.Error("expected no new development messages")
+	}
+
+	// Product should have new messages
+	if !svc.HaveNewMessagesForChannel("architect-001", ChannelProduct) {
+		t.Error("expected new product messages")
+	}
+}
+
+func TestHaveNewMessagesForChannel_ExcludesOwnMessages(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment})
+
+	// Only the architect's own message in the channel
+	addTestMessage(svc, 1, FormatAuthor("architect-001"), ChannelDevelopment, "my message")
+
+	if svc.HaveNewMessagesForChannel("architect-001", ChannelDevelopment) {
+		t.Error("expected no new messages (own messages excluded)")
+	}
+}
+
+func TestHaveNewMessagesForChannel_UnregisteredAgent(t *testing.T) {
+	svc := newTestService()
+
+	if svc.HaveNewMessagesForChannel("unknown-agent", ChannelDevelopment) {
+		t.Error("expected false for unregistered agent")
+	}
+}
+
+func TestHaveNewMessagesForChannel_UnregisteredChannel(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment})
+
+	addTestMessage(svc, 1, "@coder-001", ChannelProduct, "product msg")
+
+	if svc.HaveNewMessagesForChannel("architect-001", ChannelProduct) {
+		t.Error("expected false for unregistered channel")
+	}
+}
+
+func TestProductCursorUnaffectedByDevChannelRead(t *testing.T) {
+	svc := newTestService()
+	svc.RegisterAgent("architect-001", []string{ChannelDevelopment, ChannelProduct})
+
+	// Add messages to both channels
+	addTestMessage(svc, 1, "@coder-001", ChannelDevelopment, "dev msg 1")
+	addTestMessage(svc, 2, "@coder-001", ChannelDevelopment, "dev msg 2")
+	addTestMessage(svc, 3, "@pm-001", ChannelProduct, "product msg 1")
+	addTestMessage(svc, 4, "@pm-001", ChannelProduct, "product msg 2")
+
+	ctx := context.Background()
+
+	// Read development channel and update its cursor
+	devResp, err := svc.GetNewForChannel(ctx, "architect-001", ChannelDevelopment)
+	if err != nil {
+		t.Fatalf("GetNewForChannel failed: %v", err)
+	}
+	if len(devResp.Messages) != 2 {
+		t.Fatalf("expected 2 dev messages, got %d", len(devResp.Messages))
+	}
+	if updateErr := svc.UpdateCursorForChannel(ctx, "architect-001", ChannelDevelopment, devResp.NewPointer); updateErr != nil {
+		t.Fatalf("UpdateCursorForChannel failed: %v", updateErr)
+	}
+
+	// Product channel should still return all messages (cursor not advanced)
+	prodResp, err := svc.GetNewForChannel(ctx, "architect-001", ChannelProduct)
+	if err != nil {
+		t.Fatalf("GetNewForChannel for product failed: %v", err)
+	}
+	if len(prodResp.Messages) != 2 {
+		t.Fatalf("expected 2 product messages (cursor untouched), got %d", len(prodResp.Messages))
+	}
+
+	// Also verify via HaveNewMessages
+	if svc.HaveNewMessagesForChannel("architect-001", ChannelProduct) != true {
+		t.Error("product channel should still have new messages")
+	}
+	if svc.HaveNewMessagesForChannel("architect-001", ChannelDevelopment) != false {
+		t.Error("development channel should have no new messages after cursor update")
+	}
+}


### PR DESCRIPTION
## Summary

- Add channel-scoped chat APIs (`GetNewForChannel`, `UpdateCursorForChannel`, `HaveNewMessagesForChannel`) to prevent dev-chat reads from consuming product/escalation cursor state
- Wire `devChatService` (`*chat.Service`) into the architect driver for direct channel-scoped reads, alongside existing `ChatServiceInterface` for escalations
- On MONITORING heartbeat, check for unread dev-chat messages and transition to REQUEST for processing
- Process each message individually with per-agent context scoping, read tools for workspace inspection, and threaded reply posting via `ReplyTo`
- Add nil guards on `dbOps` async persist calls for testability

This is PR 2 of the budget review feedback loop fix. PR 1 (#189) fixed the immediate incident (APPROVED feedback injection + prompt guidance). This PR addresses the third root cause: the architect couldn't see development channel messages from coders, so status updates like "Implementation complete" were invisible during budget reviews.

### Design notes

- **Best-effort**: Dev-chat is an all-else-fails mechanism, not a reliable channel. Failed messages are marked read (cursor advanced) to avoid retry storms. The fallback reply is honest about the failure and directs coders to `ask_question` for reliable responses.
- **Context safety**: On context scoping failure or missing story lease, resets to a clean architect prompt (matching the safety pattern in `request.go`) rather than running against stale/uninitialized context.
- **Channel isolation**: Channel-scoped APIs ensure reading dev-chat never advances the product channel cursor, preserving escalation/PM traffic.

## Test plan

- [x] 12 channel-scoped chat API unit tests (`pkg/chat/service_test.go`)
- [x] 8 dev-chat handler unit tests (`pkg/architect/dev_chat_test.go`)
- [x] `make build` passes (includes linting)
- [x] `make test` passes
- [x] Integration tests pass
- [ ] Production test: coder posts to dev chat → architect reads and responds within one heartbeat cycle
- [ ] Verify product-channel messages are not consumed by dev-chat listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)