### PR TITLE
Update default models to latest: opus-4-6, gpt-5.4

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -217,12 +217,21 @@ var KnownModels = map[string]ModelInfo{
 		MaxOutputTokens:  4096,
 	},
 
-	// GPT-5.2 (latest GPT-5 series with improved capabilities)
+	// GPT-5.2
 	"gpt-5.2": {
 		Provider:         ProviderOpenAI,
 		InputCPM:         20.0,
 		OutputCPM:        60.0,
 		MaxContextTokens: 400000,
+		MaxOutputTokens:  128000,
+	},
+
+	// GPT-5.4 (latest GPT-5 series)
+	"gpt-5.4": {
+		Provider:         ProviderOpenAI,
+		InputCPM:         2.5,
+		OutputCPM:        15.0,
+		MaxContextTokens: 1050000,
 		MaxOutputTokens:  128000,
 	},
 
@@ -531,8 +540,9 @@ const (
 	ModelGPT4o            = "gpt-4o"
 	ModelGPT5             = "gpt-5"
 	ModelGPT52            = "gpt-5.2"
-	DefaultCoderModel     = ModelClaudeSonnet46
-	DefaultArchitectModel = ModelGPT52
+	ModelGPT54            = "gpt-5.4"
+	DefaultCoderModel     = ModelClaudeOpus46
+	DefaultArchitectModel = ModelGPT54
 	DefaultPMModel        = ModelClaudeOpus46
 
 	// Coder execution mode constants.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -382,7 +382,7 @@ var ProviderDefaults = map[string]ProviderLimits{
 		MaxConcurrency:  5,
 	},
 	ProviderOpenAI: {
-		TokensPerMinute: 1000000,
+		TokensPerMinute: 1200000, // Must be > MaxContextTokens/0.9 for GPT-5.4 (1.05M context)
 		MaxConcurrency:  5,
 	},
 	ProviderGoogle: {
@@ -1514,7 +1514,7 @@ func createDefaultConfig() *Config {
 						MaxConcurrency:  5,
 					},
 					OpenAI: ProviderLimits{
-						TokensPerMinute: 1000000,
+						TokensPerMinute: 1200000, // Must be > MaxContextTokens/0.9 for GPT-5.4
 						MaxConcurrency:  5,
 					},
 					Google: ProviderLimits{
@@ -2387,9 +2387,9 @@ func (p AvailableProviders) countAvailableProviders() int {
 func getSmartDefaultModel(agentType string, providers AvailableProviders) string {
 	switch agentType {
 	case AgentTypeArchitect:
-		// Architect prefers GPT-5.2 for reliability, then Anthropic, then Gemini
+		// Architect prefers GPT-5.4 for reliability, then Anthropic, then Gemini
 		if providers.OpenAI {
-			return ModelGPT52
+			return ModelGPT54
 		}
 		if providers.Anthropic {
 			return ModelClaudeOpus46
@@ -2404,7 +2404,7 @@ func getSmartDefaultModel(agentType string, providers AvailableProviders) string
 			return ModelClaudeOpus46
 		}
 		if providers.OpenAI {
-			return ModelGPT52
+			return ModelGPT54
 		}
 		if providers.Google {
 			return ModelGemini3Pro
@@ -2413,10 +2413,10 @@ func getSmartDefaultModel(agentType string, providers AvailableProviders) string
 	case AgentTypeCoder:
 		// Coder prefers Anthropic for tool use, then OpenAI, then Google
 		if providers.Anthropic {
-			return ModelClaudeSonnet46
+			return ModelClaudeOpus46
 		}
 		if providers.OpenAI {
-			return ModelGPT52
+			return ModelGPT54
 		}
 		if providers.Google {
 			return ModelGemini3Pro

--- a/pkg/config/smart_defaults_test.go
+++ b/pkg/config/smart_defaults_test.go
@@ -106,7 +106,7 @@ func TestGetSmartDefaultModel(t *testing.T) {
 			name:      "architect prefers openai",
 			agentType: AgentTypeArchitect,
 			providers: AvailableProviders{Anthropic: true, OpenAI: true, Google: true},
-			want:      ModelGPT52,
+			want:      ModelGPT54,
 		},
 		{
 			name:      "architect falls back to anthropic",
@@ -132,7 +132,7 @@ func TestGetSmartDefaultModel(t *testing.T) {
 			name:      "pm falls back to openai",
 			agentType: AgentTypePM,
 			providers: AvailableProviders{Anthropic: false, OpenAI: true, Google: true},
-			want:      ModelGPT52,
+			want:      ModelGPT54,
 		},
 		{
 			name:      "pm falls back to google",
@@ -146,13 +146,13 @@ func TestGetSmartDefaultModel(t *testing.T) {
 			name:      "coder prefers anthropic",
 			agentType: AgentTypeCoder,
 			providers: AvailableProviders{Anthropic: true, OpenAI: true, Google: true},
-			want:      ModelClaudeSonnet46,
+			want:      ModelClaudeOpus46,
 		},
 		{
 			name:      "coder falls back to openai",
 			agentType: AgentTypeCoder,
 			providers: AvailableProviders{Anthropic: false, OpenAI: true, Google: true},
-			want:      ModelGPT52,
+			want:      ModelGPT54,
 		},
 		{
 			name:      "coder falls back to google",
@@ -207,9 +207,9 @@ func TestApplySmartModelDefaults(t *testing.T) {
 			openai:             "sk-openai-test",
 			google:             "google-test",
 			wantSingleProvider: false,
-			wantCoderModel:     ModelClaudeSonnet46, // Anthropic preferred
-			wantArchitectModel: ModelGPT52,          // OpenAI preferred
-			wantPMModel:        ModelClaudeOpus46,   // Anthropic preferred
+			wantCoderModel:     ModelClaudeOpus46, // Anthropic preferred
+			wantArchitectModel: ModelGPT54,        // OpenAI preferred
+			wantPMModel:        ModelClaudeOpus46, // Anthropic preferred
 		},
 		{
 			name:               "anthropic only - single provider warning",
@@ -217,7 +217,7 @@ func TestApplySmartModelDefaults(t *testing.T) {
 			openai:             "",
 			google:             "",
 			wantSingleProvider: true,
-			wantCoderModel:     ModelClaudeSonnet46,
+			wantCoderModel:     ModelClaudeOpus46,
 			wantArchitectModel: ModelClaudeOpus46,
 			wantPMModel:        ModelClaudeOpus46,
 		},
@@ -237,7 +237,7 @@ func TestApplySmartModelDefaults(t *testing.T) {
 			openai:             "",
 			google:             "google-test",
 			wantSingleProvider: false,
-			wantCoderModel:     ModelClaudeSonnet46,
+			wantCoderModel:     ModelClaudeOpus46,
 			wantArchitectModel: ModelClaudeOpus46, // Anthropic preferred (no OpenAI)
 			wantPMModel:        ModelClaudeOpus46,
 		},

--- a/pkg/github/integration_test.go
+++ b/pkg/github/integration_test.go
@@ -346,13 +346,21 @@ func TestIntegration_PRLifecycle(t *testing.T) {
 	}
 	t.Logf("✅ PR closed")
 
-	// Verify PR is closed
-	closedPR, err := client.GetPR(ctx, fmt.Sprintf("%d", pr.Number))
-	if err != nil {
-		t.Fatalf("GetPR after close failed: %v", err)
+	// Verify PR is closed (retry briefly — GitHub API is eventually consistent)
+	prRef := fmt.Sprintf("%d", pr.Number)
+	var closedPR *PullRequest
+	for range 5 {
+		closedPR, err = client.GetPR(ctx, prRef)
+		if err != nil {
+			t.Fatalf("GetPR after close failed: %v", err)
+		}
+		if closedPR.Closed {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
 	}
 	if !closedPR.Closed {
-		t.Errorf("PR closed = %v, want true", closedPR.Closed)
+		t.Errorf("PR closed = %v, want true (after retries)", closedPR.Closed)
 	}
 	t.Logf("✅ PR closure confirmed")
 }


### PR DESCRIPTION
## Summary

- Add `gpt-5.4` to known models (1M context window, $2.50/$15 per M tokens)
- Update default coder model from `claude-sonnet-4-6` to `claude-opus-4-6`
- Update default architect model from `gpt-5.2` to `gpt-5.4`
- PM model already on `claude-opus-4-6` (unchanged)
- Fix GitHub PR closure race condition in integration test (retry loop for eventual consistency)

Also updated the production config at `maestro-work/ai-character/.maestro/config.json` (not in this repo).

## Test plan

- [x] `make build` passes
- [x] Config tests pass
- [x] Integration tests pass (including the fixed PR closure test)
- [ ] Production test with new models

🤖 Generated with [Claude Code](https://claude.com/claude-code)