### PR TITLE
Fix build tool cwd fallback and Anthropic schema serialization

### DIFF
--- a/pkg/agent/internal/llmimpl/anthropic/client.go
+++ b/pkg/agent/internal/llmimpl/anthropic/client.go
@@ -65,14 +65,16 @@ func convertPropertyToAnthropicSchema(prop *tools.Property) map[string]any {
 		schema["enum"] = prop.Enum
 	}
 
-	// Recurse into array items.
-	if prop.Type == "array" && prop.Items != nil {
-		schema["items"] = convertPropertyToAnthropicSchema(prop.Items)
+	// Add array constraints at the array level, and recurse into items when present.
+	if prop.Type == "array" {
 		if prop.MinItems != nil {
 			schema["minItems"] = *prop.MinItems
 		}
 		if prop.MaxItems != nil {
 			schema["maxItems"] = *prop.MaxItems
+		}
+		if prop.Items != nil {
+			schema["items"] = convertPropertyToAnthropicSchema(prop.Items)
 		}
 	}
 

--- a/pkg/agent/internal/llmimpl/anthropic/client.go
+++ b/pkg/agent/internal/llmimpl/anthropic/client.go
@@ -16,6 +16,7 @@ import (
 	"orchestrator/pkg/agent/llm"
 	"orchestrator/pkg/agent/llmerrors"
 	"orchestrator/pkg/config"
+	"orchestrator/pkg/tools"
 )
 
 // ClaudeClient wraps the Anthropic API client to implement llm.LLMClient interface.
@@ -48,6 +49,48 @@ func NewClaudeClientWithModel(apiKey, model string) llm.LLMClient {
 		client: client,
 		model:  model,
 	}
+}
+
+// convertPropertyToAnthropicSchema recursively converts a tools.Property to the
+// map[string]any format expected by the Anthropic API. Handles nested objects,
+// array items, enums, required fields, and minItems at every depth.
+func convertPropertyToAnthropicSchema(prop *tools.Property) map[string]any {
+	schema := map[string]any{
+		"type": prop.Type,
+	}
+	if prop.Description != "" {
+		schema["description"] = prop.Description
+	}
+	if len(prop.Enum) > 0 {
+		schema["enum"] = prop.Enum
+	}
+
+	// Recurse into array items.
+	if prop.Type == "array" && prop.Items != nil {
+		schema["items"] = convertPropertyToAnthropicSchema(prop.Items)
+		if prop.MinItems != nil {
+			schema["minItems"] = *prop.MinItems
+		}
+		if prop.MaxItems != nil {
+			schema["maxItems"] = *prop.MaxItems
+		}
+	}
+
+	// Recurse into object properties.
+	if prop.Properties != nil {
+		childProps := make(map[string]any)
+		for name, childProp := range prop.Properties {
+			if childProp != nil {
+				childProps[name] = convertPropertyToAnthropicSchema(childProp)
+			}
+		}
+		schema["properties"] = childProps
+	}
+	if len(prop.Required) > 0 {
+		schema["required"] = prop.Required
+	}
+
+	return schema
 }
 
 // validatePreSend performs final validation before API call to catch common issues.
@@ -360,20 +403,13 @@ func (c *ClaudeClient) Complete(ctx context.Context, in llm.CompletionRequest) (
 			var properties any
 			var required []string
 
-			// Convert InputSchema properties to the format expected by Anthropic API.
+			// Convert InputSchema properties recursively to preserve nested schemas
+			// (array items, object properties, enums, required fields at all depths).
 			if len(tool.InputSchema.Properties) > 0 {
 				props := make(map[string]any)
 				for name := range tool.InputSchema.Properties { //nolint:gocritic // Need to copy properties
 					prop := tool.InputSchema.Properties[name]
-					propMap := make(map[string]any)
-					propMap["type"] = prop.Type
-					if prop.Description != "" {
-						propMap["description"] = prop.Description
-					}
-					if len(prop.Enum) > 0 {
-						propMap["enum"] = prop.Enum
-					}
-					props[name] = propMap
+					props[name] = convertPropertyToAnthropicSchema(&prop)
 				}
 				properties = props
 			}

--- a/pkg/agent/internal/llmimpl/anthropic/client_test.go
+++ b/pkg/agent/internal/llmimpl/anthropic/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"orchestrator/pkg/agent/llm"
+	"orchestrator/pkg/tools"
 )
 
 // TestEnsureAlternation tests the message alternation logic.
@@ -237,4 +238,221 @@ func hasSubstring(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestConvertPropertyToAnthropicSchema verifies that the Anthropic schema serializer
+// recursively converts nested Properties, including array items with object schemas,
+// enums, required fields, and minItems/maxItems.
+// Regression: the old flat serializer dropped Items, Properties, Required, and MinItems,
+// causing submit_verification and submit_probing to reach Claude without enum constraints.
+func TestConvertPropertyToAnthropicSchema(t *testing.T) {
+	t.Run("FlatStringProperty", func(t *testing.T) {
+		prop := &tools.Property{
+			Type:        "string",
+			Description: "A simple string",
+		}
+		schema := convertPropertyToAnthropicSchema(prop)
+
+		if schema["type"] != "string" {
+			t.Errorf("expected type=string, got %v", schema["type"])
+		}
+		if schema["description"] != "A simple string" {
+			t.Errorf("expected description, got %v", schema["description"])
+		}
+		if _, ok := schema["enum"]; ok {
+			t.Error("unexpected enum field")
+		}
+	})
+
+	t.Run("StringWithEnum", func(t *testing.T) {
+		prop := &tools.Property{
+			Type:        "string",
+			Description: "Confidence level",
+			Enum:        []string{"high", "medium", "low"},
+		}
+		schema := convertPropertyToAnthropicSchema(prop)
+
+		enum, ok := schema["enum"].([]string)
+		if !ok {
+			t.Fatal("expected enum to be []string")
+		}
+		if len(enum) != 3 || enum[0] != "high" {
+			t.Errorf("unexpected enum: %v", enum)
+		}
+	})
+
+	t.Run("ArrayOfObjects", func(t *testing.T) {
+		// Mirrors the submit_verification schema: array of criterion objects.
+		minItems := 1
+		prop := &tools.Property{
+			Type:        "array",
+			Description: "Criteria results",
+			MinItems:    &minItems,
+			Items: &tools.Property{
+				Type: "object",
+				Properties: map[string]*tools.Property{
+					"criterion": {
+						Type:        "string",
+						Description: "The criterion",
+					},
+					"method": {
+						Type:        "string",
+						Description: "How verified",
+						Enum:        []string{"command", "inspection"},
+					},
+					"result": {
+						Type:        "string",
+						Description: "Result",
+						Enum:        []string{"pass", "fail", "partial", "unverified"},
+					},
+				},
+				Required: []string{"criterion", "method", "result"},
+			},
+		}
+		schema := convertPropertyToAnthropicSchema(prop)
+
+		// Verify top-level array fields.
+		if schema["type"] != "array" {
+			t.Errorf("expected type=array, got %v", schema["type"])
+		}
+		if schema["minItems"] != 1 {
+			t.Errorf("expected minItems=1, got %v", schema["minItems"])
+		}
+
+		// Verify items object was serialized.
+		items, ok := schema["items"].(map[string]any)
+		if !ok {
+			t.Fatal("expected items to be map[string]any")
+		}
+		if items["type"] != "object" {
+			t.Errorf("expected items.type=object, got %v", items["type"])
+		}
+
+		// Verify nested properties exist.
+		itemProps, ok := items["properties"].(map[string]any)
+		if !ok {
+			t.Fatal("expected items.properties to be map[string]any")
+		}
+		if len(itemProps) != 3 {
+			t.Errorf("expected 3 properties, got %d", len(itemProps))
+		}
+
+		// Verify method enum is preserved.
+		method, ok := itemProps["method"].(map[string]any)
+		if !ok {
+			t.Fatal("expected method to be map[string]any")
+		}
+		methodEnum, ok := method["enum"].([]string)
+		if !ok {
+			t.Fatal("expected method.enum to be []string")
+		}
+		if len(methodEnum) != 2 || methodEnum[0] != "command" || methodEnum[1] != "inspection" {
+			t.Errorf("unexpected method enum: %v", methodEnum)
+		}
+
+		// Verify result enum is preserved.
+		result, ok := itemProps["result"].(map[string]any)
+		if !ok {
+			t.Fatal("expected result to be map[string]any")
+		}
+		resultEnum, ok := result["enum"].([]string)
+		if !ok {
+			t.Fatal("expected result.enum to be []string")
+		}
+		if len(resultEnum) != 4 {
+			t.Errorf("expected 4 result enum values, got %d", len(resultEnum))
+		}
+
+		// Verify required is preserved at the items level.
+		required, ok := items["required"].([]string)
+		if !ok {
+			t.Fatal("expected items.required to be []string")
+		}
+		if len(required) != 3 {
+			t.Errorf("expected 3 required fields, got %d", len(required))
+		}
+	})
+
+	t.Run("NestedObjectWithoutArray", func(t *testing.T) {
+		// Object property with nested properties (not inside an array).
+		prop := &tools.Property{
+			Type:        "object",
+			Description: "A nested object",
+			Properties: map[string]*tools.Property{
+				"name": {
+					Type:        "string",
+					Description: "Name field",
+				},
+			},
+			Required: []string{"name"},
+		}
+		schema := convertPropertyToAnthropicSchema(prop)
+
+		childProps, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Fatal("expected properties to be map[string]any")
+		}
+		if _, hasName := childProps["name"]; !hasName {
+			t.Error("expected name property")
+		}
+		required, ok := schema["required"].([]string)
+		if !ok {
+			t.Fatal("expected required to be []string")
+		}
+		if len(required) != 1 || required[0] != "name" {
+			t.Errorf("unexpected required: %v", required)
+		}
+	})
+
+	t.Run("MaxItemsPresent", func(t *testing.T) {
+		maxItems := 10
+		prop := &tools.Property{
+			Type:     "array",
+			MaxItems: &maxItems,
+			Items: &tools.Property{
+				Type: "string",
+			},
+		}
+		schema := convertPropertyToAnthropicSchema(prop)
+
+		if schema["maxItems"] != 10 {
+			t.Errorf("expected maxItems=10, got %v", schema["maxItems"])
+		}
+	})
+
+	// Integration-style: verify submit_verification Definition() round-trips correctly.
+	t.Run("SubmitVerificationFullSchema", func(t *testing.T) {
+		tool := tools.NewSubmitVerificationTool()
+		def := tool.Definition()
+
+		// Convert the top-level properties through our serializer.
+		result := make(map[string]any)
+		for name := range def.InputSchema.Properties {
+			prop := def.InputSchema.Properties[name]
+			result[name] = convertPropertyToAnthropicSchema(&prop)
+		}
+
+		// Verify acceptance_criteria_checked has nested items with enum.
+		acc, ok := result["acceptance_criteria_checked"].(map[string]any)
+		if !ok {
+			t.Fatal("expected acceptance_criteria_checked")
+		}
+		items, ok := acc["items"].(map[string]any)
+		if !ok {
+			t.Fatal("expected items in acceptance_criteria_checked")
+		}
+		props, ok := items["properties"].(map[string]any)
+		if !ok {
+			t.Fatal("expected properties in items")
+		}
+
+		// The method enum must survive serialization.
+		method, ok := props["method"].(map[string]any)
+		if !ok {
+			t.Fatal("expected method property in items")
+		}
+		if _, ok := method["enum"]; !ok {
+			t.Error("method enum was dropped during serialization — this was the production bug")
+		}
+	})
 }

--- a/pkg/templates/coder/testing_adversarial_probing.tpl.md
+++ b/pkg/templates/coder/testing_adversarial_probing.tpl.md
@@ -6,7 +6,7 @@ You are a robustness probing agent. Your sole task is to inspect the implementat
 
 1. You are **READ-ONLY**. Do not suggest or attempt code changes.
 2. You **MUST** call `submit_probing` within 3 tool turns.
-3. Use the `shell` tool to run read-only commands: `cat`, `grep`, `find`, `git diff`, `git log`, `ls`, `wc`, etc.
+3. Use the `shell` tool to run read-only commands: `cat`, `grep`, `find`, `git diff`, `git log`, `ls`, `wc`, etc. Your working directory is `/workspace` — do NOT use `cd` to change directories, just run commands directly.
 4. Do NOT run commands that modify files, build artifacts, or install packages.
 5. Focus on **robustness issues**, not code quality or style.
 

--- a/pkg/templates/coder/testing_verification.tpl.md
+++ b/pkg/templates/coder/testing_verification.tpl.md
@@ -6,7 +6,7 @@ You are a verification agent. Your sole task is to verify that the implementatio
 
 1. You are **READ-ONLY**. Do not suggest or attempt code changes.
 2. You **MUST** call `submit_verification` before your 5 tool turns are exhausted. It is your only goal.
-3. Use the `shell` tool to run read-only commands: `cat`, `grep`, `find`, `git diff`, `git log`, `ls`, `wc`, etc.
+3. Use the `shell` tool to run read-only commands: `cat`, `grep`, `find`, `git diff`, `git log`, `ls`, `wc`, etc. Your working directory is `/workspace` — do NOT use `cd` to change directories, just run commands directly.
 4. Do NOT run commands that modify files, build artifacts, or install packages.
 5. Focus on **verification**, not implementation suggestions.
 

--- a/pkg/tools/build_tools.go
+++ b/pkg/tools/build_tools.go
@@ -30,7 +30,8 @@ func isExecutorUsable(e execpkg.Executor) bool {
 }
 
 // extractExecArgs extracts common arguments from tool execution.
-func extractExecArgs(args map[string]any) (cwd string, timeout int, err error) {
+// defaultCwd is used when the LLM omits the cwd parameter (typically AgentContext.WorkDir).
+func extractExecArgs(args map[string]any, defaultCwd string) (cwd string, timeout int, err error) {
 	// Extract working directory.
 	if cwdVal, hasCwd := args["cwd"]; hasCwd {
 		if cwdStr, ok := cwdVal.(string); ok {
@@ -38,7 +39,10 @@ func extractExecArgs(args map[string]any) (cwd string, timeout int, err error) {
 		}
 	}
 
-	// Use current directory if not specified.
+	// Fall back to the configured workspace directory, then os.Getwd as last resort.
+	if cwd == "" {
+		cwd = defaultCwd
+	}
 	if cwd == "" {
 		cwd, err = os.Getwd()
 		if err != nil {
@@ -163,13 +167,15 @@ func executeBuildOperation(ctx context.Context, buildService *build.Service, ope
 
 // BuildTool provides MCP interface for build operations.
 type BuildTool struct {
-	buildService *build.Service
+	buildService   *build.Service
+	defaultWorkDir string
 }
 
 // NewBuildTool creates a new build tool instance.
-func NewBuildTool(buildService *build.Service) *BuildTool {
+func NewBuildTool(buildService *build.Service, defaultWorkDir string) *BuildTool {
 	return &BuildTool{
-		buildService: buildService,
+		buildService:   buildService,
+		defaultWorkDir: defaultWorkDir,
 	}
 }
 
@@ -215,7 +221,7 @@ func (b *BuildTool) PromptDocumentation() string {
 
 // Exec executes the build operation.
 func (b *BuildTool) Exec(ctx context.Context, args map[string]any) (*ExecResult, error) {
-	cwd, timeout, err := extractExecArgs(args)
+	cwd, timeout, err := extractExecArgs(args, b.defaultWorkDir)
 	if err != nil {
 		return nil, err
 	}
@@ -246,13 +252,15 @@ func (b *BuildTool) Exec(ctx context.Context, args map[string]any) (*ExecResult,
 
 // TestTool provides MCP interface for test operations.
 type TestTool struct {
-	buildService *build.Service
+	buildService   *build.Service
+	defaultWorkDir string
 }
 
 // NewTestTool creates a new test tool instance.
-func NewTestTool(buildService *build.Service) *TestTool {
+func NewTestTool(buildService *build.Service, defaultWorkDir string) *TestTool {
 	return &TestTool{
-		buildService: buildService,
+		buildService:   buildService,
+		defaultWorkDir: defaultWorkDir,
 	}
 }
 
@@ -293,7 +301,7 @@ func (t *TestTool) PromptDocumentation() string {
 
 // Exec executes the test operation.
 func (t *TestTool) Exec(ctx context.Context, args map[string]any) (*ExecResult, error) {
-	cwd, timeout, err := extractExecArgs(args)
+	cwd, timeout, err := extractExecArgs(args, t.defaultWorkDir)
 	if err != nil {
 		return nil, err
 	}
@@ -303,13 +311,15 @@ func (t *TestTool) Exec(ctx context.Context, args map[string]any) (*ExecResult, 
 
 // LintTool provides MCP interface for linting operations.
 type LintTool struct {
-	buildService *build.Service
+	buildService   *build.Service
+	defaultWorkDir string
 }
 
 // NewLintTool creates a new lint tool instance.
-func NewLintTool(buildService *build.Service) *LintTool {
+func NewLintTool(buildService *build.Service, defaultWorkDir string) *LintTool {
 	return &LintTool{
-		buildService: buildService,
+		buildService:   buildService,
+		defaultWorkDir: defaultWorkDir,
 	}
 }
 
@@ -350,7 +360,7 @@ func (l *LintTool) PromptDocumentation() string {
 
 // Exec executes the lint operation.
 func (l *LintTool) Exec(ctx context.Context, args map[string]any) (*ExecResult, error) {
-	cwd, timeout, err := extractExecArgs(args)
+	cwd, timeout, err := extractExecArgs(args, l.defaultWorkDir)
 	if err != nil {
 		return nil, err
 	}
@@ -705,13 +715,15 @@ func (d *DoneTool) branchHasCommits(ctx context.Context, opts *execpkg.Opts) boo
 
 // BackendInfoTool provides MCP interface for backend information.
 type BackendInfoTool struct {
-	buildService *build.Service
+	buildService   *build.Service
+	defaultWorkDir string
 }
 
 // NewBackendInfoTool creates a new backend info tool instance.
-func NewBackendInfoTool(buildService *build.Service) *BackendInfoTool {
+func NewBackendInfoTool(buildService *build.Service, defaultWorkDir string) *BackendInfoTool {
 	return &BackendInfoTool{
-		buildService: buildService,
+		buildService:   buildService,
+		defaultWorkDir: defaultWorkDir,
 	}
 }
 
@@ -748,7 +760,7 @@ func (b *BackendInfoTool) PromptDocumentation() string {
 
 // Exec executes the backend info operation.
 func (b *BackendInfoTool) Exec(_ context.Context, args map[string]any) (*ExecResult, error) {
-	cwd, _, err := extractExecArgs(args)
+	cwd, _, err := extractExecArgs(args, b.defaultWorkDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tools/build_tools.go
+++ b/pkg/tools/build_tools.go
@@ -189,7 +189,7 @@ func (b *BuildTool) Definition() ToolDefinition {
 			Properties: map[string]Property{
 				"cwd": {
 					Type:        "string",
-					Description: "Working directory (defaults to current directory)",
+					Description: "Working directory (defaults to agent workspace)",
 				},
 				"timeout": {
 					Type:        "number",
@@ -274,7 +274,7 @@ func (t *TestTool) Definition() ToolDefinition {
 			Properties: map[string]Property{
 				"cwd": {
 					Type:        "string",
-					Description: "Working directory (defaults to current directory)",
+					Description: "Working directory (defaults to agent workspace)",
 				},
 				"timeout": {
 					Type:        "number",
@@ -333,7 +333,7 @@ func (l *LintTool) Definition() ToolDefinition {
 			Properties: map[string]Property{
 				"cwd": {
 					Type:        "string",
-					Description: "Working directory (defaults to current directory)",
+					Description: "Working directory (defaults to agent workspace)",
 				},
 				"timeout": {
 					Type:        "number",
@@ -737,7 +737,7 @@ func (b *BackendInfoTool) Definition() ToolDefinition {
 			Properties: map[string]Property{
 				"cwd": {
 					Type:        "string",
-					Description: "Working directory (defaults to current directory)",
+					Description: "Working directory (defaults to agent workspace)",
 				},
 			},
 			Required: []string{},

--- a/pkg/tools/build_tools_test.go
+++ b/pkg/tools/build_tools_test.go
@@ -60,7 +60,7 @@ lint:
 
 	// Test BackendInfoTool.
 	t.Run("BackendInfoTool", func(t *testing.T) {
-		tool := NewBackendInfoTool(buildService)
+		tool := NewBackendInfoTool(buildService, tempDir)
 
 		// Test tool definition.
 		def := tool.Definition()
@@ -106,7 +106,7 @@ lint:
 
 	// Test BuildTool.
 	t.Run("BuildTool", func(t *testing.T) {
-		tool := NewBuildTool(buildService)
+		tool := NewBuildTool(buildService, tempDir)
 
 		// Test tool definition.
 		def := tool.Definition()
@@ -158,7 +158,7 @@ lint:
 
 	// Test TestTool.
 	t.Run("TestTool", func(t *testing.T) {
-		tool := NewTestTool(buildService)
+		tool := NewTestTool(buildService, tempDir)
 
 		// Test tool definition.
 		def := tool.Definition()
@@ -197,7 +197,7 @@ lint:
 
 	// Test LintTool.
 	t.Run("LintTool", func(t *testing.T) {
-		tool := NewLintTool(buildService)
+		tool := NewLintTool(buildService, tempDir)
 
 		// Test tool definition.
 		def := tool.Definition()
@@ -236,7 +236,7 @@ lint:
 
 	// Test error handling.
 	t.Run("ErrorHandling", func(t *testing.T) {
-		tool := NewBuildTool(buildService)
+		tool := NewBuildTool(buildService, tempDir)
 
 		// Test with non-existent directory.
 		args := map[string]any{
@@ -284,10 +284,10 @@ func TestBuildToolsDefinitions(t *testing.T) {
 
 	// Test all tool definitions.
 	tools := []Tool{
-		NewBuildTool(buildService),
-		NewTestTool(buildService),
-		NewLintTool(buildService),
-		NewBackendInfoTool(buildService),
+		NewBuildTool(buildService, ""),
+		NewTestTool(buildService, ""),
+		NewLintTool(buildService, ""),
+		NewBackendInfoTool(buildService, ""),
 	}
 
 	expectedNames := []string{"build", "test", "lint", "backend_info"}
@@ -314,12 +314,126 @@ func TestBuildToolsDefinitions(t *testing.T) {
 	}
 }
 
+// TestBuildToolsDefaultWorkDir verifies that build tools use defaultWorkDir
+// when cwd is omitted from the LLM's arguments, instead of falling back to os.Getwd().
+// Regression test: in production, the orchestrator's cwd is different from the agent
+// workspace, causing build validation to inspect the wrong directory.
+//
+// The test asserts on the Dir field recorded by MockExecutor to confirm the workspace
+// path actually reached the executor — not just that the tool call succeeded (which
+// would also pass under the broken os.Getwd fallback when the repo has its own Makefile).
+func TestBuildToolsDefaultWorkDir(t *testing.T) {
+	// Create a temporary workspace with a valid Go project.
+	workspace, err := os.MkdirTemp("", "build-default-cwd")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(workspace)
+
+	// Resolve symlinks so assertions match (macOS /var -> /private/var).
+	workspace, err = filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("Failed to resolve symlinks: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(workspace, "go.mod"), []byte("module test\ngo 1.21\n"), 0644); err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "Makefile"), []byte("build:\n\t@echo ok\ntest:\n\t@echo ok\nlint:\n\t@echo ok\n"), 0644); err != nil {
+		t.Fatalf("Failed to create Makefile: %v", err)
+	}
+
+	// Build/test/lint tools go through the mock executor, so we can check Dir.
+	// BackendInfoTool doesn't call the executor (it only detects backend), so it's
+	// tested separately via the returned project_root field.
+	t.Run("BuildTestLint_MockDir", func(t *testing.T) {
+		tools := []struct {
+			name string
+			make func(*build.Service, string) Tool
+		}{
+			{"BuildTool", func(svc *build.Service, ws string) Tool { return NewBuildTool(svc, ws) }},
+			{"TestTool", func(svc *build.Service, ws string) Tool { return NewTestTool(svc, ws) }},
+			{"LintTool", func(svc *build.Service, ws string) Tool { return NewLintTool(svc, ws) }},
+		}
+
+		for _, tt := range tools {
+			t.Run(tt.name, func(t *testing.T) {
+				buildService := build.NewBuildService()
+				mockExec := build.NewMockExecutor()
+				buildService.SetExecutor(mockExec)
+
+				tool := tt.make(buildService, workspace)
+
+				// Deliberately omit cwd — tool should fall back to defaultWorkDir.
+				result, err := tool.Exec(context.Background(), map[string]any{})
+				if err != nil {
+					t.Fatalf("Exec returned error: %v", err)
+				}
+
+				var resultMap map[string]any
+				if err := json.Unmarshal([]byte(result.Content), &resultMap); err != nil {
+					t.Fatalf("Failed to unmarshal result: %v", err)
+				}
+
+				success, _ := utils.GetMapField[bool](resultMap, "success")
+				if !success {
+					errMsg, _ := utils.GetMapField[string](resultMap, "error")
+					t.Fatalf("Expected success=true, got error: %s", errMsg)
+				}
+
+				// Key assertion: the mock executor must have received the workspace
+				// path, not the test runner's cwd.
+				if len(mockExec.Calls) == 0 {
+					t.Fatal("Expected mock executor to be called")
+				}
+				gotDir := mockExec.Calls[0].Dir
+				if gotDir != workspace {
+					t.Errorf("Executor received Dir=%q, want %q (defaultWorkDir)", gotDir, workspace)
+				}
+			})
+		}
+	})
+
+	// BackendInfoTool doesn't call the executor — verify via project_root in output.
+	t.Run("BackendInfoTool_ProjectRoot", func(t *testing.T) {
+		buildService := build.NewBuildService()
+		mockExec := build.NewMockExecutor()
+		buildService.SetExecutor(mockExec)
+
+		tool := NewBackendInfoTool(buildService, workspace)
+
+		result, err := tool.Exec(context.Background(), map[string]any{})
+		if err != nil {
+			t.Fatalf("Exec returned error: %v", err)
+		}
+
+		var resultMap map[string]any
+		if err := json.Unmarshal([]byte(result.Content), &resultMap); err != nil {
+			t.Fatalf("Failed to unmarshal result: %v", err)
+		}
+
+		success, _ := utils.GetMapField[bool](resultMap, "success")
+		if !success {
+			errMsg, _ := utils.GetMapField[string](resultMap, "error")
+			t.Fatalf("Expected success=true, got error: %s", errMsg)
+		}
+
+		projectRoot, err := utils.GetMapField[string](resultMap, "project_root")
+		if err != nil {
+			t.Fatalf("Expected project_root field: %v", err)
+		}
+		if projectRoot != workspace {
+			t.Errorf("project_root=%q, want %q (defaultWorkDir)", projectRoot, workspace)
+		}
+	})
+}
+
 func TestBuildServiceRequiresExecutor(t *testing.T) {
 	// Verify that build service fails gracefully without executor.
 	buildService := build.NewBuildService()
 	// Don't set an executor
 
-	tool := NewBuildTool(buildService)
+	tool := NewBuildTool(buildService, "")
 
 	args := map[string]any{
 		"cwd": "/tmp",

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -276,21 +276,21 @@ func createStoryCompleteTool(_ *AgentContext) (Tool, error) {
 func createBuildTool(ctx *AgentContext) (Tool, error) {
 	buildSvc := build.NewBuildService()
 	configureBuildServiceExecutor(buildSvc, ctx)
-	return NewBuildTool(buildSvc), nil
+	return NewBuildTool(buildSvc, ctx.WorkDir), nil
 }
 
 // createTestTool creates a test tool instance.
 func createTestTool(ctx *AgentContext) (Tool, error) {
 	buildSvc := build.NewBuildService()
 	configureBuildServiceExecutor(buildSvc, ctx)
-	return NewTestTool(buildSvc), nil
+	return NewTestTool(buildSvc, ctx.WorkDir), nil
 }
 
 // createLintTool creates a lint tool instance.
 func createLintTool(ctx *AgentContext) (Tool, error) {
 	buildSvc := build.NewBuildService()
 	configureBuildServiceExecutor(buildSvc, ctx)
-	return NewLintTool(buildSvc), nil
+	return NewLintTool(buildSvc, ctx.WorkDir), nil
 }
 
 // createDoneTool creates a done tool instance.
@@ -302,7 +302,7 @@ func createDoneTool(ctx *AgentContext) (Tool, error) {
 func createBackendInfoTool(ctx *AgentContext) (Tool, error) {
 	buildSvc := build.NewBuildService()
 	configureBuildServiceExecutor(buildSvc, ctx)
-	return NewBackendInfoTool(buildSvc), nil
+	return NewBackendInfoTool(buildSvc, ctx.WorkDir), nil
 }
 
 // configureBuildServiceExecutor sets up the executor for a build service based on context.
@@ -448,17 +448,17 @@ func getSubmitProbingSchema() InputSchema {
 
 func getBuildSchema() InputSchema {
 	buildSvc := build.NewBuildService()
-	return NewBuildTool(buildSvc).Definition().InputSchema
+	return NewBuildTool(buildSvc, "").Definition().InputSchema
 }
 
 func getTestSchema() InputSchema {
 	buildSvc := build.NewBuildService()
-	return NewTestTool(buildSvc).Definition().InputSchema
+	return NewTestTool(buildSvc, "").Definition().InputSchema
 }
 
 func getLintSchema() InputSchema {
 	buildSvc := build.NewBuildService()
-	return NewLintTool(buildSvc).Definition().InputSchema
+	return NewLintTool(buildSvc, "").Definition().InputSchema
 }
 
 func getDoneSchema() InputSchema {
@@ -467,7 +467,7 @@ func getDoneSchema() InputSchema {
 
 func getBackendInfoSchema() InputSchema {
 	buildSvc := build.NewBuildService()
-	return NewBackendInfoTool(buildSvc).Definition().InputSchema
+	return NewBackendInfoTool(buildSvc, "").Definition().InputSchema
 }
 
 func getContainerBuildSchema() InputSchema {


### PR DESCRIPTION
## Summary

Two production bugs discovered during TESTING pipeline validation:

- **Build tools defaulted to orchestrator's cwd** when the LLM omitted the `cwd` parameter, causing `build`, `test`, `lint`, and `backend_info` to validate against the wrong directory. Now defaults from `AgentContext.WorkDir` with `os.Getwd()` as last resort.
- **Anthropic client dropped nested tool schemas** — only serialized top-level `type`, `description`, and `enum`, silently losing `Items`, `Properties`, `Required`, and `MinItems`. This meant `submit_verification` and `submit_probing` reached Claude without their array-of-object structure or enum constraints. Added recursive `convertPropertyToAnthropicSchema` matching the pattern already used by OpenAI, Google, and Ollama clients.
- **Verification/probing prompts now state the workspace path** (`/workspace`) so the LLM doesn't hallucinate container paths.

## Test plan

- [x] `TestBuildToolsDefaultWorkDir` — asserts mock executor `Dir` matches workspace (not just success), covers build/test/lint/backend_info
- [x] `TestConvertPropertyToAnthropicSchema` — flat, enum, array-of-objects (mirrors submit_verification), nested object, minItems/maxItems, full submit_verification round-trip
- [x] All existing build tools tests pass with updated signatures
- [x] `make build` (includes lint) passes
- [x] `make test` — full suite passes
- [x] Pre-push integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)