### PR TITLE
Add submit reminder to probing toolloop

### DIFF
--- a/pkg/coder/probing.go
+++ b/pkg/coder/probing.go
@@ -206,6 +206,12 @@ func (c *Coder) runAdversarialProbing(
 				c.logger.Warn("🔌 Circuit breaker tripped in probing: %s (%d failures)", label, count)
 			},
 		},
+		BeforeIteration: func(iteration int, cm *contextmgr.ContextManager) {
+			if iteration == maxProbingIterations-1 {
+				c.logger.Info("🔍 Injecting submit reminder at probing iteration %d", iteration)
+				cm.AddMessage("user", "You have 1 tool call remaining. Call submit_probing now with your findings. If any area was not fully investigated, mark it as inconclusive and submit.")
+			}
+		},
 	}
 
 	// Run probing loop


### PR DESCRIPTION
## Summary

- Production logs showed ~50% of adversarial probing runs exhausting the 3-turn budget without calling `submit_probing`, wasting compute and degrading to "unavailable"
- Adds a `BeforeIteration` callback (same pattern as verification's fix in 6cb1be1) that injects a reminder at the penultimate turn nudging the LLM to submit findings
- Fires at iteration 2 of 3, matching verification's `maxIterations - 1` pattern

## Test plan

- [x] `make build` passes
- [x] All existing probing tests pass (`go test ./pkg/coder/...`)
- [x] Integration tests pass (pre-push hook)
- [ ] Production run: verify probing completion rate improves (expect `submit_probing` called instead of budget exhaustion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)