### PR TITLE
Validate API keys at startup, enter setup mode on failure

### DIFF
--- a/pkg/dispatch/dispatcher.go
+++ b/pkg/dispatch/dispatcher.go
@@ -169,17 +169,17 @@ func NewDispatcher(cfg *config.Config) (*Dispatcher, error) {
 		shutdown:          make(chan struct{}),
 		running:           false,
 		storyCh:           make(chan *proto.AgentMsg, storyChannelSize(cfg.Agents.MaxCoders)), // S-5: Buffer size = factor × numCoders (clamped)
-		hotfixStoryCh:     make(chan *proto.AgentMsg, 10),                                                       // Hotfix stories channel (dedicated coder)
-		questionsCh:       make(chan *proto.AgentMsg, config.QuestionsChannelSize),                              // Buffer size from config
-		pmRequestsCh:      make(chan *proto.AgentMsg, 10),                                                       // Buffered channel for PM interview requests
-		statusUpdatesCh:   make(chan *proto.StoryStatusUpdate, 100),                                             // Buffered channel for status updates
-		requeueRequestsCh: make(chan *proto.StoryRequeueRequest, 100),                                           // Buffered channel for requeue requests
-		replyChannels:     make(map[string]chan *proto.AgentMsg),                                                // Per-agent reply channels
-		errCh:             make(chan AgentError, 10),                                                            // Buffered channel for error reporting
-		stateChangeCh:     make(chan *proto.StateChangeNotification, 100),                                       // Buffered channel for state change notifications
-		cancelRequestsCh:  make(chan *proto.AgentCancelRequest, 20),                                             // Buffered channel for agent cancellation requests
-		leases:            make(map[string]string),                                                              // Story lease tracking
-		runStrat:          &goroutineStrategy{},                                                                 // Default to production goroutine strategy
+		hotfixStoryCh:     make(chan *proto.AgentMsg, 10),                                     // Hotfix stories channel (dedicated coder)
+		questionsCh:       make(chan *proto.AgentMsg, config.QuestionsChannelSize),            // Buffer size from config
+		pmRequestsCh:      make(chan *proto.AgentMsg, 10),                                     // Buffered channel for PM interview requests
+		statusUpdatesCh:   make(chan *proto.StoryStatusUpdate, 100),                           // Buffered channel for status updates
+		requeueRequestsCh: make(chan *proto.StoryRequeueRequest, 100),                         // Buffered channel for requeue requests
+		replyChannels:     make(map[string]chan *proto.AgentMsg),                              // Per-agent reply channels
+		errCh:             make(chan AgentError, 10),                                          // Buffered channel for error reporting
+		stateChangeCh:     make(chan *proto.StateChangeNotification, 100),                     // Buffered channel for state change notifications
+		cancelRequestsCh:  make(chan *proto.AgentCancelRequest, 20),                           // Buffered channel for agent cancellation requests
+		leases:            make(map[string]string),                                            // Story lease tracking
+		runStrat:          &goroutineStrategy{},                                               // Default to production goroutine strategy
 	}, nil
 }
 

--- a/pkg/preflight/readiness.go
+++ b/pkg/preflight/readiness.go
@@ -1,0 +1,96 @@
+package preflight
+
+import (
+	"context"
+
+	"orchestrator/pkg/config"
+)
+
+// ValidatorFunc validates API keys for the given config and returns check results.
+// The default implementation calls ValidateRequiredKeys with real API calls.
+// Tests can replace this to inject deterministic validation results.
+type ValidatorFunc func(ctx context.Context, cfg *config.Config) []KeyCheckResult
+
+// validatorFunc is the current validator implementation. Tests inject mocks here.
+var validatorFunc ValidatorFunc //nolint:gochecknoglobals // injectable seam for tests
+
+// SetValidatorFunc replaces the validator used by EvaluateSetupReadiness.
+// Pass nil to restore the default (real API validation).
+func SetValidatorFunc(fn ValidatorFunc) {
+	validatorFunc = fn
+}
+
+// ReadinessResult describes whether all required API keys are accessible and valid.
+//
+//nolint:govet // fieldalignment: logical grouping preferred over memory optimization
+type ReadinessResult struct {
+	// Ready is true when all required keys are accessible and validated successfully.
+	Ready bool `json:"ready"`
+
+	// AllPresent is true when all required keys are accessible (env or decrypted secrets).
+	AllPresent bool `json:"all_present"`
+
+	// KeyInfo lists presence status for each required key.
+	KeyInfo []ProviderKeyInfo `json:"key_info"`
+
+	// ValidationErrors holds results for keys that are present but rejected (unauthorized/forbidden).
+	ValidationErrors []KeyCheckResult `json:"validation_errors,omitempty"`
+
+	// Warnings holds results for transient failures (unreachable, generic error) that don't block startup.
+	Warnings []KeyCheckResult `json:"warnings,omitempty"`
+}
+
+// EvaluateSetupReadiness checks whether all required API keys are accessible
+// and valid for the current configuration.
+//
+// Flow:
+//  1. Determine required providers from config
+//  2. Check key presence via GetSystemSecret (handles env + decrypted secrets)
+//  3. If any keys missing → not ready (missing-key setup flow)
+//  4. If all present → validate with real API calls (or injected validator)
+//  5. Classify results: unauthorized/forbidden → blocking; unreachable/error → warning
+func EvaluateSetupReadiness(ctx context.Context, cfg *config.Config) *ReadinessResult {
+	result := &ReadinessResult{}
+
+	// Step 1-2: Check which required keys are accessible
+	keyInfo, allPresent := CheckRequiredAPIKeys(cfg)
+	result.KeyInfo = keyInfo
+	result.AllPresent = allPresent
+
+	if !allPresent {
+		// Can't validate what we don't have — report missing keys
+		result.Ready = false
+		return result
+	}
+
+	// Step 3: All required keys are present — validate them
+	validate := validatorFunc
+	if validate == nil {
+		validate = ValidateRequiredKeys
+	}
+	validationResults := validate(ctx, cfg)
+
+	// Step 4: Classify results
+	hasBlockingError := false
+	for i := range validationResults {
+		r := &validationResults[i]
+		switch r.Status {
+		case KeyStatusValid:
+			// OK — nothing to do
+		case KeyStatusUnauthorized, KeyStatusForbidden:
+			// Blocking — key is wrong
+			hasBlockingError = true
+			result.ValidationErrors = append(result.ValidationErrors, *r)
+		case KeyStatusMissing:
+			// Shouldn't happen (allPresent was true) but handle defensively
+			hasBlockingError = true
+			result.ValidationErrors = append(result.ValidationErrors, *r)
+		default:
+			// Unreachable, generic error, etc. — warn but don't block
+			result.Warnings = append(result.Warnings, *r)
+		}
+	}
+
+	result.Ready = !hasBlockingError
+	return result
+}

--- a/pkg/preflight/readiness_test.go
+++ b/pkg/preflight/readiness_test.go
@@ -1,0 +1,220 @@
+package preflight
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"orchestrator/pkg/config"
+)
+
+// fakeValidator returns a ValidatorFunc that returns the given results.
+func fakeValidator(results []KeyCheckResult) ValidatorFunc {
+	return func(_ context.Context, _ *config.Config) []KeyCheckResult {
+		return results
+	}
+}
+
+func setupReadinessTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := &config.Config{
+		OperatingMode: config.OperatingModeStandard,
+		Agents: &config.AgentConfig{
+			CoderModel:     "claude-sonnet-4-5",
+			ArchitectModel: "o3-mini",
+			PMModel:        "claude-opus-4-5",
+		},
+	}
+	config.SetConfigForTesting(cfg)
+	t.Cleanup(func() { config.SetConfigForTesting(nil) })
+	return cfg
+}
+
+func setTestKeys(t *testing.T, keys map[string]string) {
+	t.Helper()
+	for k, v := range keys {
+		orig := os.Getenv(k)
+		if v != "" {
+			os.Setenv(k, v)
+		} else {
+			os.Unsetenv(k)
+		}
+		k2, orig2 := k, orig
+		t.Cleanup(func() {
+			if orig2 != "" {
+				os.Setenv(k2, orig2)
+			} else {
+				os.Unsetenv(k2)
+			}
+		})
+	}
+}
+
+var allKeysPresent = map[string]string{
+	"ANTHROPIC_API_KEY": "sk-ant-test",
+	"OPENAI_API_KEY":    "sk-openai-test",
+	"GITHUB_TOKEN":      "ghp_test",
+}
+
+var allKeysMissing = map[string]string{
+	"ANTHROPIC_API_KEY": "",
+	"OPENAI_API_KEY":    "",
+	"GITHUB_TOKEN":      "",
+}
+
+func TestEvaluateSetupReadiness(t *testing.T) {
+	tests := []struct {
+		name             string
+		keys             map[string]string
+		validatorResults []KeyCheckResult
+		wantReady        bool
+		wantAllPresent   bool
+		wantErrors       int
+		wantWarnings     int
+	}{
+		{
+			name: "all_valid",
+			keys: allKeysPresent,
+			validatorResults: []KeyCheckResult{
+				{Provider: ProviderAnthropic, EnvVar: "ANTHROPIC_API_KEY", Status: KeyStatusValid},
+				{Provider: ProviderOpenAI, EnvVar: "OPENAI_API_KEY", Status: KeyStatusValid},
+				{Provider: ProviderGitHub, EnvVar: "GITHUB_TOKEN", Status: KeyStatusValid},
+			},
+			wantReady:      true,
+			wantAllPresent: true,
+			wantErrors:     0,
+			wantWarnings:   0,
+		},
+		{
+			name:           "missing_keys_skips_validation",
+			keys:           allKeysMissing,
+			wantReady:      false,
+			wantAllPresent: false,
+			wantErrors:     0,
+			wantWarnings:   0,
+		},
+		{
+			name: "unauthorized_blocks",
+			keys: allKeysPresent,
+			validatorResults: []KeyCheckResult{
+				{Provider: ProviderAnthropic, EnvVar: "ANTHROPIC_API_KEY", Status: KeyStatusUnauthorized, Message: "401"},
+				{Provider: ProviderOpenAI, EnvVar: "OPENAI_API_KEY", Status: KeyStatusValid},
+				{Provider: ProviderGitHub, EnvVar: "GITHUB_TOKEN", Status: KeyStatusValid},
+			},
+			wantReady:      false,
+			wantAllPresent: true,
+			wantErrors:     1,
+			wantWarnings:   0,
+		},
+		{
+			name: "forbidden_blocks",
+			keys: allKeysPresent,
+			validatorResults: []KeyCheckResult{
+				{Provider: ProviderAnthropic, EnvVar: "ANTHROPIC_API_KEY", Status: KeyStatusValid},
+				{Provider: ProviderOpenAI, EnvVar: "OPENAI_API_KEY", Status: KeyStatusForbidden, Message: "403"},
+				{Provider: ProviderGitHub, EnvVar: "GITHUB_TOKEN", Status: KeyStatusValid},
+			},
+			wantReady:      false,
+			wantAllPresent: true,
+			wantErrors:     1,
+			wantWarnings:   0,
+		},
+		{
+			name: "unreachable_warns_but_allows",
+			keys: allKeysPresent,
+			validatorResults: []KeyCheckResult{
+				{Provider: ProviderAnthropic, EnvVar: "ANTHROPIC_API_KEY", Status: KeyStatusValid},
+				{Provider: ProviderOpenAI, EnvVar: "OPENAI_API_KEY", Status: KeyStatusUnreachable, Message: "timeout"},
+				{Provider: ProviderGitHub, EnvVar: "GITHUB_TOKEN", Status: KeyStatusValid},
+			},
+			wantReady:      true,
+			wantAllPresent: true,
+			wantErrors:     0,
+			wantWarnings:   1,
+		},
+		{
+			name: "generic_error_warns_but_allows",
+			keys: allKeysPresent,
+			validatorResults: []KeyCheckResult{
+				{Provider: ProviderAnthropic, EnvVar: "ANTHROPIC_API_KEY", Status: KeyStatusError, Message: "unexpected"},
+				{Provider: ProviderOpenAI, EnvVar: "OPENAI_API_KEY", Status: KeyStatusValid},
+				{Provider: ProviderGitHub, EnvVar: "GITHUB_TOKEN", Status: KeyStatusValid},
+			},
+			wantReady:      true,
+			wantAllPresent: true,
+			wantErrors:     0,
+			wantWarnings:   1,
+		},
+		{
+			name: "mixed_unauthorized_and_unreachable",
+			keys: allKeysPresent,
+			validatorResults: []KeyCheckResult{
+				{Provider: ProviderAnthropic, EnvVar: "ANTHROPIC_API_KEY", Status: KeyStatusUnauthorized, Message: "bad key"},
+				{Provider: ProviderOpenAI, EnvVar: "OPENAI_API_KEY", Status: KeyStatusUnreachable, Message: "timeout"},
+				{Provider: ProviderGitHub, EnvVar: "GITHUB_TOKEN", Status: KeyStatusValid},
+			},
+			wantReady:      false,
+			wantAllPresent: true,
+			wantErrors:     1,
+			wantWarnings:   1,
+		},
+		{
+			name: "partial_keys_missing",
+			keys: map[string]string{
+				"ANTHROPIC_API_KEY": "sk-ant-test",
+				"OPENAI_API_KEY":    "",
+				"GITHUB_TOKEN":      "ghp_test",
+			},
+			wantReady:      false,
+			wantAllPresent: false,
+			wantErrors:     0,
+			wantWarnings:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setupReadinessTestConfig(t)
+			setTestKeys(t, tt.keys)
+			config.SetDecryptedSecrets(nil)
+
+			if tt.validatorResults != nil {
+				SetValidatorFunc(fakeValidator(tt.validatorResults))
+			} else {
+				// No validator needed — missing keys path skips validation entirely
+				SetValidatorFunc(nil)
+			}
+			t.Cleanup(func() { SetValidatorFunc(nil) })
+
+			result := EvaluateSetupReadiness(context.Background(), cfg)
+
+			if result.Ready != tt.wantReady {
+				t.Errorf("Ready = %v, want %v", result.Ready, tt.wantReady)
+			}
+			if result.AllPresent != tt.wantAllPresent {
+				t.Errorf("AllPresent = %v, want %v", result.AllPresent, tt.wantAllPresent)
+			}
+			if len(result.ValidationErrors) != tt.wantErrors {
+				t.Errorf("ValidationErrors = %d, want %d", len(result.ValidationErrors), tt.wantErrors)
+			}
+			if len(result.Warnings) != tt.wantWarnings {
+				t.Errorf("Warnings = %d, want %d", len(result.Warnings), tt.wantWarnings)
+			}
+		})
+	}
+}
+
+func TestSetValidatorFunc_NilRestoresDefault(t *testing.T) {
+	// Setting nil should make EvaluateSetupReadiness use ValidateRequiredKeys.
+	// We can't call it with real keys, but we verify the variable is nil.
+	SetValidatorFunc(func(_ context.Context, _ *config.Config) []KeyCheckResult {
+		return nil
+	})
+	if validatorFunc == nil {
+		t.Error("expected non-nil after set")
+	}
+	SetValidatorFunc(nil)
+	if validatorFunc != nil {
+		t.Error("expected nil after reset")
+	}
+}

--- a/pkg/preflight/validate.go
+++ b/pkg/preflight/validate.go
@@ -60,17 +60,36 @@ var validateMu sync.Mutex //nolint:gochecknoglobals // protects against concurre
 // ValidateKeys checks all configured API keys by making real API calls.
 // Keys that are present get validated; missing keys are reported as "missing".
 // All providers are checked concurrently with per-provider timeouts.
+// Used by the "Check Keys" button to validate all known providers.
 func ValidateKeys(ctx context.Context) []KeyCheckResult {
+	return validateProviders(ctx, []Provider{ProviderAnthropic, ProviderOpenAI, ProviderGoogle, ProviderGitHub})
+}
+
+// ValidateRequiredKeys checks only providers required by the current config.
+// Providers without API key mappings (docker, gitea, ollama) are skipped.
+// Used by startup readiness evaluation.
+func ValidateRequiredKeys(ctx context.Context, cfg *config.Config) []KeyCheckResult {
+	return validateProviders(ctx, RequiredProviders(cfg))
+}
+
+// validateProviders validates a set of providers concurrently.
+// Providers without API key mappings (docker, gitea, ollama) are silently skipped.
+func validateProviders(ctx context.Context, providers []Provider) []KeyCheckResult {
 	validateMu.Lock()
 	defer validateMu.Unlock()
 
-	// Check all providers that have env var mappings (LLM + GitHub)
-	providers := []Provider{ProviderAnthropic, ProviderOpenAI, ProviderGoogle, ProviderGitHub}
+	// Filter to providers that use API keys
+	var apiProviders []Provider
+	for _, p := range providers {
+		if _, ok := providerEnvVar[p]; ok {
+			apiProviders = append(apiProviders, p)
+		}
+	}
 
 	var wg sync.WaitGroup
-	results := make([]KeyCheckResult, len(providers))
+	results := make([]KeyCheckResult, len(apiProviders))
 
-	for i, provider := range providers {
+	for i, provider := range apiProviders {
 		envVar := providerEnvVar[provider]
 		value, _ := config.GetSystemSecret(envVar)
 

--- a/pkg/webui/secrets_handlers.go
+++ b/pkg/webui/secrets_handlers.go
@@ -138,7 +138,7 @@ func (s *Server) handleSecretsSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Signal setup mode if active (belt-and-suspenders with frontend auto-recheck)
-	s.notifySetupIfReady()
+	s.notifySetupIfReady(r.Context())
 
 	response := map[string]interface{}{
 		"success": true,

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -30,6 +30,7 @@ import (
 	"orchestrator/pkg/dispatch"
 	"orchestrator/pkg/logx"
 	"orchestrator/pkg/persistence"
+	"orchestrator/pkg/preflight"
 	"orchestrator/pkg/version"
 )
 
@@ -73,6 +74,9 @@ type Server struct {
 	// Password recovery: verify Basic Auth against verifier file when no password in memory
 	passwordRecovered atomic.Bool
 	recoverMu         sync.Mutex
+	// Startup key validation results (persisted for setup page display)
+	validationResults   *preflight.ReadinessResult
+	validationResultsMu sync.RWMutex
 	// Issue reporting HTTP client (injectable for tests)
 	issueHTTPClient *http.Client
 	// Session token auth: one-time token exchange for cookie-based browser auth
@@ -121,6 +125,20 @@ func (s *Server) SetDemoService(demoService DemoService) {
 // PM implements this to indicate when bootstrap is complete and demo is available.
 func (s *Server) SetDemoAvailabilityChecker(checker DemoAvailabilityChecker) {
 	s.demoAvailabilityChecker = checker
+}
+
+// setValidationResults stores the latest readiness evaluation for the setup page.
+func (s *Server) setValidationResults(result *preflight.ReadinessResult) {
+	s.validationResultsMu.Lock()
+	defer s.validationResultsMu.Unlock()
+	s.validationResults = result
+}
+
+// getValidationResults retrieves the latest readiness evaluation.
+func (s *Server) getValidationResults() *preflight.ReadinessResult {
+	s.validationResultsMu.RLock()
+	defer s.validationResultsMu.RUnlock()
+	return s.validationResults
 }
 
 // handleSessionAuth implements GET /auth/session?token=<token>.
@@ -282,7 +300,7 @@ func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 
 		// Slow path: no password in memory, try to recover via verifier file
 		if config.PasswordVerifierExists(s.workDir) {
-			if s.tryRecoverPassword(password) {
+			if s.tryRecoverPassword(r.Context(), password) {
 				next(w, r)
 				return
 			}
@@ -304,7 +322,7 @@ func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 // caches it in memory and decrypts the secrets file if present.
 // This runs at most once per process — after success, GetWebUIPassword() returns the
 // cached value and requireAuth uses the fast path.
-func (s *Server) tryRecoverPassword(password string) bool {
+func (s *Server) tryRecoverPassword(ctx context.Context, password string) bool {
 	// Already recovered — shouldn't reach here, but guard anyway
 	if s.passwordRecovered.Load() {
 		return false
@@ -347,7 +365,7 @@ func (s *Server) tryRecoverPassword(password string) bool {
 	s.passwordRecovered.Store(true)
 
 	// Signal setup mode in case API keys are now available from decrypted secrets
-	s.notifySetupIfReady()
+	s.notifySetupIfReady(ctx)
 
 	return true
 }
@@ -362,6 +380,7 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/setup", s.requireAuth(s.handleSetupPage))
 	mux.HandleFunc("/api/setup/status", s.requireAuth(s.handleSetupStatus))
 	mux.HandleFunc("/api/setup/recheck", s.requireAuth(s.handleSetupRecheck))
+	mux.HandleFunc("/api/setup/validation-results", s.requireAuth(s.handleValidationResults))
 
 	// Serve static files from embedded filesystem - protected by basic auth
 	staticSubFS, err := fs.Sub(staticFS, "web/static")

--- a/pkg/webui/setup.go
+++ b/pkg/webui/setup.go
@@ -25,9 +25,12 @@ func (s *Server) IsSetupMode() bool {
 	return s.setupMode.Load() == 1
 }
 
-// notifySetupIfReady checks API key readiness and, if all keys are present,
-// sends a non-blocking signal on the setupReady channel.
-func (s *Server) notifySetupIfReady() {
+// notifySetupIfReady evaluates full readiness (presence + validation) and,
+// if all required keys are accessible and valid, sends a non-blocking signal
+// on the setupReady channel. Always persists the latest result so the setup
+// UI reflects current state even when readiness is still false (e.g., keys
+// decrypted after login but unauthorized).
+func (s *Server) notifySetupIfReady(ctx context.Context) {
 	if !s.IsSetupMode() {
 		return
 	}
@@ -37,8 +40,12 @@ func (s *Server) notifySetupIfReady() {
 		return
 	}
 
-	_, allPresent := preflight.CheckRequiredAPIKeys(&cfg)
-	if allPresent {
+	result := preflight.EvaluateSetupReadiness(ctx, &cfg)
+
+	// Always persist so the setup UI can reflect the latest state.
+	s.setValidationResults(result)
+
+	if result.Ready {
 		select {
 		case s.setupReady <- struct{}{}:
 		default:
@@ -122,7 +129,7 @@ func (s *Server) handleSetupRecheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.notifySetupIfReady()
+	s.notifySetupIfReady(r.Context())
 
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -165,29 +172,47 @@ func (s *Server) handleKeysCheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// WaitForSetup blocks until all required API keys are configured.
-// If all keys are already present, returns immediately without entering setup mode.
-// If WebUI is not available, this is a no-op (agent creation will fail with its own error).
-func (s *Server) WaitForSetup(ctx context.Context, cfg *config.Config) error {
-	keys, allPresent := preflight.CheckRequiredAPIKeys(cfg)
-	if allPresent {
-		return nil
+// handleValidationResults implements GET /api/setup/validation-results.
+// Returns the latest readiness evaluation stored by WaitForSetup or notifySetupIfReady.
+func (s *Server) handleValidationResults(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
 	}
 
-	// Enter setup mode
-	s.SetSetupMode(true)
-	defer s.SetSetupMode(false)
+	result := s.getValidationResults()
+	if result == nil {
+		// No results yet — return empty object
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ready":false,"all_present":false,"key_info":[]}`))
+		return
+	}
 
-	// Print terminal guidance
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		s.logger.Error("Failed to encode validation results: %v", err)
+	}
+}
+
+// printSetupGuidance prints terminal guidance about missing or invalid keys.
+func printSetupGuidance(result *preflight.ReadinessResult, cfg *config.Config) {
 	fmt.Println()
-	fmt.Println("Missing API keys:")
-	for i := range keys {
-		if !keys[i].Present {
-			fmt.Printf("  - %s\n", keys[i].EnvVarName)
+	if !result.AllPresent {
+		fmt.Println("Missing API keys:")
+		for i := range result.KeyInfo {
+			if !result.KeyInfo[i].Present {
+				fmt.Printf("  - %s\n", result.KeyInfo[i].EnvVarName)
+			}
+		}
+	}
+	if len(result.ValidationErrors) > 0 {
+		fmt.Println("Invalid API keys:")
+		for i := range result.ValidationErrors {
+			e := &result.ValidationErrors[i]
+			fmt.Printf("  - %s: %s\n", e.EnvVar, e.Status)
 		}
 	}
 
-	// Determine WebUI URL
 	protocol := "http"
 	if cfg.WebUI != nil && cfg.WebUI.SSL {
 		protocol = "https"
@@ -206,19 +231,47 @@ func (s *Server) WaitForSetup(ctx context.Context, cfg *config.Config) error {
 	fmt.Printf("Configure them in the WebUI at %s://%s:%d/setup\n", protocol, host, port)
 	fmt.Println("Press Ctrl+C to cancel.")
 	fmt.Println()
+}
 
-	// Wait for keys to be configured
+// WaitForSetup blocks until all required API keys are configured and valid.
+// If all keys are already present and valid, returns immediately without entering setup mode.
+// If keys are missing or invalid (unauthorized/forbidden), enters setup mode and waits.
+// Transient errors (unreachable) are logged as warnings but don't block startup.
+func (s *Server) WaitForSetup(ctx context.Context, cfg *config.Config) error {
+	result := preflight.EvaluateSetupReadiness(ctx, cfg)
+
+	// Log warnings for transient provider issues (non-blocking)
+	for i := range result.Warnings {
+		w := &result.Warnings[i]
+		s.logger.Warn("⚠️  %s: %s (non-blocking)", w.Provider, w.Message)
+	}
+
+	if result.Ready {
+		return nil
+	}
+
+	// Store results for the setup page to display on load
+	s.setValidationResults(result)
+
+	// Enter setup mode
+	s.SetSetupMode(true)
+	defer s.SetSetupMode(false)
+
+	printSetupGuidance(result, cfg)
+
+	// Wait for keys to be configured and validated
 	for {
 		select {
 		case <-s.setupReady:
 			// Re-verify — channel signal may be a false positive
-			_, allPresent := preflight.CheckRequiredAPIKeys(cfg)
-			if allPresent {
-				s.logger.Info("All API keys configured. Continuing startup...")
-				fmt.Println("All API keys configured. Continuing startup...")
+			fresh := preflight.EvaluateSetupReadiness(ctx, cfg)
+			if fresh.Ready {
+				s.logger.Info("All API keys configured and valid. Continuing startup...")
+				fmt.Println("All API keys configured and valid. Continuing startup...")
 				return nil
 			}
-			// Not all present yet, keep waiting
+			// Not ready yet — update stored results and keep waiting
+			s.setValidationResults(fresh)
 		case <-ctx.Done():
 			return fmt.Errorf("waiting for API keys: %w", ctx.Err())
 		}

--- a/pkg/webui/setup_test.go
+++ b/pkg/webui/setup_test.go
@@ -12,6 +12,7 @@ import (
 
 	"orchestrator/pkg/config"
 	"orchestrator/pkg/logx"
+	"orchestrator/pkg/preflight"
 )
 
 func TestSetupMode_Toggle(t *testing.T) {
@@ -165,7 +166,21 @@ func TestSetupStatus_Response(t *testing.T) {
 	}
 }
 
+// allValidValidator returns a ValidatorFunc that reports all keys as valid.
+func allValidValidator() preflight.ValidatorFunc {
+	return func(_ context.Context, _ *config.Config) []preflight.KeyCheckResult {
+		return []preflight.KeyCheckResult{
+			{Provider: "anthropic", EnvVar: "ANTHROPIC_API_KEY", Status: preflight.KeyStatusValid, Message: "ok"},
+			{Provider: "openai", EnvVar: "OPENAI_API_KEY", Status: preflight.KeyStatusValid, Message: "ok"},
+			{Provider: "github", EnvVar: "GITHUB_TOKEN", Status: preflight.KeyStatusValid, Message: "ok"},
+		}
+	}
+}
+
 func TestNotifySetupIfReady_SignalsWhenReady(t *testing.T) {
+	preflight.SetValidatorFunc(allValidValidator())
+	defer preflight.SetValidatorFunc(nil)
+
 	cfg := &config.Config{
 		OperatingMode: config.OperatingModeStandard,
 		Agents: &config.AgentConfig{
@@ -195,7 +210,7 @@ func TestNotifySetupIfReady_SignalsWhenReady(t *testing.T) {
 	}
 	s.SetSetupMode(true)
 
-	s.notifySetupIfReady()
+	s.notifySetupIfReady(context.Background())
 
 	select {
 	case <-s.setupReady:
@@ -236,7 +251,7 @@ func TestNotifySetupIfReady_NoSignalWhenMissing(t *testing.T) {
 	}
 	s.SetSetupMode(true)
 
-	s.notifySetupIfReady()
+	s.notifySetupIfReady(context.Background())
 
 	select {
 	case <-s.setupReady:
@@ -246,7 +261,9 @@ func TestNotifySetupIfReady_NoSignalWhenMissing(t *testing.T) {
 	}
 }
 
-func TestNotifySetupIfReady_MultipleSignalsNoPanic(_ *testing.T) {
+func TestNotifySetupIfReady_MultipleSignalsNoPanic(_ *testing.T) { //nolint:revive // t unused but needed for test signature
+	preflight.SetValidatorFunc(allValidValidator())
+	defer preflight.SetValidatorFunc(nil)
 	cfg := &config.Config{
 		OperatingMode: config.OperatingModeStandard,
 		Agents: &config.AgentConfig{
@@ -277,11 +294,13 @@ func TestNotifySetupIfReady_MultipleSignalsNoPanic(_ *testing.T) {
 
 	// Multiple signals should not panic
 	for i := 0; i < 10; i++ {
-		s.notifySetupIfReady()
+		s.notifySetupIfReady(context.Background())
 	}
 }
 
 func TestWaitForSetup_ReturnsImmediatelyWhenReady(t *testing.T) {
+	preflight.SetValidatorFunc(allValidValidator())
+	defer preflight.SetValidatorFunc(nil)
 	cfg := &config.Config{
 		OperatingMode: config.OperatingModeStandard,
 		Agents: &config.AgentConfig{
@@ -321,6 +340,8 @@ func TestWaitForSetup_ReturnsImmediatelyWhenReady(t *testing.T) {
 }
 
 func TestWaitForSetup_BlocksAndUnblocks(t *testing.T) {
+	preflight.SetValidatorFunc(allValidValidator())
+	defer preflight.SetValidatorFunc(nil)
 	cfg := &config.Config{
 		OperatingMode: config.OperatingModeStandard,
 		Agents: &config.AgentConfig{
@@ -370,7 +391,7 @@ func TestWaitForSetup_BlocksAndUnblocks(t *testing.T) {
 
 	// Simulate adding the missing key
 	os.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-	s.notifySetupIfReady()
+	s.notifySetupIfReady(context.Background())
 
 	select {
 	case err := <-done:

--- a/pkg/webui/web/templates/setup.html
+++ b/pkg/webui/web/templates/setup.html
@@ -105,6 +105,12 @@
         const form = document.getElementById('add-key-form');
         const select = document.getElementById('key-select');
 
+        // Auto-redirect if setup mode is off (e.g., login triggered auto-exit)
+        if (data.setup_mode === false) {
+            window.location.href = '/';
+            return;
+        }
+
         if (!keysData.length) {
             list.innerHTML = '<p class="text-gray-500 text-sm">No API keys required.</p>';
             continueBtn.disabled = false;
@@ -172,12 +178,67 @@
         }
     }
 
+    async function fetchValidationResults() {
+        try {
+            const resp = await fetch('/api/setup/validation-results');
+            if (!resp.ok) return null;
+            return await resp.json();
+        } catch (e) {
+            console.error('Validation results fetch error:', e);
+            return null;
+        }
+    }
+
+    function renderValidationResults(data) {
+        if (!data) return;
+
+        const resultsDiv = document.getElementById('validation-results');
+        const listDiv = document.getElementById('validation-list');
+
+        const errors = data.validation_errors || [];
+        const warnings = data.warnings || [];
+        if (errors.length === 0 && warnings.length === 0) {
+            resultsDiv.classList.add('hidden');
+            return;
+        }
+
+        resultsDiv.classList.remove('hidden');
+        const all = errors.concat(warnings);
+        listDiv.innerHTML = all.map(r => {
+            let icon, badgeClass;
+            switch(r.status) {
+                case 'valid': icon = '\u2705'; badgeClass = 'bg-green-100 text-green-800'; break;
+                case 'missing': icon = '\u2014'; badgeClass = 'bg-gray-100 text-gray-800'; break;
+                case 'unauthorized': icon = '\u274C'; badgeClass = 'bg-red-100 text-red-800'; break;
+                case 'forbidden': icon = '\u26A0\uFE0F'; badgeClass = 'bg-yellow-100 text-yellow-800'; break;
+                case 'unreachable': icon = '\uD83D\uDD0C'; badgeClass = 'bg-orange-100 text-orange-800'; break;
+                default: icon = '\u2753'; badgeClass = 'bg-red-100 text-red-800'; break;
+            }
+            const latency = r.latency_ms > 0 ? ' (' + r.latency_ms + 'ms)' : '';
+            return '<div class="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">' +
+                '<div><span class="text-sm font-mono text-gray-800">' + r.env_var + '</span>' +
+                '<span class="ml-2 text-xs text-gray-500">(' + r.provider + ')</span></div>' +
+                '<div class="flex items-center gap-2">' +
+                '<span class="text-xs text-gray-400">' + latency + '</span>' +
+                '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ' + badgeClass + '">' +
+                icon + ' ' + r.status + '</span></div></div>';
+        }).join('');
+
+        // Disable continue if there are blocking errors
+        if (errors.length > 0) {
+            document.getElementById('continue-btn').disabled = true;
+        }
+    }
+
     async function recheckKeys() {
         try {
             const resp = await fetch('/api/setup/recheck', {method: 'POST'});
             if (!resp.ok) throw new Error('Recheck failed');
             const data = await resp.json();
             renderKeys(data);
+            // Also refresh validation results (recheck triggers re-evaluation)
+            const valData = await fetchValidationResults();
+            renderValidationResults(valData);
         } catch (e) {
             console.error('Recheck error:', e);
         }
@@ -186,6 +247,9 @@
     async function refreshStatus() {
         const data = await fetchStatus();
         if (data) renderKeys(data);
+        // Auto-fetch validation results on load
+        const valData = await fetchValidationResults();
+        renderValidationResults(valData);
     }
 
     async function continueSetup() {
@@ -204,6 +268,17 @@
                 const data = await fetchStatus();
                 if (data && !data.setup_mode) {
                     window.location.href = '/';
+                    return;
+                }
+                // Refresh validation results to show updated state
+                if (data) renderKeys(data);
+                const valData = await fetchValidationResults();
+                renderValidationResults(valData);
+                // If validation errors appeared, stop polling and let user fix
+                if (valData && valData.validation_errors && valData.validation_errors.length > 0) {
+                    status.textContent = 'Some API keys are invalid. Please fix them and try again.';
+                    btn.disabled = false;
+                    btn.textContent = 'Continue Setup';
                     return;
                 }
             }


### PR DESCRIPTION
## Summary

- **Problem**: Invalid API keys cause `FatalShutdown` (exit code 1) when the architect's first LLM call fails with 401. Users see "Maestro exited unexpectedly" with no way to fix the key.
- **Fix**: Validate all required API keys *before* launching agents. If any key is rejected (`unauthorized`/`forbidden`), re-enter setup mode so users can fix keys through the WebUI. Transient errors (`unreachable`) are logged as warnings but don't block startup.
- Adds `EvaluateSetupReadiness()` with injectable `ValidatorFunc` seam for testable validation
- Adds `ValidateRequiredKeys()` that filters to API-key providers only (skips docker/gitea/ollama)
- Rewrites `WaitForSetup()` to validate keys, not just check presence
- Adds `/api/setup/validation-results` endpoint; setup.html auto-fetches and displays results

## Test plan

- [x] Table-driven tests for `EvaluateSetupReadiness()` covering: all-valid, unauthorized, forbidden, unreachable (warning), generic error, mixed, partial missing, fully missing
- [x] Existing `setup_test.go` tests updated to use `ValidatorFunc` seam (no real API calls)
- [x] `make test` passes (all unit + integration tests green)
- [x] `make lint` clean
- [x] Manual boot test with valid keys — startup completes normally, no setup mode
- [ ] Manual test with invalid key — enters setup mode, shows validation errors
- [ ] Manual test with encrypted secrets + login recovery path

🤖 Generated with [Claude Code](https://claude.com/claude-code)