### PR TITLE
Add durable asks and incidents for PM memory and idle detection

### DIFF
--- a/docs/DURABLE_ASKS_AND_INCIDENTS.md
+++ b/docs/DURABLE_ASKS_AND_INCIDENTS.md
@@ -179,14 +179,33 @@ Adds a structured `incident_action` PM tool with `resume` as the only supported 
 - `incident_action_result` RESPONSE payload delivers typed success/failure back to PM.
 - Orphan recovery in `system_idle`: dispatched stories whose assigned coder is no longer active are requeued to pending before re-dispatching.
 
-### Phase 2 (follow-up)
+### Phase 2: Full Action Semantics
 
-- Full action semantics: `try_again`, `skip`, `change_request`
-- `try_again` requeues the story (possibly with edited content)
-- `skip` marks the story as permanently abandoned
-- `change_request` modifies story before retry
-- `resume` signals external resolution of the blocking condition
-- Phase 2 may also replace the existing `story_blocked` and `clarification_request` notifications entirely with incidents
+Implemented. Four actions on the `incident_action` tool:
+
+| Action | Description |
+|---|---|
+| `resume` | External blocker resolved — release held stories and re-dispatch |
+| `try_again` | Identical to `resume` (PM picks the word that fits the context) |
+| `skip` | Intentionally abandon a story — marks it `StatusSkipped` (new terminal state) |
+| `change_request` | Append user instructions to story content, reset retry budget, requeue |
+
+**Action × incident-kind matrix:**
+
+| Action | `system_idle` | `story_blocked` | `clarification_needed` |
+|---|---|---|---|
+| `resume` / `try_again` | orphan sweep + re-dispatch | Failed→retry; OnHold→release holds | release holds + re-dispatch |
+| `skip` | N/A | mark story skipped (no sibling release) | N/A |
+| `change_request` | N/A | StatusFailed only; append + reset + retry | N/A |
+
+**Key design decisions:**
+
+- **`StatusSkipped`** is a new terminal status distinct from `StatusFailed`. Terminal guards, `AllStoriesTerminal()`, deadlock detection, session summaries, and PM notifications all include it. `AllStoriesCompleted()` does *not* — skipped ≠ completed. Dependencies on a skipped story are never satisfied.
+- **Reverse-dependency gating:** `SkipStory` rejects if non-terminal stories depend on the target (they would become permanently unstartable).
+- **Skip does not release siblings:** Failure-group holds represent shared blockers. Skipping one story doesn't resolve the shared condition, so siblings stay on hold. Only `resume` releases failure groups.
+- **`change_request` restricted to `StatusFailed`:** For group-scoped incidents (`StatusOnHold`, `clarification_needed`), annotating one story and resuming the group would leave siblings without the annotation. `change_request` only operates on story-local (failed) incidents.
+- **AttemptCount reset:** `change_request` resets attempts to 0 — a user-supplied change is a new direction and deserves a fresh retry budget.
+- **Content annotation:** Appends `"## Change Request (User)"` section to story content, consistent with existing `"## Implementation Notes (Auto-generated)"` and `"## Failure Context (Auto-generated)"` patterns.
 
 ---
 

--- a/docs/DURABLE_ASKS_AND_INCIDENTS.md
+++ b/docs/DURABLE_ASKS_AND_INCIDENTS.md
@@ -157,11 +157,27 @@ Both asks and incidents must survive process restart:
 - `AllowedActions` populated as advisory metadata
 - User acts through natural language via PM; PM routes to architect as needed
 
-### Phase 1.5 (follow-up)
+### Phase 1.5 — `incident_action` tool with `resume`
 
-- Add `incident_action` tool with `resume` action only
-- PM can call `incident_action(id, "resume")` which sends a typed message to architect
-- Architect processes the action and resolves the incident if conditions are met
+Adds a structured `incident_action` PM tool with `resume` as the only supported action. Closes the loop: PM detects incident → tells user → user says retry → PM calls tool → architect recovers.
+
+**Routing:** `PayloadKindIncidentAction` maps to `RequestKindExecution` (no new request kind).
+
+**Resume semantics per incident kind:**
+
+| Kind | Story Status | Recovery Action |
+|------|-------------|-----------------|
+| `system_idle` | N/A | Sweep orphaned dispatched stories (no live coder), resume dispatch |
+| `story_blocked` | `StatusFailed` | `RetryFailedStory` — reset to pending for fresh attempt (preserves attempt count) |
+| `story_blocked` | `StatusOnHold` | Release held stories by failure ID (same as repair_complete path) |
+| `clarification_needed` | `StatusOnHold` | Release held stories by failure ID, resume dispatch |
+
+**Key rules:**
+- Recovery executes *before* incident resolution. If recovery fails, incident stays open and PM gets a failure result.
+- When resuming by failure ID, *all* related incidents for that failure are resolved (not just the clicked one). A single prerequisite failure can open both `story_blocked` and `clarification_needed`.
+- Both PM (tool side) and architect (handler side) validate `resume` ∈ `AllowedActions`.
+- `incident_action_result` RESPONSE payload delivers typed success/failure back to PM.
+- Orphan recovery in `system_idle`: dispatched stories whose assigned coder is no longer active are requeued to pending before re-dispatching.
 
 ### Phase 2 (follow-up)
 

--- a/docs/DURABLE_ASKS_AND_INCIDENTS.md
+++ b/docs/DURABLE_ASKS_AND_INCIDENTS.md
@@ -1,0 +1,184 @@
+# Durable Asks & Incidents
+
+*Design document for fixes to GitHub issues #200 (PM silent in AWAIT_USER) and #201 (architect silent in MONITORING).*
+
+## Problem Statement
+
+Maestro goes silent for hours when work stalls. Two root causes:
+
+1. **PM memory loss (#200):** PM sends ACTION REQUIRED via `chat_ask_user`, transitions to AWAIT_USER, and waits indefinitely. When the user eventually responds, PM has no structured memory of what's pending, so it gives stale or incorrect status.
+
+2. **Architect silence (#201):** When all coders die (watchdog kills) or stall, the architect loops in MONITORING every 30s checking for messages that will never arrive. No escalation to PM or user.
+
+## Design Principle
+
+"Waiting on user" should be a durable product-state object, not a timer problem. Timers compensate for missing memory; durable asks and incidents solve the actual bug.
+
+Timers are intentionally not part of this design. Edge-triggered communication (one notification per incident open/close) replaces polling and reminders.
+
+---
+
+## Data Model
+
+### Incident
+
+An **incident** is an architect-owned operational blocker. The architect is the sole authority for opening and closing incidents.
+
+```go
+type Incident struct {
+    ID               string           // incident-{kind}-{storyID|system}-{failureID|timestamp}
+    Kind             IncidentKind     // story_blocked | clarification_needed | system_idle
+    Scope            string           // "story" | "system"
+    StoryID          string           // set for story-scoped incidents
+    FailureID        string           // cross-reference to failure record
+    Title            string
+    Summary          string
+    AffectedStoryIDs []string         // for system_idle: which stories are stuck
+    AllowedActions   []IncidentAction // advisory in Phase 1
+    Blocking         bool
+    OpenedAt         string
+    ResolvedAt       string
+    Resolution       string           // how it was resolved
+}
+```
+
+**Incident kinds:**
+- `story_blocked` — Story abandoned after exhausting retries. Scoped to a single story.
+- `clarification_needed` — Failure requires human input (credentials, unclear requirements). Scoped to a story.
+- `system_idle` — No active coders making progress but pending work exists. Scoped to system.
+
+### UserAsk
+
+A **UserAsk** is a PM-owned conversational obligation. Created when PM calls `chat_ask_user`, resolved when the user responds.
+
+```go
+type UserAsk struct {
+    ID                string // ask-{kind}-{timestamp}
+    Prompt            string
+    Kind              string // "interview_question" | "clarification" | "decision_required"
+    RelatedIncidentID string // optional link to triggering incident
+    OpenedAt          string
+    ResolvedAt        string
+}
+```
+
+**Constraint:** At most one active ask at a time. A new ask implicitly supersedes any prior unresolved ask.
+
+### IncidentAction
+
+Recovery actions a user can take. Advisory metadata in Phase 1.
+
+- `try_again` — Retry the failed story with same or edited content
+- `change_request` — Modify story requirements before retry
+- `skip` — Abandon the story permanently
+- `resume` — Signal that the blocking condition has been resolved externally
+
+---
+
+## Ownership Rules
+
+These rules are the heart of the design:
+
+1. **Asks are PM-owned.** PM creates asks; user replies resolve asks.
+2. **Incidents are architect-owned.** Architect opens incidents; architect-side recovery closes incidents.
+3. **User replies do NOT automatically resolve incidents.** A user chatting with PM may provide information that PM relays to the architect, but the incident closes only when the architect observes recovery (story requeued, hold released, coder becomes active).
+4. **Architect does NOT create or resolve asks.** The PM decides when to ask the user for input.
+
+---
+
+## Lifecycle Rules
+
+### Incident Lifecycle
+
+**Opening triggers:**
+| Kind | Trigger | Location |
+|------|---------|----------|
+| `story_blocked` | Story abandoned (exhausted retries, `!willRetry`) | `notifyPMOfBlockedStory` in `request.go` |
+| `clarification_needed` | Failure requires human input | `notifyPMOfClarificationNeeded` in `request.go` |
+| `system_idle` | No active coders + pending work + idle > 60s | `checkAndOpenIdleIncident` in `monitoring.go` |
+
+**Closing triggers:**
+| Kind | Trigger | Resolution value |
+|------|---------|-----------------|
+| `story_blocked` | Story status no longer `failed`/`on_hold` | `"story_requeued"` |
+| `clarification_needed` | Hold released via `repair_complete` | `"manual"` |
+| `system_idle` | Idle predicate false (coder becomes active) | `"work_resumed"` |
+| Any | All stories terminal | `"all_terminal"` |
+
+**Idle detection specifics:**
+- **Opening** uses a 60s debounce guard (2 heartbeats) to avoid false positives during dispatch transitions.
+- **Closing** is predicate-based only — no timing guard. Once work resumes, close immediately.
+- The `monitoringIdleSince` timestamp is a debounce guard, not durable business state. It is not persisted.
+
+### UserAsk Lifecycle
+
+**Opening:** PM calls `chat_ask_user` → `SignalAwaitUser` handler creates `UserAsk`.
+
+**Closing:** User sends a chat message while PM is in AWAIT_USER → current ask resolved.
+
+**Supersession:** If PM issues a new `chat_ask_user` before the prior ask is resolved, the new ask replaces the old one. Only one ask can be active.
+
+---
+
+## Communication Pattern
+
+Incidents use edge-triggered, not level-triggered, communication:
+
+1. Architect opens incident → sends `incident_opened` payload to PM (once)
+2. PM stores incident in `openIncidents` and injects context into LLM
+3. Architect closes incident → sends `incident_resolved` payload to PM (once)
+4. PM removes incident from `openIncidents`
+
+No polling, no reminders, no timers. The PM's `maybeInjectPendingItemsSummary()` re-injects the summary only when the digest changes (hash-based deduplication), preventing context bloat from `handleWorking()` re-entry loops.
+
+---
+
+## Persistence
+
+Both asks and incidents must survive process restart:
+
+- **PM:** `currentAsk` and `openIncidents` serialized as JSON in `PMState` (explicit DB columns via schema migration).
+- **Architect:** `openIncidents` serialized as JSON in `ArchitectState` (explicit DB column).
+- **State data mirroring:** Runtime state is also mirrored into state data keys (`StateKeyCurrentAsk`, `StateKeyOpenIncidents`) for FSM visibility through existing inspection tools.
+
+---
+
+## Phase Boundaries
+
+### Phase 1 (this implementation)
+
+- Durable `UserAsk` and `Incident` models
+- `incident_opened` / `incident_resolved` payload kinds
+- Architect incident lifecycle (open on story_blocked/clarification, system_idle detection, reconciliation)
+- PM durable ask (singular, created on `chat_ask_user`, resolved on user reply)
+- PM mirrored incidents (stored on `incident_opened`, removed on `incident_resolved`)
+- Pending items summary injection with hash-based change detection
+- Persistence via explicit JSON columns (schema migration v22)
+- `AllowedActions` populated as advisory metadata
+- User acts through natural language via PM; PM routes to architect as needed
+
+### Phase 1.5 (follow-up)
+
+- Add `incident_action` tool with `resume` action only
+- PM can call `incident_action(id, "resume")` which sends a typed message to architect
+- Architect processes the action and resolves the incident if conditions are met
+
+### Phase 2 (follow-up)
+
+- Full action semantics: `try_again`, `skip`, `change_request`
+- `try_again` requeues the story (possibly with edited content)
+- `skip` marks the story as permanently abandoned
+- `change_request` modifies story before retry
+- `resume` signals external resolution of the blocking condition
+- Phase 2 may also replace the existing `story_blocked` and `clarification_request` notifications entirely with incidents
+
+---
+
+## Relationship to Existing Notifications
+
+Phase 1 layers incidents on top of existing notifications. The existing `story_blocked` and `clarification_request` payloads continue to flow and inject immediate LLM context. The new `incident_opened` messages arrive separately and add durable state. Both coexist:
+
+- **Existing notification** → immediate context injection into PM's LLM conversation
+- **New incident** → durable state that survives resume and provides accurate status on re-entry
+
+This avoids a risky migration while still solving the core problem. Phase 2+ may consolidate.

--- a/pkg/architect/STATES.md
+++ b/pkg/architect/STATES.md
@@ -130,7 +130,7 @@ The architect maintains a map of open `Incident` objects — architect-owned ope
 Each monitoring tick runs `reconcileOpenIncidents()` then `checkAndOpenIdleIncident()`:
 - **Opening** uses a 60s debounce guard to avoid false positives during dispatch transitions
 - **Closing** is predicate-based only — no timing guard; once work resumes, close immediately
-- `monitoringIdleSince` is a non-persistent debounce timestamp, reset when a coder message arrives
+- `monitoringIdleSince` is a non-persistent debounce timestamp, set when the idle predicate first becomes true, reset when predicate becomes false or a coder message arrives
 
 ### Ownership Rule
 Architect opens and closes incidents. User replies do NOT automatically resolve incidents — only PM-owned asks. The PM receives `incident_opened`/`incident_resolved` payloads and mirrors the state.

--- a/pkg/architect/STATES.md
+++ b/pkg/architect/STATES.md
@@ -107,6 +107,36 @@ Each type uses appropriate review logic and tools for its domain.
 
 ---
 
+## Durable Incident Lifecycle
+
+The architect maintains a map of open `Incident` objects — architect-owned operational blockers. See `docs/DURABLE_ASKS_AND_INCIDENTS.md` for the full design.
+
+### Incident Opening Triggers
+| Kind | Trigger | Location |
+|------|---------|----------|
+| `story_blocked` | Story abandoned (exhausted retries) | `notifyPMOfBlockedStory` |
+| `clarification_needed` | Failure requires human input | `notifyPMOfClarificationNeeded` |
+| `system_idle` | No active coders + pending work + idle > 60s | `checkAndOpenIdleIncident` in MONITORING |
+
+### Incident Closing Triggers
+| Kind | Trigger | Resolution |
+|------|---------|------------|
+| `story_blocked` | Story no longer failed/on_hold | `"story_requeued"` |
+| `clarification_needed` | Hold released via `repair_complete` | `"manual"` |
+| `system_idle` | Idle predicate false (coder becomes active) | `"work_resumed"` |
+| Any | All stories terminal | `"all_terminal"` |
+
+### System Idle Detection (MONITORING state)
+Each monitoring tick runs `reconcileOpenIncidents()` then `checkAndOpenIdleIncident()`:
+- **Opening** uses a 60s debounce guard to avoid false positives during dispatch transitions
+- **Closing** is predicate-based only — no timing guard; once work resumes, close immediately
+- `monitoringIdleSince` is a non-persistent debounce timestamp, reset when a coder message arrives
+
+### Ownership Rule
+Architect opens and closes incidents. User replies do NOT automatically resolve incidents — only PM-owned asks. The PM receives `incident_opened`/`incident_resolved` payloads and mirrors the state.
+
+---
+
 ## Error handling
 
 * The agent enters **ERROR** when:

--- a/pkg/architect/dispatching.go
+++ b/pkg/architect/dispatching.go
@@ -277,7 +277,7 @@ func (d *Driver) detectDeadlock() bool {
 	var unreleasedStories []*QueuedStory
 	for _, story := range allStories {
 		status := story.GetStatus()
-		if status != StatusDone && status != StatusFailed && status != StatusOnHold {
+		if status != StatusDone && status != StatusFailed && status != StatusSkipped && status != StatusOnHold {
 			unreleasedStories = append(unreleasedStories, story)
 		}
 	}

--- a/pkg/architect/driver.go
+++ b/pkg/architect/driver.go
@@ -115,6 +115,8 @@ type Driver struct {
 	scopeWidener            *ScopeWidener                         // Tracks failure recurrence for scope auto-escalation
 	workDir                 string                                // Workspace directory
 	reviewStreaks           map[string]map[string]int             // Per-coder, per-review-type consecutive NEEDS_CHANGES count
+	openIncidents           map[string]*proto.Incident            // Durable incidents keyed by incident ID
+	monitoringIdleSince     time.Time                             // Debounce guard for system_idle detection (not persisted)
 	pmAllCompleteNotified   bool                                  // Guard: PM "all stories complete" notification already sent
 	pmAllTerminalNotified   bool                                  // Guard: PM "all stories terminal" (with failures) notification already sent
 }
@@ -190,6 +192,7 @@ func NewDriver(architectID, _ string, dispatcher *dispatch.Dispatcher, workDir s
 		BaseStateMachine:   sm,
 		agentContexts:      make(map[string]*contextmgr.ContextManager), // Initialize context map
 		reviewStreaks:      make(map[string]map[string]int),             // Initialize streak tracking
+		openIncidents:      make(map[string]*proto.Incident),            // Initialize incident tracking
 		toolLoop:           nil,                                         // Set via SetLLMClient
 		renderer:           renderer,
 		workDir:            workDir,

--- a/pkg/architect/driver.go
+++ b/pkg/architect/driver.go
@@ -920,7 +920,7 @@ func (d *Driver) processRequeueRequests(ctx context.Context) {
 
 				// Check if all stories are now terminal — if so, notify PM and finish
 				if d.queue.AllStoriesTerminal() {
-					d.logger.Info("📋 All stories are terminal (done or failed). Transitioning to DONE.")
+					d.logger.Info("📋 All stories are terminal (done, failed, or skipped). Transitioning to DONE.")
 					if err := d.notifyPMAllStoriesTerminal(ctx); err != nil {
 						d.logger.Warn("⚠️ Failed to notify PM of all stories terminal: %v", err)
 					}

--- a/pkg/architect/driver.go
+++ b/pkg/architect/driver.go
@@ -115,6 +115,7 @@ type Driver struct {
 	scopeWidener            *ScopeWidener                         // Tracks failure recurrence for scope auto-escalation
 	workDir                 string                                // Workspace directory
 	reviewStreaks           map[string]map[string]int             // Per-coder, per-review-type consecutive NEEDS_CHANGES count
+	incidentsMu             sync.Mutex                            // Protects openIncidents from concurrent access
 	openIncidents           map[string]*proto.Incident            // Durable incidents keyed by incident ID
 	monitoringIdleSince     time.Time                             // Debounce guard for system_idle detection (not persisted)
 	pmAllCompleteNotified   bool                                  // Guard: PM "all stories complete" notification already sent

--- a/pkg/architect/incidents.go
+++ b/pkg/architect/incidents.go
@@ -510,6 +510,12 @@ func (d *Driver) changeRequestStoryBlocked(ctx context.Context, action *proto.In
 		return ""
 	}
 
+	if inc.FailureID != "" && d.queue.HasHeldStoriesForFailure(inc.FailureID) {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			"change_request cannot be used while sibling stories are held by the same failure; use resume to release them first, or revise the story through the spec")
+		return ""
+	}
+
 	if action.Content != "" {
 		story.Content += "\n\n## Change Request (User)\n\n" + action.Content
 		d.logger.Info("📝 Appended change request to story %s (%d chars)", inc.StoryID, len(action.Content))

--- a/pkg/architect/incidents.go
+++ b/pkg/architect/incidents.go
@@ -269,3 +269,193 @@ func (d *Driver) reconcileOpenIncidents(ctx context.Context) {
 		d.resolveIncident(ctx, toResolve[i].id, toResolve[i].reason, toResolve[i].message)
 	}
 }
+
+// handleIncidentAction processes an incident_action request from PM.
+// Performs recovery first, resolves incident on success. Returns next state or "".
+func (d *Driver) handleIncidentAction(ctx context.Context, msg *proto.AgentMsg) proto.State {
+	typedPayload := msg.GetTypedPayload()
+	if typedPayload == nil {
+		d.logger.Warn("Incident action has no payload")
+		return ""
+	}
+
+	action, err := typedPayload.ExtractIncidentAction()
+	if err != nil {
+		d.logger.Warn("Failed to extract incident_action payload: %v", err)
+		return ""
+	}
+
+	d.logger.Info("🔧 Incident action received: %s on %s (%s)", action.Action, action.IncidentID, action.Reason)
+
+	// Look up incident under lock and take a snapshot
+	d.incidentsMu.Lock()
+	inc, exists := d.openIncidents[action.IncidentID]
+	var incidentCopy proto.Incident
+	if exists {
+		incidentCopy = *inc
+	}
+	d.incidentsMu.Unlock()
+
+	if !exists {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Incident %s not found", action.IncidentID))
+		return ""
+	}
+
+	// Validate action is allowed
+	allowed := false
+	for _, a := range incidentCopy.AllowedActions {
+		if string(a) == action.Action {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Action %q not allowed for incident %s", action.Action, action.IncidentID))
+		return ""
+	}
+
+	switch incidentCopy.Kind {
+	case proto.IncidentKindSystemIdle:
+		return d.resumeSystemIdle(ctx, action, &incidentCopy)
+	case proto.IncidentKindStoryBlocked:
+		return d.resumeStoryBlocked(ctx, action, &incidentCopy)
+	case proto.IncidentKindClarification:
+		return d.resumeClarification(ctx, action, &incidentCopy)
+	default:
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Unknown incident kind: %s", incidentCopy.Kind))
+		return ""
+	}
+}
+
+func (d *Driver) resumeSystemIdle(ctx context.Context, action *proto.IncidentActionPayload, _ *proto.Incident) proto.State {
+	// Sweep orphaned dispatched stories before re-dispatching
+	activeAgents := d.getActiveCoderIDs()
+	requeued := d.queue.RequeueOrphanedDispatched(activeAgents)
+	if len(requeued) > 0 {
+		d.logger.Info("🔄 Requeued %d orphaned dispatched stories: %v", len(requeued), requeued)
+	}
+
+	// Resume dispatch if suppressed
+	if suppressed, reason := d.queue.IsDispatchSuppressed(); suppressed {
+		d.queue.ResumeDispatch()
+		d.logger.Info("▶️ Dispatch resumed (was suppressed: %s)", reason)
+	}
+
+	d.resolveIncident(ctx, action.IncidentID, "resumed", action.Reason)
+	d.monitoringIdleSince = time.Time{}
+	d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, true,
+		fmt.Sprintf("System resumed, %d orphaned stories requeued", len(requeued)))
+	return StateDispatching
+}
+
+func (d *Driver) resumeStoryBlocked(ctx context.Context, action *proto.IncidentActionPayload, inc *proto.Incident) proto.State {
+	story, exists := d.queue.GetStory(inc.StoryID)
+	if !exists {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Story %s not found", inc.StoryID))
+		return ""
+	}
+
+	status := story.GetStatus()
+	switch status {
+	case StatusFailed:
+		if retryErr := d.queue.RetryFailedStory(inc.StoryID); retryErr != nil {
+			d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+				fmt.Sprintf("Failed to retry story %s: %v", inc.StoryID, retryErr))
+			return ""
+		}
+		d.logger.Info("🔄 Retrying failed story %s", inc.StoryID)
+
+	case StatusOnHold:
+		// Delegate to repair/release path by failure ID
+		failureID := inc.FailureID
+		if failureID == "" {
+			d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+				"Story is on_hold but incident has no failure ID")
+			return ""
+		}
+		released, _ := d.queue.ReleaseHeldStoriesByFailure(failureID, action.Reason)
+		d.logger.Info("🔓 Released %d held stories for failure %s", len(released), failureID)
+
+	default:
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Story %s is in unexpected status %s", inc.StoryID, status))
+		return ""
+	}
+
+	// Resume dispatch if suppressed
+	if suppressed, reason := d.queue.IsDispatchSuppressed(); suppressed {
+		d.queue.ResumeDispatch()
+		d.logger.Info("▶️ Dispatch resumed (was suppressed: %s)", reason)
+	}
+
+	// Resolve all incidents with matching failure ID (not just this one)
+	if inc.FailureID != "" {
+		d.resolveIncidentsByFailureID(ctx, inc.FailureID, "resumed", action.Reason)
+	}
+	// Also resolve this specific incident if it wasn't caught by failure ID
+	d.resolveIncident(ctx, action.IncidentID, "resumed", action.Reason)
+
+	d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, true,
+		fmt.Sprintf("Story %s recovery initiated", inc.StoryID))
+	return StateDispatching
+}
+
+func (d *Driver) resumeClarification(ctx context.Context, action *proto.IncidentActionPayload, inc *proto.Incident) proto.State {
+	failureID := inc.FailureID
+	if failureID == "" {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			"Clarification incident has no failure ID")
+		return ""
+	}
+
+	released, _ := d.queue.ReleaseHeldStoriesByFailure(failureID, action.Reason)
+	d.logger.Info("🔓 Released %d held stories for failure %s", len(released), failureID)
+
+	// Resume dispatch if suppressed
+	if suppressed, reason := d.queue.IsDispatchSuppressed(); suppressed {
+		d.queue.ResumeDispatch()
+		d.logger.Info("▶️ Dispatch resumed (was suppressed: %s)", reason)
+	}
+
+	// Resolve all incidents with matching failure ID
+	d.resolveIncidentsByFailureID(ctx, failureID, "resumed", action.Reason)
+	d.resolveIncident(ctx, action.IncidentID, "resumed", action.Reason)
+
+	d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, true,
+		fmt.Sprintf("Released %d held stories, clarification resolved", len(released)))
+	return StateDispatching
+}
+
+// sendIncidentActionResult sends the outcome of an incident action back to PM.
+func (d *Driver) sendIncidentActionResult(ctx context.Context, incidentID, action string, success bool, message string) {
+	msg := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), "pm-001")
+	msg.SetTypedPayload(proto.NewIncidentActionResultPayload(&proto.IncidentActionResultPayload{
+		IncidentID: incidentID,
+		Action:     action,
+		Success:    success,
+		Message:    message,
+	}))
+	if err := d.ExecuteEffect(ctx, &SendMessageEffect{Message: msg}); err != nil {
+		d.logger.Warn("Failed to send incident_action_result: %v", err)
+	}
+}
+
+// getActiveCoderIDs returns agent IDs of coders in active states.
+func (d *Driver) getActiveCoderIDs() []string {
+	var ids []string
+	agents := d.dispatcher.GetRegisteredAgents()
+	for i := range agents {
+		if agents[i].Type != "coder" {
+			continue
+		}
+		switch agents[i].State {
+		case "PLANNING", "CODING", "TESTING", "AWAIT_APPROVAL", "PREPARE_MERGE":
+			ids = append(ids, agents[i].ID)
+		}
+	}
+	return ids
+}

--- a/pkg/architect/incidents.go
+++ b/pkg/architect/incidents.go
@@ -10,9 +10,12 @@ import (
 )
 
 // openIncident stores an incident locally and notifies the PM.
+// Thread-safe: acquires incidentsMu.
 func (d *Driver) openIncident(ctx context.Context, incident *proto.Incident) {
+	d.incidentsMu.Lock()
 	d.openIncidents[incident.ID] = incident
-	d.syncIncidentsToStateData()
+	d.syncIncidentsToStateDataLocked()
+	d.incidentsMu.Unlock()
 
 	msg := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), "pm-001")
 	msg.SetTypedPayload(proto.NewIncidentOpenedPayload(incident))
@@ -23,17 +26,18 @@ func (d *Driver) openIncident(ctx context.Context, incident *proto.Incident) {
 	d.logger.Info("Opened incident %s: %s", incident.ID, incident.Title)
 }
 
-// resolveIncident closes an open incident and notifies the PM.
-func (d *Driver) resolveIncident(ctx context.Context, incidentID, resolution, message string) {
+// resolveIncidentLocked closes an open incident and returns the notification to send.
+// Caller must hold incidentsMu.
+func (d *Driver) resolveIncidentLocked(incidentID, resolution, message string) *proto.AgentMsg {
 	inc, exists := d.openIncidents[incidentID]
 	if !exists {
-		return
+		return nil
 	}
 
 	inc.ResolvedAt = time.Now().UTC().Format(time.RFC3339)
 	inc.Resolution = resolution
 	delete(d.openIncidents, incidentID)
-	d.syncIncidentsToStateData()
+	d.syncIncidentsToStateDataLocked()
 
 	msg := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), "pm-001")
 	msg.SetTypedPayload(proto.NewIncidentResolvedPayload(&proto.IncidentResolvedPayload{
@@ -42,31 +46,68 @@ func (d *Driver) resolveIncident(ctx context.Context, incidentID, resolution, me
 		Message:    message,
 		Timestamp:  time.Now().UTC().Format(time.RFC3339),
 	}))
+	return msg
+}
+
+// resolveIncident closes an open incident and notifies the PM.
+// Thread-safe: acquires incidentsMu.
+func (d *Driver) resolveIncident(ctx context.Context, incidentID, resolution, message string) {
+	d.incidentsMu.Lock()
+	msg := d.resolveIncidentLocked(incidentID, resolution, message)
+	d.incidentsMu.Unlock()
+
+	if msg == nil {
+		return
+	}
 	if err := d.ExecuteEffect(ctx, &SendMessageEffect{Message: msg}); err != nil {
 		d.logger.Warn("Failed to send incident_resolved for %s: %v", incidentID, err)
 	}
-
 	d.logger.Info("Resolved incident %s: %s (%s)", incidentID, resolution, message)
 }
 
 // resolveAllIncidents closes all open incidents with the given resolution.
+// Thread-safe: acquires incidentsMu.
 func (d *Driver) resolveAllIncidents(ctx context.Context, resolution, message string) {
+	d.incidentsMu.Lock()
+	var msgs []*proto.AgentMsg
 	for id := range d.openIncidents {
-		d.resolveIncident(ctx, id, resolution, message)
+		if msg := d.resolveIncidentLocked(id, resolution, message); msg != nil {
+			msgs = append(msgs, msg)
+		}
 	}
-}
+	d.incidentsMu.Unlock()
 
-// resolveIncidentsByFailureID closes incidents matching a specific failure ID.
-func (d *Driver) resolveIncidentsByFailureID(ctx context.Context, failureID, resolution, message string) {
-	for id, inc := range d.openIncidents {
-		if inc.FailureID == failureID {
-			d.resolveIncident(ctx, id, resolution, message)
+	for _, msg := range msgs {
+		if err := d.ExecuteEffect(ctx, &SendMessageEffect{Message: msg}); err != nil {
+			d.logger.Warn("Failed to send incident_resolved: %v", err)
 		}
 	}
 }
 
-// syncIncidentsToStateData mirrors open incidents to a state data key for FSM visibility.
-func (d *Driver) syncIncidentsToStateData() {
+// resolveIncidentsByFailureID closes incidents matching a specific failure ID.
+// Thread-safe: acquires incidentsMu.
+func (d *Driver) resolveIncidentsByFailureID(ctx context.Context, failureID, resolution, message string) {
+	d.incidentsMu.Lock()
+	var msgs []*proto.AgentMsg
+	for id, inc := range d.openIncidents {
+		if inc.FailureID == failureID {
+			if msg := d.resolveIncidentLocked(id, resolution, message); msg != nil {
+				msgs = append(msgs, msg)
+			}
+		}
+	}
+	d.incidentsMu.Unlock()
+
+	for _, msg := range msgs {
+		if err := d.ExecuteEffect(ctx, &SendMessageEffect{Message: msg}); err != nil {
+			d.logger.Warn("Failed to send incident_resolved: %v", err)
+		}
+	}
+}
+
+// syncIncidentsToStateDataLocked mirrors open incidents to a state data key.
+// Caller must hold incidentsMu.
+func (d *Driver) syncIncidentsToStateDataLocked() {
 	if len(d.openIncidents) == 0 {
 		d.SetStateData(StateKeyOpenIncidents, "")
 		return
@@ -80,7 +121,11 @@ func (d *Driver) syncIncidentsToStateData() {
 }
 
 // collectOpenIncidentsJSON serializes open incidents as a JSON string for persistence.
+// Thread-safe: acquires incidentsMu.
 func (d *Driver) collectOpenIncidentsJSON() *string {
+	d.incidentsMu.Lock()
+	defer d.incidentsMu.Unlock()
+
 	if len(d.openIncidents) == 0 {
 		return nil
 	}
@@ -95,6 +140,7 @@ func (d *Driver) collectOpenIncidentsJSON() *string {
 
 // isSystemIdlePredicate checks the core idle conditions (1-3) without timing or blocking-incident guards.
 // Used for closing idle incidents — once work resumes, close immediately.
+// Does NOT acquire incidentsMu (no map access).
 func (d *Driver) isSystemIdlePredicate() bool {
 	if d.queue.AllStoriesTerminal() {
 		return false
@@ -120,9 +166,10 @@ func (d *Driver) isSystemIdlePredicate() bool {
 	return true
 }
 
-// isSystemIdle checks all five conditions for opening a system_idle incident.
+// isSystemIdleLocked checks all five conditions for opening a system_idle incident.
 // Includes 60s debounce guard and blocking-incident check.
-func (d *Driver) isSystemIdle() bool {
+// Caller must hold incidentsMu.
+func (d *Driver) isSystemIdleLocked() bool {
 	if !d.isSystemIdlePredicate() {
 		return false
 	}
@@ -140,16 +187,33 @@ func (d *Driver) isSystemIdle() bool {
 }
 
 // checkAndOpenIdleIncident opens a system_idle incident if conditions are met.
+// Thread-safe: acquires incidentsMu.
 func (d *Driver) checkAndOpenIdleIncident(ctx context.Context) {
+	// Update debounce timer based on current idle predicate.
+	// This ensures the 60s guard measures time since idle predicate first became true,
+	// not time since entering MONITORING.
+	if d.isSystemIdlePredicate() {
+		if d.monitoringIdleSince.IsZero() {
+			d.monitoringIdleSince = time.Now()
+		}
+	} else {
+		d.monitoringIdleSince = time.Time{}
+		return
+	}
+
+	d.incidentsMu.Lock()
 	for _, inc := range d.openIncidents {
 		if inc.Kind == proto.IncidentKindSystemIdle {
+			d.incidentsMu.Unlock()
 			return
 		}
 	}
 
-	if !d.isSystemIdle() {
+	if !d.isSystemIdleLocked() {
+		d.incidentsMu.Unlock()
 		return
 	}
+	d.incidentsMu.Unlock()
 
 	pending := d.queue.GetStoriesByStatus(StatusPending)
 	dispatched := d.queue.GetStoriesByStatus(StatusDispatched)
@@ -176,20 +240,32 @@ func (d *Driver) checkAndOpenIdleIncident(ctx context.Context) {
 }
 
 // reconcileOpenIncidents auto-closes incidents whose conditions are no longer true.
+// Thread-safe: acquires incidentsMu for snapshot, then resolves outside lock.
 func (d *Driver) reconcileOpenIncidents(ctx context.Context) {
+	type resolution struct {
+		id, reason, message string
+	}
+	var toResolve []resolution
+
+	d.incidentsMu.Lock()
 	for id, inc := range d.openIncidents {
 		switch inc.Kind {
 		case proto.IncidentKindSystemIdle:
 			if !d.isSystemIdlePredicate() {
-				d.resolveIncident(ctx, id, "work_resumed", "Active coder detected, system no longer idle")
+				toResolve = append(toResolve, resolution{id, "work_resumed", "Active coder detected, system no longer idle"})
 			}
 		case proto.IncidentKindStoryBlocked:
 			story, exists := d.queue.GetStory(inc.StoryID)
 			if exists && story.GetStatus() != StatusFailed && story.GetStatus() != StatusOnHold {
-				d.resolveIncident(ctx, id, "story_requeued", fmt.Sprintf("Story %s resumed", inc.StoryID))
+				toResolve = append(toResolve, resolution{id, "story_requeued", fmt.Sprintf("Story %s resumed", inc.StoryID)})
 			}
 		case proto.IncidentKindClarification:
 			// Closed by repair_complete handler, not by reconciliation
 		}
+	}
+	d.incidentsMu.Unlock()
+
+	for i := range toResolve {
+		d.resolveIncident(ctx, toResolve[i].id, toResolve[i].reason, toResolve[i].message)
 	}
 }

--- a/pkg/architect/incidents.go
+++ b/pkg/architect/incidents.go
@@ -485,11 +485,8 @@ func (d *Driver) skipStoryBlocked(ctx context.Context, action *proto.IncidentAct
 	}
 	d.logger.Info("⏭️ Skipped story %s: %s", inc.StoryID, action.Reason)
 
-	// Resume dispatch if suppressed
-	if suppressed, reason := d.queue.IsDispatchSuppressed(); suppressed {
-		d.queue.ResumeDispatch()
-		d.logger.Info("▶️ Dispatch resumed (was suppressed: %s)", reason)
-	}
+	// Do NOT lift dispatch suppression — skip is a story-local action and
+	// suppression is a global flag set for system-scoped repairs. Only resume lifts it.
 
 	// Resolve only this specific incident — skip does NOT release failure-group siblings
 	d.resolveIncident(ctx, action.IncidentID, "skipped", action.Reason)
@@ -518,8 +515,9 @@ func (d *Driver) changeRequestStoryBlocked(ctx context.Context, action *proto.In
 		d.logger.Info("📝 Appended change request to story %s (%d chars)", inc.StoryID, len(action.Content))
 	}
 
-	// Reset attempt count for a fresh budget
+	// Reset all budgets for a fresh start
 	story.AttemptCount = 0
+	d.queue.ResetAllBudgets(inc.StoryID)
 
 	if retryErr := d.queue.RetryFailedStory(inc.StoryID); retryErr != nil {
 		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
@@ -528,11 +526,8 @@ func (d *Driver) changeRequestStoryBlocked(ctx context.Context, action *proto.In
 	}
 	d.logger.Info("🔄 Retrying story %s with change request", inc.StoryID)
 
-	// Resume dispatch if suppressed
-	if suppressed, reason := d.queue.IsDispatchSuppressed(); suppressed {
-		d.queue.ResumeDispatch()
-		d.logger.Info("▶️ Dispatch resumed (was suppressed: %s)", reason)
-	}
+	// Do NOT lift dispatch suppression — change_request is a story-local action and
+	// suppression is a global flag set for system-scoped repairs. Only resume lifts it.
 
 	// Resolve incidents by failure ID (same as resume for failed stories)
 	if inc.FailureID != "" {

--- a/pkg/architect/incidents.go
+++ b/pkg/architect/incidents.go
@@ -318,14 +318,51 @@ func (d *Driver) handleIncidentAction(ctx context.Context, msg *proto.AgentMsg) 
 
 	switch incidentCopy.Kind {
 	case proto.IncidentKindSystemIdle:
-		return d.resumeSystemIdle(ctx, action, &incidentCopy)
+		return d.handleSystemIdleAction(ctx, action, &incidentCopy)
 	case proto.IncidentKindStoryBlocked:
-		return d.resumeStoryBlocked(ctx, action, &incidentCopy)
+		return d.handleStoryBlockedAction(ctx, action, &incidentCopy)
 	case proto.IncidentKindClarification:
-		return d.resumeClarification(ctx, action, &incidentCopy)
+		return d.handleClarificationAction(ctx, action, &incidentCopy)
 	default:
 		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
 			fmt.Sprintf("Unknown incident kind: %s", incidentCopy.Kind))
+		return ""
+	}
+}
+
+func (d *Driver) handleSystemIdleAction(ctx context.Context, action *proto.IncidentActionPayload, inc *proto.Incident) proto.State {
+	switch action.Action {
+	case string(proto.IncidentActionResume), string(proto.IncidentActionTryAgain):
+		return d.resumeSystemIdle(ctx, action, inc)
+	default:
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Action %q not supported for system_idle incidents", action.Action))
+		return ""
+	}
+}
+
+func (d *Driver) handleStoryBlockedAction(ctx context.Context, action *proto.IncidentActionPayload, inc *proto.Incident) proto.State {
+	switch action.Action {
+	case string(proto.IncidentActionResume), string(proto.IncidentActionTryAgain):
+		return d.resumeStoryBlocked(ctx, action, inc)
+	case string(proto.IncidentActionSkip):
+		return d.skipStoryBlocked(ctx, action, inc)
+	case string(proto.IncidentActionChangeRequest):
+		return d.changeRequestStoryBlocked(ctx, action, inc)
+	default:
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Action %q not supported for story_blocked incidents", action.Action))
+		return ""
+	}
+}
+
+func (d *Driver) handleClarificationAction(ctx context.Context, action *proto.IncidentActionPayload, inc *proto.Incident) proto.State {
+	switch action.Action {
+	case string(proto.IncidentActionResume):
+		return d.resumeClarification(ctx, action, inc)
+	default:
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Action %q not supported for clarification incidents", action.Action))
 		return ""
 	}
 }
@@ -437,6 +474,74 @@ func (d *Driver) resumeClarification(ctx context.Context, action *proto.Incident
 
 	d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, true,
 		fmt.Sprintf("Released %d held stories, clarification resolved", len(released)))
+	return StateDispatching
+}
+
+func (d *Driver) skipStoryBlocked(ctx context.Context, action *proto.IncidentActionPayload, inc *proto.Incident) proto.State {
+	if err := d.queue.SkipStory(inc.StoryID); err != nil {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Failed to skip story %s: %v", inc.StoryID, err))
+		return ""
+	}
+	d.logger.Info("⏭️ Skipped story %s: %s", inc.StoryID, action.Reason)
+
+	// Resume dispatch if suppressed
+	if suppressed, reason := d.queue.IsDispatchSuppressed(); suppressed {
+		d.queue.ResumeDispatch()
+		d.logger.Info("▶️ Dispatch resumed (was suppressed: %s)", reason)
+	}
+
+	// Resolve only this specific incident — skip does NOT release failure-group siblings
+	d.resolveIncident(ctx, action.IncidentID, "skipped", action.Reason)
+
+	d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, true,
+		fmt.Sprintf("Story %s skipped", inc.StoryID))
+	return StateDispatching
+}
+
+func (d *Driver) changeRequestStoryBlocked(ctx context.Context, action *proto.IncidentActionPayload, inc *proto.Incident) proto.State {
+	story, exists := d.queue.GetStory(inc.StoryID)
+	if !exists {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Story %s not found", inc.StoryID))
+		return ""
+	}
+
+	if story.GetStatus() != StatusFailed {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("change_request requires a failed story (status=%s); use resume to release held stories", story.GetStatus()))
+		return ""
+	}
+
+	if action.Content != "" {
+		story.Content += "\n\n## Change Request (User)\n\n" + action.Content
+		d.logger.Info("📝 Appended change request to story %s (%d chars)", inc.StoryID, len(action.Content))
+	}
+
+	// Reset attempt count for a fresh budget
+	story.AttemptCount = 0
+
+	if retryErr := d.queue.RetryFailedStory(inc.StoryID); retryErr != nil {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("Failed to retry story %s after change request: %v", inc.StoryID, retryErr))
+		return ""
+	}
+	d.logger.Info("🔄 Retrying story %s with change request", inc.StoryID)
+
+	// Resume dispatch if suppressed
+	if suppressed, reason := d.queue.IsDispatchSuppressed(); suppressed {
+		d.queue.ResumeDispatch()
+		d.logger.Info("▶️ Dispatch resumed (was suppressed: %s)", reason)
+	}
+
+	// Resolve incidents by failure ID (same as resume for failed stories)
+	if inc.FailureID != "" {
+		d.resolveIncidentsByFailureID(ctx, inc.FailureID, "change_request", action.Reason)
+	}
+	d.resolveIncident(ctx, action.IncidentID, "change_request", action.Reason)
+
+	d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, true,
+		fmt.Sprintf("Story %s modified and retried with fresh budget", inc.StoryID))
 	return StateDispatching
 }
 

--- a/pkg/architect/incidents.go
+++ b/pkg/architect/incidents.go
@@ -331,9 +331,11 @@ func (d *Driver) handleIncidentAction(ctx context.Context, msg *proto.AgentMsg) 
 }
 
 func (d *Driver) resumeSystemIdle(ctx context.Context, action *proto.IncidentActionPayload, _ *proto.Incident) proto.State {
-	// Sweep orphaned dispatched stories before re-dispatching
-	activeAgents := d.getActiveCoderIDs()
-	requeued := d.queue.RequeueOrphanedDispatched(activeAgents)
+	// Sweep orphaned dispatched stories before re-dispatching.
+	// Use the dispatcher's lease table as source of truth for ownership —
+	// QueuedStory.AssignedAgent is not populated during live dispatch.
+	leasedStoryIDs := d.dispatcher.GetLeasedStoryIDs()
+	requeued := d.queue.RequeueOrphanedDispatched(leasedStoryIDs)
 	if len(requeued) > 0 {
 		d.logger.Info("🔄 Requeued %d orphaned dispatched stories: %v", len(requeued), requeued)
 	}
@@ -370,7 +372,6 @@ func (d *Driver) resumeStoryBlocked(ctx context.Context, action *proto.IncidentA
 		d.logger.Info("🔄 Retrying failed story %s", inc.StoryID)
 
 	case StatusOnHold:
-		// Delegate to repair/release path by failure ID
 		failureID := inc.FailureID
 		if failureID == "" {
 			d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
@@ -378,6 +379,11 @@ func (d *Driver) resumeStoryBlocked(ctx context.Context, action *proto.IncidentA
 			return ""
 		}
 		released, _ := d.queue.ReleaseHeldStoriesByFailure(failureID, action.Reason)
+		if len(released) == 0 {
+			d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+				fmt.Sprintf("No held stories released for failure %s — story may have already been resumed", failureID))
+			return ""
+		}
 		d.logger.Info("🔓 Released %d held stories for failure %s", len(released), failureID)
 
 	default:
@@ -396,7 +402,6 @@ func (d *Driver) resumeStoryBlocked(ctx context.Context, action *proto.IncidentA
 	if inc.FailureID != "" {
 		d.resolveIncidentsByFailureID(ctx, inc.FailureID, "resumed", action.Reason)
 	}
-	// Also resolve this specific incident if it wasn't caught by failure ID
 	d.resolveIncident(ctx, action.IncidentID, "resumed", action.Reason)
 
 	d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, true,
@@ -413,6 +418,11 @@ func (d *Driver) resumeClarification(ctx context.Context, action *proto.Incident
 	}
 
 	released, _ := d.queue.ReleaseHeldStoriesByFailure(failureID, action.Reason)
+	if len(released) == 0 {
+		d.sendIncidentActionResult(ctx, action.IncidentID, action.Action, false,
+			fmt.Sprintf("No held stories released for failure %s — issue may have already been resolved", failureID))
+		return ""
+	}
 	d.logger.Info("🔓 Released %d held stories for failure %s", len(released), failureID)
 
 	// Resume dispatch if suppressed
@@ -442,20 +452,4 @@ func (d *Driver) sendIncidentActionResult(ctx context.Context, incidentID, actio
 	if err := d.ExecuteEffect(ctx, &SendMessageEffect{Message: msg}); err != nil {
 		d.logger.Warn("Failed to send incident_action_result: %v", err)
 	}
-}
-
-// getActiveCoderIDs returns agent IDs of coders in active states.
-func (d *Driver) getActiveCoderIDs() []string {
-	var ids []string
-	agents := d.dispatcher.GetRegisteredAgents()
-	for i := range agents {
-		if agents[i].Type != "coder" {
-			continue
-		}
-		switch agents[i].State {
-		case "PLANNING", "CODING", "TESTING", "AWAIT_APPROVAL", "PREPARE_MERGE":
-			ids = append(ids, agents[i].ID)
-		}
-	}
-	return ids
 }

--- a/pkg/architect/incidents.go
+++ b/pkg/architect/incidents.go
@@ -69,8 +69,12 @@ func (d *Driver) resolveIncident(ctx context.Context, incidentID, resolution, me
 // Thread-safe: acquires incidentsMu.
 func (d *Driver) resolveAllIncidents(ctx context.Context, resolution, message string) {
 	d.incidentsMu.Lock()
-	var msgs []*proto.AgentMsg
+	ids := make([]string, 0, len(d.openIncidents))
 	for id := range d.openIncidents {
+		ids = append(ids, id)
+	}
+	var msgs []*proto.AgentMsg
+	for _, id := range ids {
 		if msg := d.resolveIncidentLocked(id, resolution, message); msg != nil {
 			msgs = append(msgs, msg)
 		}
@@ -88,12 +92,16 @@ func (d *Driver) resolveAllIncidents(ctx context.Context, resolution, message st
 // Thread-safe: acquires incidentsMu.
 func (d *Driver) resolveIncidentsByFailureID(ctx context.Context, failureID, resolution, message string) {
 	d.incidentsMu.Lock()
-	var msgs []*proto.AgentMsg
+	var matchIDs []string
 	for id, inc := range d.openIncidents {
 		if inc.FailureID == failureID {
-			if msg := d.resolveIncidentLocked(id, resolution, message); msg != nil {
-				msgs = append(msgs, msg)
-			}
+			matchIDs = append(matchIDs, id)
+		}
+	}
+	var msgs []*proto.AgentMsg
+	for _, id := range matchIDs {
+		if msg := d.resolveIncidentLocked(id, resolution, message); msg != nil {
+			msgs = append(msgs, msg)
 		}
 	}
 	d.incidentsMu.Unlock()

--- a/pkg/architect/incidents.go
+++ b/pkg/architect/incidents.go
@@ -1,0 +1,195 @@
+package architect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"orchestrator/pkg/proto"
+)
+
+// openIncident stores an incident locally and notifies the PM.
+func (d *Driver) openIncident(ctx context.Context, incident *proto.Incident) {
+	d.openIncidents[incident.ID] = incident
+	d.syncIncidentsToStateData()
+
+	msg := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), "pm-001")
+	msg.SetTypedPayload(proto.NewIncidentOpenedPayload(incident))
+	if err := d.ExecuteEffect(ctx, &SendMessageEffect{Message: msg}); err != nil {
+		d.logger.Warn("Failed to send incident_opened for %s: %v", incident.ID, err)
+	}
+
+	d.logger.Info("Opened incident %s: %s", incident.ID, incident.Title)
+}
+
+// resolveIncident closes an open incident and notifies the PM.
+func (d *Driver) resolveIncident(ctx context.Context, incidentID, resolution, message string) {
+	inc, exists := d.openIncidents[incidentID]
+	if !exists {
+		return
+	}
+
+	inc.ResolvedAt = time.Now().UTC().Format(time.RFC3339)
+	inc.Resolution = resolution
+	delete(d.openIncidents, incidentID)
+	d.syncIncidentsToStateData()
+
+	msg := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), "pm-001")
+	msg.SetTypedPayload(proto.NewIncidentResolvedPayload(&proto.IncidentResolvedPayload{
+		IncidentID: incidentID,
+		Resolution: resolution,
+		Message:    message,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+	}))
+	if err := d.ExecuteEffect(ctx, &SendMessageEffect{Message: msg}); err != nil {
+		d.logger.Warn("Failed to send incident_resolved for %s: %v", incidentID, err)
+	}
+
+	d.logger.Info("Resolved incident %s: %s (%s)", incidentID, resolution, message)
+}
+
+// resolveAllIncidents closes all open incidents with the given resolution.
+func (d *Driver) resolveAllIncidents(ctx context.Context, resolution, message string) {
+	for id := range d.openIncidents {
+		d.resolveIncident(ctx, id, resolution, message)
+	}
+}
+
+// resolveIncidentsByFailureID closes incidents matching a specific failure ID.
+func (d *Driver) resolveIncidentsByFailureID(ctx context.Context, failureID, resolution, message string) {
+	for id, inc := range d.openIncidents {
+		if inc.FailureID == failureID {
+			d.resolveIncident(ctx, id, resolution, message)
+		}
+	}
+}
+
+// syncIncidentsToStateData mirrors open incidents to a state data key for FSM visibility.
+func (d *Driver) syncIncidentsToStateData() {
+	if len(d.openIncidents) == 0 {
+		d.SetStateData(StateKeyOpenIncidents, "")
+		return
+	}
+	raw, err := json.Marshal(d.openIncidents)
+	if err != nil {
+		d.logger.Warn("Failed to marshal open incidents for state data: %v", err)
+		return
+	}
+	d.SetStateData(StateKeyOpenIncidents, string(raw))
+}
+
+// collectOpenIncidentsJSON serializes open incidents as a JSON string for persistence.
+func (d *Driver) collectOpenIncidentsJSON() *string {
+	if len(d.openIncidents) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(d.openIncidents)
+	if err != nil {
+		d.logger.Warn("Failed to marshal open incidents: %v", err)
+		return nil
+	}
+	s := string(data)
+	return &s
+}
+
+// isSystemIdlePredicate checks the core idle conditions (1-3) without timing or blocking-incident guards.
+// Used for closing idle incidents — once work resumes, close immediately.
+func (d *Driver) isSystemIdlePredicate() bool {
+	if d.queue.AllStoriesTerminal() {
+		return false
+	}
+
+	pendingCount := len(d.queue.GetStoriesByStatus(StatusPending))
+	dispatchedCount := len(d.queue.GetStoriesByStatus(StatusDispatched))
+	if pendingCount == 0 && dispatchedCount == 0 {
+		return false
+	}
+
+	agents := d.dispatcher.GetRegisteredAgents()
+	for i := range agents {
+		if agents[i].Type != "coder" {
+			continue
+		}
+		switch agents[i].State {
+		case "PLANNING", "CODING", "TESTING":
+			return false
+		}
+	}
+
+	return true
+}
+
+// isSystemIdle checks all five conditions for opening a system_idle incident.
+// Includes 60s debounce guard and blocking-incident check.
+func (d *Driver) isSystemIdle() bool {
+	if !d.isSystemIdlePredicate() {
+		return false
+	}
+
+	for _, inc := range d.openIncidents {
+		if inc.Blocking {
+			return false
+		}
+	}
+
+	if d.monitoringIdleSince.IsZero() {
+		return false
+	}
+	return time.Since(d.monitoringIdleSince) > 60*time.Second
+}
+
+// checkAndOpenIdleIncident opens a system_idle incident if conditions are met.
+func (d *Driver) checkAndOpenIdleIncident(ctx context.Context) {
+	for _, inc := range d.openIncidents {
+		if inc.Kind == proto.IncidentKindSystemIdle {
+			return
+		}
+	}
+
+	if !d.isSystemIdle() {
+		return
+	}
+
+	pending := d.queue.GetStoriesByStatus(StatusPending)
+	dispatched := d.queue.GetStoriesByStatus(StatusDispatched)
+	affected := make([]string, 0, len(pending)+len(dispatched))
+	for _, s := range pending {
+		affected = append(affected, s.ID)
+	}
+	for _, s := range dispatched {
+		affected = append(affected, s.ID)
+	}
+
+	incident := &proto.Incident{
+		ID:               fmt.Sprintf("incident-system_idle-system-%s", time.Now().UTC().Format("20060102T150405Z")),
+		Kind:             proto.IncidentKindSystemIdle,
+		Scope:            "system",
+		Title:            "System idle with pending work",
+		Summary:          "No active coders are making progress but there are stories waiting for work.",
+		AffectedStoryIDs: affected,
+		AllowedActions:   []proto.IncidentAction{proto.IncidentActionTryAgain, proto.IncidentActionResume},
+		Blocking:         true,
+		OpenedAt:         time.Now().UTC().Format(time.RFC3339),
+	}
+	d.openIncident(ctx, incident)
+}
+
+// reconcileOpenIncidents auto-closes incidents whose conditions are no longer true.
+func (d *Driver) reconcileOpenIncidents(ctx context.Context) {
+	for id, inc := range d.openIncidents {
+		switch inc.Kind {
+		case proto.IncidentKindSystemIdle:
+			if !d.isSystemIdlePredicate() {
+				d.resolveIncident(ctx, id, "work_resumed", "Active coder detected, system no longer idle")
+			}
+		case proto.IncidentKindStoryBlocked:
+			story, exists := d.queue.GetStory(inc.StoryID)
+			if exists && story.GetStatus() != StatusFailed && story.GetStatus() != StatusOnHold {
+				d.resolveIncident(ctx, id, "story_requeued", fmt.Sprintf("Story %s resumed", inc.StoryID))
+			}
+		case proto.IncidentKindClarification:
+			// Closed by repair_complete handler, not by reconciliation
+		}
+	}
+}

--- a/pkg/architect/monitoring.go
+++ b/pkg/architect/monitoring.go
@@ -13,11 +13,6 @@ import (
 func (d *Driver) handleMonitoring(ctx context.Context) (proto.State, error) {
 	// State: waiting for coder requests and review completions
 
-	// Track when monitoring entered idle state (for system_idle debounce)
-	if d.monitoringIdleSince.IsZero() {
-		d.monitoringIdleSince = time.Now()
-	}
-
 	// Check if all stories are completed.
 	if d.queue.AllStoriesCompleted() {
 		d.logger.Info("🚀 MONITORING → DONE: All stories completed successfully")

--- a/pkg/architect/monitoring.go
+++ b/pkg/architect/monitoring.go
@@ -13,6 +13,11 @@ import (
 func (d *Driver) handleMonitoring(ctx context.Context) (proto.State, error) {
 	// State: waiting for coder requests and review completions
 
+	// Track when monitoring entered idle state (for system_idle debounce)
+	if d.monitoringIdleSince.IsZero() {
+		d.monitoringIdleSince = time.Now()
+	}
+
 	// Check if all stories are completed.
 	if d.queue.AllStoriesCompleted() {
 		d.logger.Info("🚀 MONITORING → DONE: All stories completed successfully")
@@ -36,6 +41,10 @@ func (d *Driver) handleMonitoring(ctx context.Context) (proto.State, error) {
 		return StateDone, nil
 	}
 
+	// Reconcile open incidents and check for system idle
+	d.reconcileOpenIncidents(ctx)
+	d.checkAndOpenIdleIncident(ctx)
+
 	// In monitoring state, we wait for either:
 	// 1. Coder questions/requests (transition to REQUEST).
 	// 2. Heartbeat to check for new ready stories.
@@ -48,6 +57,7 @@ func (d *Driver) handleMonitoring(ctx context.Context) (proto.State, error) {
 		if questionMsg == nil {
 			return StateMonitoring, nil
 		}
+		d.monitoringIdleSince = time.Time{} // Reset idle timer on coder activity
 		// Store the question for processing in REQUEST state.
 		d.SetStateData(StateKeyCurrentRequest, questionMsg)
 		return StateRequest, nil

--- a/pkg/architect/queue.go
+++ b/pkg/architect/queue.go
@@ -1137,22 +1137,19 @@ func (q *Queue) RetryFailedStory(storyID string) error {
 	return nil
 }
 
-// RequeueOrphanedDispatched finds stories in StatusDispatched whose AssignedAgent
-// is not in the activeAgentIDs set and requeues them to StatusPending.
+// RequeueOrphanedDispatched finds stories in StatusDispatched that are not in the
+// leasedStoryIDs set (from the dispatcher's lease table) and requeues them to StatusPending.
+// The lease table is the source of truth for agent-story ownership; QueuedStory.AssignedAgent
+// is not populated during live dispatch.
 // Returns the IDs of requeued stories.
-func (q *Queue) RequeueOrphanedDispatched(activeAgentIDs []string) []string {
-	activeSet := make(map[string]bool, len(activeAgentIDs))
-	for _, id := range activeAgentIDs {
-		activeSet[id] = true
-	}
-
+func (q *Queue) RequeueOrphanedDispatched(leasedStoryIDs map[string]bool) []string {
 	q.mutex.Lock()
 	requeued := make([]string, 0, len(q.stories))
 	for _, story := range q.stories {
 		if story.GetStatus() != StatusDispatched {
 			continue
 		}
-		if activeSet[story.AssignedAgent] {
+		if leasedStoryIDs[story.ID] {
 			continue
 		}
 		_ = story.SetStatus(StatusPending)

--- a/pkg/architect/queue.go
+++ b/pkg/architect/queue.go
@@ -32,6 +32,8 @@ const (
 	StatusFailed StoryStatus = "failed"
 	// StatusOnHold indicates the story is paused but recoverable (e.g., blocked by a failure under recovery).
 	StatusOnHold StoryStatus = "on_hold"
+	// StatusSkipped indicates the story was intentionally abandoned by user decision.
+	StatusSkipped StoryStatus = "skipped"
 )
 
 // ToDatabaseStatus converts StoryStatus to persistence package status string.
@@ -52,6 +54,8 @@ func (s StoryStatus) ToDatabaseStatus() string {
 		return persistence.StatusFailed
 	case StatusOnHold:
 		return persistence.StatusOnHold
+	case StatusSkipped:
+		return persistence.StatusSkipped
 	default:
 		return persistence.StatusNew
 	}
@@ -101,6 +105,9 @@ func (s *QueuedStory) SetStatus(status StoryStatus) error {
 	}
 	if current == StatusFailed {
 		return fmt.Errorf("cannot change status of failed story %s from failed to %s: failed stories are terminal", s.ID, status)
+	}
+	if current == StatusSkipped {
+		return fmt.Errorf("cannot change status of skipped story %s from skipped to %s: skipped stories are terminal", s.ID, status)
 	}
 	s.Status = string(status)
 	return nil
@@ -306,7 +313,7 @@ func (q *Queue) AllStoriesCompleted() bool {
 	return true
 }
 
-// AllStoriesTerminal checks if all stories in the queue are in a terminal state (done or failed).
+// AllStoriesTerminal checks if all stories are in a terminal state (done, failed, or skipped).
 // Used by the circuit breaker to detect "no more work to do" without implying success.
 // This is distinct from AllStoriesCompleted which only checks for success (StatusDone).
 func (q *Queue) AllStoriesTerminal() bool {
@@ -315,7 +322,7 @@ func (q *Queue) AllStoriesTerminal() bool {
 
 	for _, story := range q.stories {
 		status := story.GetStatus()
-		if status != StatusDone && status != StatusFailed {
+		if status != StatusDone && status != StatusFailed && status != StatusSkipped {
 			return false
 		}
 	}
@@ -494,7 +501,7 @@ func (q *Queue) RequeueStory(storyID string) error {
 	}
 
 	// Protect terminal stories from requeue
-	if story.GetStatus() == StatusDone || story.GetStatus() == StatusFailed {
+	if story.GetStatus() == StatusDone || story.GetStatus() == StatusFailed || story.GetStatus() == StatusSkipped {
 		return fmt.Errorf("cannot requeue terminal story %s (status=%s)", storyID, story.GetStatus())
 	}
 
@@ -716,7 +723,7 @@ func (q *Queue) UpdateStoryStatus(storyID string, status StoryStatus) error {
 	}
 
 	// Protect terminal stories from status changes
-	if story.GetStatus() == StatusDone || story.GetStatus() == StatusFailed {
+	if story.GetStatus() == StatusDone || story.GetStatus() == StatusFailed || story.GetStatus() == StatusSkipped {
 		q.mutex.Unlock()
 		return fmt.Errorf("cannot update status of terminal story %s (status=%s)", storyID, story.GetStatus())
 	}
@@ -1014,7 +1021,7 @@ func (q *Queue) HoldStory(storyID, reason, owner, failureID, note string) error 
 		return fmt.Errorf("story %s not found in queue", storyID)
 	}
 
-	if story.GetStatus() == StatusDone || story.GetStatus() == StatusFailed {
+	if story.GetStatus() == StatusDone || story.GetStatus() == StatusFailed || story.GetStatus() == StatusSkipped {
 		q.mutex.Unlock()
 		return fmt.Errorf("cannot hold terminal story %s (status=%s)", storyID, story.GetStatus())
 	}
@@ -1123,6 +1130,80 @@ func (q *Queue) RetryFailedStory(storyID string) error {
 	story.AssignedAgent = ""
 	story.ApprovedPlan = ""
 	story.StartedAt = nil
+	story.LastUpdated = time.Now().UTC()
+
+	var dbStory *persistence.Story
+	if q.persistenceChannel != nil {
+		dbStory = story.ToPersistenceStory()
+	}
+	q.mutex.Unlock()
+
+	if dbStory != nil {
+		persistence.PersistStory(dbStory, q.persistenceChannel)
+	}
+	return nil
+}
+
+// DependentInfo identifies a story that depends on another.
+type DependentInfo struct {
+	ID    string
+	Title string
+}
+
+// GetNonTerminalDependents returns stories that depend on the given story and are not terminal.
+// Used by SkipStory to prevent skipping a story that has active dependents.
+func (q *Queue) GetNonTerminalDependents(storyID string) []DependentInfo {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+	var deps []DependentInfo
+	for _, story := range q.stories {
+		status := story.GetStatus()
+		if status == StatusDone || status == StatusFailed || status == StatusSkipped {
+			continue
+		}
+		for _, depID := range story.DependsOn {
+			if depID == storyID {
+				deps = append(deps, DependentInfo{ID: story.ID, Title: story.Title})
+				break
+			}
+		}
+	}
+	return deps
+}
+
+// SkipStory marks a failed or on_hold story as skipped (intentionally abandoned by user).
+// Rejects if the story has non-terminal dependents that would become permanently unstartable.
+// Bypasses SetStatus's terminal guard since the story may be in StatusFailed.
+func (q *Queue) SkipStory(storyID string) error {
+	dependents := q.GetNonTerminalDependents(storyID)
+	if len(dependents) > 0 {
+		ids := make([]string, len(dependents))
+		for i := range dependents {
+			ids[i] = fmt.Sprintf("%s (%s)", dependents[i].ID, dependents[i].Title)
+		}
+		return fmt.Errorf("cannot skip story %s: %d non-terminal stories depend on it: %v",
+			storyID, len(dependents), ids)
+	}
+
+	q.mutex.Lock()
+	story, exists := q.stories[storyID]
+	if !exists {
+		q.mutex.Unlock()
+		return fmt.Errorf("story %s not found", storyID)
+	}
+	status := story.GetStatus()
+	if status != StatusFailed && status != StatusOnHold {
+		q.mutex.Unlock()
+		return fmt.Errorf("story %s cannot be skipped (status=%s): only failed or on_hold stories can be skipped", storyID, status)
+	}
+
+	story.Status = string(StatusSkipped)
+	story.AssignedAgent = ""
+	story.HoldReason = ""
+	story.HoldSince = nil
+	story.HoldOwner = ""
+	story.HoldNote = ""
+	story.BlockedByFailureID = ""
 	story.LastUpdated = time.Now().UTC()
 
 	var dbStory *persistence.Story

--- a/pkg/architect/queue.go
+++ b/pkg/architect/queue.go
@@ -1109,6 +1109,18 @@ func (q *Queue) ReleaseHeldStories(storyIDs []string, _ string) ([]string, error
 	return released, nil
 }
 
+// HasHeldStoriesForFailure returns true if any stories are on_hold with the given failure ID.
+func (q *Queue) HasHeldStoriesForFailure(failureID string) bool {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+	for _, story := range q.stories {
+		if story.GetStatus() == StatusOnHold && story.BlockedByFailureID == failureID {
+			return true
+		}
+	}
+	return false
+}
+
 // ReleaseHeldStoriesByFailure releases all stories held by a specific failure ID.
 // Returns the IDs of stories that were released.
 func (q *Queue) ReleaseHeldStoriesByFailure(failureID, cause string) ([]string, error) {

--- a/pkg/architect/queue.go
+++ b/pkg/architect/queue.go
@@ -1104,6 +1104,81 @@ func (q *Queue) ReleaseHeldStoriesByFailure(failureID, cause string) ([]string, 
 	return q.ReleaseHeldStories(matchingIDs, cause)
 }
 
+// RetryFailedStory resets a failed story back to pending for a fresh attempt.
+// Preserves AttemptCount for budget tracking. Returns error if story is not failed.
+func (q *Queue) RetryFailedStory(storyID string) error {
+	q.mutex.Lock()
+	story, exists := q.stories[storyID]
+	if !exists {
+		q.mutex.Unlock()
+		return fmt.Errorf("story %s not found", storyID)
+	}
+	if story.GetStatus() != StatusFailed {
+		q.mutex.Unlock()
+		return fmt.Errorf("story %s is not failed (status=%s)", storyID, story.GetStatus())
+	}
+
+	// Bypass SetStatus which rejects transitions from terminal states
+	story.Status = string(StatusPending)
+	story.AssignedAgent = ""
+	story.ApprovedPlan = ""
+	story.StartedAt = nil
+	story.LastUpdated = time.Now().UTC()
+
+	var dbStory *persistence.Story
+	if q.persistenceChannel != nil {
+		dbStory = story.ToPersistenceStory()
+	}
+	q.mutex.Unlock()
+
+	if dbStory != nil {
+		persistence.PersistStory(dbStory, q.persistenceChannel)
+	}
+	return nil
+}
+
+// RequeueOrphanedDispatched finds stories in StatusDispatched whose AssignedAgent
+// is not in the activeAgentIDs set and requeues them to StatusPending.
+// Returns the IDs of requeued stories.
+func (q *Queue) RequeueOrphanedDispatched(activeAgentIDs []string) []string {
+	activeSet := make(map[string]bool, len(activeAgentIDs))
+	for _, id := range activeAgentIDs {
+		activeSet[id] = true
+	}
+
+	q.mutex.Lock()
+	requeued := make([]string, 0, len(q.stories))
+	for _, story := range q.stories {
+		if story.GetStatus() != StatusDispatched {
+			continue
+		}
+		if activeSet[story.AssignedAgent] {
+			continue
+		}
+		_ = story.SetStatus(StatusPending)
+		story.AssignedAgent = ""
+		story.ApprovedPlan = ""
+		story.StartedAt = nil
+		story.LastUpdated = time.Now().UTC()
+		requeued = append(requeued, story.ID)
+	}
+
+	var toPersist []*persistence.Story
+	if q.persistenceChannel != nil {
+		for _, storyID := range requeued {
+			if story, exists := q.stories[storyID]; exists {
+				toPersist = append(toPersist, story.ToPersistenceStory())
+			}
+		}
+	}
+	q.mutex.Unlock()
+
+	for _, dbStory := range toPersist {
+		persistence.PersistStory(dbStory, q.persistenceChannel)
+	}
+	return requeued
+}
+
 // GetAssignedAgent returns the agent ID assigned to the given story, or empty if unassigned.
 func (q *Queue) GetAssignedAgent(storyID string) string {
 	q.mutex.RLock()

--- a/pkg/architect/queue.go
+++ b/pkg/architect/queue.go
@@ -992,6 +992,23 @@ func (q *Queue) ReconstructBudgetsFromFailures(storyID string, failureCounts map
 	}
 }
 
+// ResetAllBudgets zeroes every per-class retry budget for a story.
+// Used by change_request to give a user-modified story a completely fresh start.
+func (q *Queue) ResetAllBudgets(storyID string) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	story, exists := q.stories[storyID]
+	if !exists {
+		return
+	}
+
+	story.AttemptRetryBudget = 0
+	story.RewriteBudget = 0
+	story.RepairBudget = 0
+	story.HumanBudget = 0
+}
+
 // GetHeldStories returns all stories currently on hold.
 func (q *Queue) GetHeldStories() []*QueuedStory {
 	q.mutex.RLock()

--- a/pkg/architect/queue_test.go
+++ b/pkg/architect/queue_test.go
@@ -124,25 +124,24 @@ func TestRetryFailedStory_DoneStory(t *testing.T) {
 }
 
 // --- RequeueOrphanedDispatched tests ---
+// These tests use leasedStoryIDs (the dispatcher's lease table) as the source of truth
+// for whether a dispatched story is orphaned, matching the live dispatch flow.
 
 func TestRequeueOrphanedDispatched(t *testing.T) {
 	q := newTestQueue()
 
-	// story-1: dispatched, assigned to coder-001 (active)
-	s1 := addQueueStory(q, "story-1", StatusDispatched)
-	s1.AssignedAgent = "coder-001"
-	s1.ApprovedPlan = "plan for story-1"
+	// story-1: dispatched, leased to a coder (in lease table)
+	addQueueStory(q, "story-1", StatusDispatched)
 
-	// story-2: dispatched, assigned to coder-002 (NOT in active list)
-	s2 := addQueueStory(q, "story-2", StatusDispatched)
-	s2.AssignedAgent = "coder-002"
-	s2.ApprovedPlan = "plan for story-2"
+	// story-2: dispatched, NOT in lease table (orphaned)
+	addQueueStory(q, "story-2", StatusDispatched)
 
 	// story-3: pending (should be untouched)
 	addQueueStory(q, "story-3", StatusPending)
 
-	// Only coder-001 is active
-	requeued := q.RequeueOrphanedDispatched([]string{"coder-001"})
+	// Only story-1 is leased
+	leased := map[string]bool{"story-1": true}
+	requeued := q.RequeueOrphanedDispatched(leased)
 
 	// Only story-2 should be requeued (orphaned)
 	if len(requeued) != 1 {
@@ -167,13 +166,10 @@ func TestRequeueOrphanedDispatched(t *testing.T) {
 		t.Errorf("story-2: expected nil StartedAt, got %v", updated2.StartedAt)
 	}
 
-	// Verify story-1 is still dispatched (active agent)
+	// Verify story-1 is still dispatched (leased)
 	updated1, _ := q.GetStory("story-1")
 	if updated1.GetStatus() != StatusDispatched {
 		t.Errorf("story-1: expected status %q, got %q", StatusDispatched, updated1.GetStatus())
-	}
-	if updated1.AssignedAgent != "coder-001" {
-		t.Errorf("story-1: expected AssignedAgent coder-001, got %q", updated1.AssignedAgent)
 	}
 
 	// Verify story-3 is still pending (untouched)
@@ -186,34 +182,29 @@ func TestRequeueOrphanedDispatched(t *testing.T) {
 func TestRequeueOrphanedDispatched_NoOrphans(t *testing.T) {
 	q := newTestQueue()
 
-	s1 := addQueueStory(q, "story-1", StatusDispatched)
-	s1.AssignedAgent = "coder-001"
+	addQueueStory(q, "story-1", StatusDispatched)
+	addQueueStory(q, "story-2", StatusDispatched)
 
-	s2 := addQueueStory(q, "story-2", StatusDispatched)
-	s2.AssignedAgent = "coder-002"
-
-	// Both agents are active
-	requeued := q.RequeueOrphanedDispatched([]string{"coder-001", "coder-002"})
+	// Both stories are leased
+	leased := map[string]bool{"story-1": true, "story-2": true}
+	requeued := q.RequeueOrphanedDispatched(leased)
 
 	if len(requeued) != 0 {
-		t.Errorf("expected 0 requeued stories when all agents active, got %d: %v", len(requeued), requeued)
+		t.Errorf("expected 0 requeued stories when all are leased, got %d: %v", len(requeued), requeued)
 	}
 }
 
 func TestRequeueOrphanedDispatched_AllOrphans(t *testing.T) {
 	q := newTestQueue()
 
-	s1 := addQueueStory(q, "story-1", StatusDispatched)
-	s1.AssignedAgent = "coder-001"
+	addQueueStory(q, "story-1", StatusDispatched)
+	addQueueStory(q, "story-2", StatusDispatched)
 
-	s2 := addQueueStory(q, "story-2", StatusDispatched)
-	s2.AssignedAgent = "coder-002"
-
-	// No active agents
-	requeued := q.RequeueOrphanedDispatched([]string{})
+	// No leases — all dispatched stories are orphaned
+	requeued := q.RequeueOrphanedDispatched(map[string]bool{})
 
 	if len(requeued) != 2 {
-		t.Errorf("expected 2 requeued stories when no agents active, got %d: %v", len(requeued), requeued)
+		t.Errorf("expected 2 requeued stories when no leases exist, got %d: %v", len(requeued), requeued)
 	}
 
 	// Verify both are pending now
@@ -234,8 +225,8 @@ func TestRequeueOrphanedDispatched_SkipsNonDispatched(t *testing.T) {
 	addQueueStory(q, "story-done", StatusDone)
 	addQueueStory(q, "story-failed", StatusFailed)
 
-	// No active agents - but none of these are dispatched
-	requeued := q.RequeueOrphanedDispatched([]string{})
+	// No leases — but none of these are dispatched so none should be requeued
+	requeued := q.RequeueOrphanedDispatched(map[string]bool{})
 
 	if len(requeued) != 0 {
 		t.Errorf("expected 0 requeued stories for non-dispatched statuses, got %d: %v", len(requeued), requeued)
@@ -245,7 +236,7 @@ func TestRequeueOrphanedDispatched_SkipsNonDispatched(t *testing.T) {
 func TestRequeueOrphanedDispatched_EmptyQueue(t *testing.T) {
 	q := newTestQueue()
 
-	requeued := q.RequeueOrphanedDispatched([]string{"coder-001"})
+	requeued := q.RequeueOrphanedDispatched(map[string]bool{"story-1": true})
 
 	if len(requeued) != 0 {
 		t.Errorf("expected 0 requeued stories for empty queue, got %d", len(requeued))

--- a/pkg/architect/queue_test.go
+++ b/pkg/architect/queue_test.go
@@ -419,6 +419,40 @@ func TestAllStoriesCompleted_WithSkipped(t *testing.T) {
 
 // --- SetStatus guard for skipped ---
 
+// --- ResetAllBudgets tests ---
+
+func TestResetAllBudgets(t *testing.T) {
+	q := newTestQueue()
+	story := addQueueStory(q, "story-1", StatusFailed)
+	story.AttemptRetryBudget = 3
+	story.RewriteBudget = 2
+	story.RepairBudget = 1
+	story.HumanBudget = 1
+
+	q.ResetAllBudgets("story-1")
+
+	if story.AttemptRetryBudget != 0 {
+		t.Errorf("AttemptRetryBudget: expected 0, got %d", story.AttemptRetryBudget)
+	}
+	if story.RewriteBudget != 0 {
+		t.Errorf("RewriteBudget: expected 0, got %d", story.RewriteBudget)
+	}
+	if story.RepairBudget != 0 {
+		t.Errorf("RepairBudget: expected 0, got %d", story.RepairBudget)
+	}
+	if story.HumanBudget != 0 {
+		t.Errorf("HumanBudget: expected 0, got %d", story.HumanBudget)
+	}
+}
+
+func TestResetAllBudgets_NotFound(_ *testing.T) {
+	q := newTestQueue()
+	// Should not panic
+	q.ResetAllBudgets("nonexistent")
+}
+
+// --- SetStatus guard for skipped ---
+
 func TestSetStatus_RejectsFromSkipped(t *testing.T) {
 	q := newTestQueue()
 	story := addQueueStory(q, "story-1", StatusSkipped)

--- a/pkg/architect/queue_test.go
+++ b/pkg/architect/queue_test.go
@@ -1,0 +1,253 @@
+package architect
+
+import (
+	"testing"
+	"time"
+
+	"orchestrator/pkg/persistence"
+)
+
+// newTestQueue creates a Queue with nil persistence channel for testing.
+func newTestQueue() *Queue {
+	return NewQueue(nil)
+}
+
+// addQueueStory adds a story to the queue with minimal fields for testing.
+// Uses raw Status field to allow setting terminal statuses (failed, done)
+// which SetStatus would reject.
+func addQueueStory(q *Queue, id string, status StoryStatus) *QueuedStory {
+	now := time.Now()
+	story := &QueuedStory{
+		Story: persistence.Story{
+			ID:          id,
+			SpecID:      "spec-1",
+			Title:       "Test story " + id,
+			Content:     "Test content for " + id,
+			Priority:    1,
+			LastUpdated: now,
+			CreatedAt:   now,
+		},
+	}
+	story.Status = string(status)
+
+	q.mutex.Lock()
+	q.stories[id] = story
+	q.mutex.Unlock()
+
+	return story
+}
+
+// --- RetryFailedStory tests ---
+
+func TestRetryFailedStory_Success(t *testing.T) {
+	q := newTestQueue()
+
+	// Create a failed story with some prior state
+	story := addQueueStory(q, "story-1", StatusFailed)
+	story.AssignedAgent = "coder-001"
+	story.ApprovedPlan = "original plan"
+	story.AttemptCount = 2
+	startTime := time.Now().Add(-time.Hour)
+	story.StartedAt = &startTime
+
+	err := q.RetryFailedStory("story-1")
+	if err != nil {
+		t.Fatalf("RetryFailedStory returned unexpected error: %v", err)
+	}
+
+	// Verify the story was reset to pending
+	updated, exists := q.GetStory("story-1")
+	if !exists {
+		t.Fatal("story-1 should still exist in queue")
+	}
+
+	if updated.GetStatus() != StatusPending {
+		t.Errorf("expected status %q, got %q", StatusPending, updated.GetStatus())
+	}
+
+	// AssignedAgent should be cleared
+	if updated.AssignedAgent != "" {
+		t.Errorf("expected empty AssignedAgent, got %q", updated.AssignedAgent)
+	}
+
+	// ApprovedPlan should be cleared
+	if updated.ApprovedPlan != "" {
+		t.Errorf("expected empty ApprovedPlan, got %q", updated.ApprovedPlan)
+	}
+
+	// StartedAt should be cleared
+	if updated.StartedAt != nil {
+		t.Errorf("expected nil StartedAt, got %v", updated.StartedAt)
+	}
+
+	// AttemptCount should be preserved (not reset)
+	if updated.AttemptCount != 2 {
+		t.Errorf("expected AttemptCount=2 (preserved), got %d", updated.AttemptCount)
+	}
+}
+
+func TestRetryFailedStory_NotFailed(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "story-1", StatusPending)
+
+	err := q.RetryFailedStory("story-1")
+	if err == nil {
+		t.Fatal("expected error for non-failed story, got nil")
+	}
+
+	if got := err.Error(); got == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestRetryFailedStory_NotFound(t *testing.T) {
+	q := newTestQueue()
+
+	err := q.RetryFailedStory("nonexistent-story")
+	if err == nil {
+		t.Fatal("expected error for missing story, got nil")
+	}
+
+	if got := err.Error(); got == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestRetryFailedStory_DoneStory(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "story-1", StatusDone)
+
+	err := q.RetryFailedStory("story-1")
+	if err == nil {
+		t.Fatal("expected error for done story, got nil")
+	}
+}
+
+// --- RequeueOrphanedDispatched tests ---
+
+func TestRequeueOrphanedDispatched(t *testing.T) {
+	q := newTestQueue()
+
+	// story-1: dispatched, assigned to coder-001 (active)
+	s1 := addQueueStory(q, "story-1", StatusDispatched)
+	s1.AssignedAgent = "coder-001"
+	s1.ApprovedPlan = "plan for story-1"
+
+	// story-2: dispatched, assigned to coder-002 (NOT in active list)
+	s2 := addQueueStory(q, "story-2", StatusDispatched)
+	s2.AssignedAgent = "coder-002"
+	s2.ApprovedPlan = "plan for story-2"
+
+	// story-3: pending (should be untouched)
+	addQueueStory(q, "story-3", StatusPending)
+
+	// Only coder-001 is active
+	requeued := q.RequeueOrphanedDispatched([]string{"coder-001"})
+
+	// Only story-2 should be requeued (orphaned)
+	if len(requeued) != 1 {
+		t.Fatalf("expected 1 requeued story, got %d: %v", len(requeued), requeued)
+	}
+	if requeued[0] != "story-2" {
+		t.Errorf("expected requeued story to be story-2, got %q", requeued[0])
+	}
+
+	// Verify story-2 was reset
+	updated2, _ := q.GetStory("story-2")
+	if updated2.GetStatus() != StatusPending {
+		t.Errorf("story-2: expected status %q, got %q", StatusPending, updated2.GetStatus())
+	}
+	if updated2.AssignedAgent != "" {
+		t.Errorf("story-2: expected empty AssignedAgent, got %q", updated2.AssignedAgent)
+	}
+	if updated2.ApprovedPlan != "" {
+		t.Errorf("story-2: expected empty ApprovedPlan, got %q", updated2.ApprovedPlan)
+	}
+	if updated2.StartedAt != nil {
+		t.Errorf("story-2: expected nil StartedAt, got %v", updated2.StartedAt)
+	}
+
+	// Verify story-1 is still dispatched (active agent)
+	updated1, _ := q.GetStory("story-1")
+	if updated1.GetStatus() != StatusDispatched {
+		t.Errorf("story-1: expected status %q, got %q", StatusDispatched, updated1.GetStatus())
+	}
+	if updated1.AssignedAgent != "coder-001" {
+		t.Errorf("story-1: expected AssignedAgent coder-001, got %q", updated1.AssignedAgent)
+	}
+
+	// Verify story-3 is still pending (untouched)
+	updated3, _ := q.GetStory("story-3")
+	if updated3.GetStatus() != StatusPending {
+		t.Errorf("story-3: expected status %q, got %q", StatusPending, updated3.GetStatus())
+	}
+}
+
+func TestRequeueOrphanedDispatched_NoOrphans(t *testing.T) {
+	q := newTestQueue()
+
+	s1 := addQueueStory(q, "story-1", StatusDispatched)
+	s1.AssignedAgent = "coder-001"
+
+	s2 := addQueueStory(q, "story-2", StatusDispatched)
+	s2.AssignedAgent = "coder-002"
+
+	// Both agents are active
+	requeued := q.RequeueOrphanedDispatched([]string{"coder-001", "coder-002"})
+
+	if len(requeued) != 0 {
+		t.Errorf("expected 0 requeued stories when all agents active, got %d: %v", len(requeued), requeued)
+	}
+}
+
+func TestRequeueOrphanedDispatched_AllOrphans(t *testing.T) {
+	q := newTestQueue()
+
+	s1 := addQueueStory(q, "story-1", StatusDispatched)
+	s1.AssignedAgent = "coder-001"
+
+	s2 := addQueueStory(q, "story-2", StatusDispatched)
+	s2.AssignedAgent = "coder-002"
+
+	// No active agents
+	requeued := q.RequeueOrphanedDispatched([]string{})
+
+	if len(requeued) != 2 {
+		t.Errorf("expected 2 requeued stories when no agents active, got %d: %v", len(requeued), requeued)
+	}
+
+	// Verify both are pending now
+	for _, id := range []string{"story-1", "story-2"} {
+		story, _ := q.GetStory(id)
+		if story.GetStatus() != StatusPending {
+			t.Errorf("%s: expected status %q, got %q", id, StatusPending, story.GetStatus())
+		}
+	}
+}
+
+func TestRequeueOrphanedDispatched_SkipsNonDispatched(t *testing.T) {
+	q := newTestQueue()
+
+	// Various non-dispatched statuses
+	addQueueStory(q, "story-pending", StatusPending)
+	addQueueStory(q, "story-coding", StatusCoding)
+	addQueueStory(q, "story-done", StatusDone)
+	addQueueStory(q, "story-failed", StatusFailed)
+
+	// No active agents - but none of these are dispatched
+	requeued := q.RequeueOrphanedDispatched([]string{})
+
+	if len(requeued) != 0 {
+		t.Errorf("expected 0 requeued stories for non-dispatched statuses, got %d: %v", len(requeued), requeued)
+	}
+}
+
+func TestRequeueOrphanedDispatched_EmptyQueue(t *testing.T) {
+	q := newTestQueue()
+
+	requeued := q.RequeueOrphanedDispatched([]string{"coder-001"})
+
+	if len(requeued) != 0 {
+		t.Errorf("expected 0 requeued stories for empty queue, got %d", len(requeued))
+	}
+}

--- a/pkg/architect/queue_test.go
+++ b/pkg/architect/queue_test.go
@@ -451,6 +451,37 @@ func TestResetAllBudgets_NotFound(_ *testing.T) {
 	q.ResetAllBudgets("nonexistent")
 }
 
+// --- HasHeldStoriesForFailure tests ---
+
+func TestHasHeldStoriesForFailure_True(t *testing.T) {
+	q := newTestQueue()
+	story := addQueueStory(q, "story-1", StatusOnHold)
+	story.BlockedByFailureID = "fail-abc"
+
+	if !q.HasHeldStoriesForFailure("fail-abc") {
+		t.Error("expected true when a story is held by the given failure ID")
+	}
+}
+
+func TestHasHeldStoriesForFailure_False(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "story-1", StatusFailed)
+
+	if q.HasHeldStoriesForFailure("fail-abc") {
+		t.Error("expected false when no stories are held by the given failure ID")
+	}
+}
+
+func TestHasHeldStoriesForFailure_DifferentFailureID(t *testing.T) {
+	q := newTestQueue()
+	story := addQueueStory(q, "story-1", StatusOnHold)
+	story.BlockedByFailureID = "fail-xyz"
+
+	if q.HasHeldStoriesForFailure("fail-abc") {
+		t.Error("expected false when held story has a different failure ID")
+	}
+}
+
 // --- SetStatus guard for skipped ---
 
 func TestSetStatus_RejectsFromSkipped(t *testing.T) {

--- a/pkg/architect/queue_test.go
+++ b/pkg/architect/queue_test.go
@@ -242,3 +242,194 @@ func TestRequeueOrphanedDispatched_EmptyQueue(t *testing.T) {
 		t.Errorf("expected 0 requeued stories for empty queue, got %d", len(requeued))
 	}
 }
+
+// --- SkipStory tests ---
+
+func TestSkipStory_FromFailed(t *testing.T) {
+	q := newTestQueue()
+	story := addQueueStory(q, "story-1", StatusFailed)
+	story.AssignedAgent = "coder-001"
+	story.AttemptCount = 3
+	story.LastFailReason = "build failed"
+
+	if err := q.SkipStory("story-1"); err != nil {
+		t.Fatalf("SkipStory failed: %v", err)
+	}
+
+	story, _ = q.GetStory("story-1")
+	if story.GetStatus() != StatusSkipped {
+		t.Errorf("expected status %s, got %s", StatusSkipped, story.GetStatus())
+	}
+	if story.AssignedAgent != "" {
+		t.Errorf("expected AssignedAgent cleared, got %q", story.AssignedAgent)
+	}
+	if story.AttemptCount != 3 {
+		t.Errorf("expected AttemptCount preserved at 3, got %d", story.AttemptCount)
+	}
+}
+
+func TestSkipStory_FromOnHold(t *testing.T) {
+	q := newTestQueue()
+	story := addQueueStory(q, "story-1", StatusOnHold)
+	story.HoldReason = "blocked by failure"
+	story.HoldOwner = "architect"
+	story.HoldNote = "needs fix"
+	story.BlockedByFailureID = "fail-123"
+
+	if err := q.SkipStory("story-1"); err != nil {
+		t.Fatalf("SkipStory failed: %v", err)
+	}
+
+	story, _ = q.GetStory("story-1")
+	if story.GetStatus() != StatusSkipped {
+		t.Errorf("expected status %s, got %s", StatusSkipped, story.GetStatus())
+	}
+	if story.HoldReason != "" {
+		t.Errorf("expected HoldReason cleared, got %q", story.HoldReason)
+	}
+	if story.HoldOwner != "" {
+		t.Errorf("expected HoldOwner cleared, got %q", story.HoldOwner)
+	}
+	if story.HoldNote != "" {
+		t.Errorf("expected HoldNote cleared, got %q", story.HoldNote)
+	}
+	if story.BlockedByFailureID != "" {
+		t.Errorf("expected BlockedByFailureID cleared, got %q", story.BlockedByFailureID)
+	}
+}
+
+func TestSkipStory_FromPending_Rejected(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "story-1", StatusPending)
+
+	err := q.SkipStory("story-1")
+	if err == nil {
+		t.Fatal("expected error when skipping pending story")
+	}
+	if story, _ := q.GetStory("story-1"); story.GetStatus() != StatusPending {
+		t.Errorf("status should remain pending, got %s", story.GetStatus())
+	}
+}
+
+func TestSkipStory_NotFound(t *testing.T) {
+	q := newTestQueue()
+
+	err := q.SkipStory("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing story")
+	}
+}
+
+func TestSkipStory_WithNonTerminalDependents_Rejected(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "story-a", StatusFailed)
+	storyB := addQueueStory(q, "story-b", StatusPending)
+	storyB.DependsOn = []string{"story-a"}
+
+	err := q.SkipStory("story-a")
+	if err == nil {
+		t.Fatal("expected error when skipping story with non-terminal dependents")
+	}
+
+	if storyA, _ := q.GetStory("story-a"); storyA.GetStatus() != StatusFailed {
+		t.Errorf("story-a status should remain failed, got %s", storyA.GetStatus())
+	}
+}
+
+func TestSkipStory_WithTerminalDependents_Allowed(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "story-a", StatusFailed)
+	storyB := addQueueStory(q, "story-b", StatusDone)
+	storyB.DependsOn = []string{"story-a"}
+
+	if err := q.SkipStory("story-a"); err != nil {
+		t.Fatalf("SkipStory should succeed when dependents are terminal: %v", err)
+	}
+
+	if storyA, _ := q.GetStory("story-a"); storyA.GetStatus() != StatusSkipped {
+		t.Errorf("expected status skipped, got %s", storyA.GetStatus())
+	}
+}
+
+// --- GetNonTerminalDependents tests ---
+
+func TestGetNonTerminalDependents(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "story-a", StatusFailed)
+	storyB := addQueueStory(q, "story-b", StatusPending)
+	storyB.DependsOn = []string{"story-a"}
+	storyC := addQueueStory(q, "story-c", StatusDone)
+	storyC.DependsOn = []string{"story-a"}
+	storyD := addQueueStory(q, "story-d", StatusOnHold)
+	storyD.DependsOn = []string{"story-a"}
+
+	deps := q.GetNonTerminalDependents("story-a")
+
+	// story-b (pending) and story-d (on_hold) are non-terminal; story-c (done) is terminal
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 non-terminal dependents, got %d: %+v", len(deps), deps)
+	}
+
+	ids := map[string]bool{}
+	for _, d := range deps {
+		ids[d.ID] = true
+	}
+	if !ids["story-b"] {
+		t.Error("expected story-b in non-terminal dependents")
+	}
+	if !ids["story-d"] {
+		t.Error("expected story-d in non-terminal dependents")
+	}
+}
+
+func TestGetNonTerminalDependents_SkippedIsTerminal(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "story-a", StatusFailed)
+	storyB := addQueueStory(q, "story-b", StatusSkipped)
+	storyB.DependsOn = []string{"story-a"}
+
+	deps := q.GetNonTerminalDependents("story-a")
+	if len(deps) != 0 {
+		t.Errorf("expected 0 non-terminal dependents (skipped is terminal), got %d", len(deps))
+	}
+}
+
+// --- AllStoriesTerminal / AllStoriesCompleted with skipped ---
+
+func TestAllStoriesTerminal_WithSkipped(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "s1", StatusDone)
+	addQueueStory(q, "s2", StatusSkipped)
+	addQueueStory(q, "s3", StatusFailed)
+
+	if !q.AllStoriesTerminal() {
+		t.Error("AllStoriesTerminal should be true when all stories are done, failed, or skipped")
+	}
+}
+
+func TestAllStoriesCompleted_WithSkipped(t *testing.T) {
+	q := newTestQueue()
+	addQueueStory(q, "s1", StatusDone)
+	addQueueStory(q, "s2", StatusSkipped)
+
+	if q.AllStoriesCompleted() {
+		t.Error("AllStoriesCompleted should be false when a story is skipped (not done)")
+	}
+}
+
+// --- SetStatus guard for skipped ---
+
+func TestSetStatus_RejectsFromSkipped(t *testing.T) {
+	q := newTestQueue()
+	story := addQueueStory(q, "story-1", StatusSkipped)
+
+	if err := story.SetStatus(StatusPending); err == nil {
+		t.Error("should not be able to transition from skipped to pending")
+	}
+	if err := story.SetStatus(StatusDone); err == nil {
+		t.Error("should not be able to transition from skipped to done")
+	}
+	if story.GetStatus() != StatusSkipped {
+		t.Errorf("status should remain skipped, got %s", story.GetStatus())
+	}
+}

--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -930,12 +930,24 @@ func (d *Driver) notifyPMOfBlockedStory(ctx context.Context, story *QueuedStory,
 			FailureID:      fi.ID,
 			Title:          fmt.Sprintf("Story abandoned: %s", story.Title),
 			Summary:        fi.Explanation,
-			AllowedActions: []proto.IncidentAction{proto.IncidentActionTryAgain, proto.IncidentActionChangeRequest, proto.IncidentActionSkip, proto.IncidentActionResume},
+			AllowedActions: storyBlockedAllowedActions(fi),
 			Blocking:       true,
 			OpenedAt:       time.Now().UTC().Format(time.RFC3339),
 		}
 		d.openIncident(ctx, incident)
 	}
+}
+
+// storyBlockedAllowedActions returns the set of allowed incident actions for a
+// story_blocked incident. change_request is only offered for story-scoped failures
+// (where the content might need changing). For wider-scoped failures (epoch/system),
+// the issue is environmental and change_request would modify the wrong thing.
+func storyBlockedAllowedActions(fi *proto.FailureInfo) []proto.IncidentAction {
+	actions := []proto.IncidentAction{proto.IncidentActionTryAgain, proto.IncidentActionSkip, proto.IncidentActionResume}
+	if fi.ResolvedScope == proto.FailureScopeStory || fi.ResolvedScope == proto.FailureScopeAttempt || fi.ResolvedScope == "" {
+		actions = append(actions, proto.IncidentActionChangeRequest)
+	}
+	return actions
 }
 
 // handleRepairComplete processes a repair_complete signal from PM.

--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -930,7 +930,7 @@ func (d *Driver) notifyPMOfBlockedStory(ctx context.Context, story *QueuedStory,
 			FailureID:      fi.ID,
 			Title:          fmt.Sprintf("Story abandoned: %s", story.Title),
 			Summary:        fi.Explanation,
-			AllowedActions: storyBlockedAllowedActions(fi),
+			AllowedActions: storyBlockedAllowedActions(fi, story.GetStatus()),
 			Blocking:       true,
 			OpenedAt:       time.Now().UTC().Format(time.RFC3339),
 		}
@@ -939,12 +939,13 @@ func (d *Driver) notifyPMOfBlockedStory(ctx context.Context, story *QueuedStory,
 }
 
 // storyBlockedAllowedActions returns the set of allowed incident actions for a
-// story_blocked incident. change_request is only offered for story-scoped failures
-// (where the content might need changing). For wider-scoped failures (epoch/system),
-// the issue is environmental and change_request would modify the wrong thing.
-func storyBlockedAllowedActions(fi *proto.FailureInfo) []proto.IncidentAction {
+// story_blocked incident. change_request is only offered when:
+//   - the story is actually StatusFailed (not on_hold from a prerequisite hold)
+//   - the failure scope is story-local (story/attempt), not environmental (epoch/system)
+func storyBlockedAllowedActions(fi *proto.FailureInfo, storyStatus StoryStatus) []proto.IncidentAction {
 	actions := []proto.IncidentAction{proto.IncidentActionTryAgain, proto.IncidentActionSkip, proto.IncidentActionResume}
-	if fi.ResolvedScope == proto.FailureScopeStory || fi.ResolvedScope == proto.FailureScopeAttempt || fi.ResolvedScope == "" {
+	isStoryLocal := fi.ResolvedScope == proto.FailureScopeStory || fi.ResolvedScope == proto.FailureScopeAttempt || fi.ResolvedScope == ""
+	if storyStatus == StatusFailed && isStoryLocal {
 		actions = append(actions, proto.IncidentActionChangeRequest)
 	}
 	return actions

--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -833,7 +833,7 @@ func (d *Driver) notifyPMAllStoriesComplete(ctx context.Context) error {
 }
 
 // notifyPMAllStoriesTerminal sends an all-stories-terminal notification to PM
-// when all stories are done or failed (but not all succeeded). This clears in_flight
+// when all stories are done, failed, or skipped (but not all succeeded). This clears in_flight
 // so the PM can accept new specs.
 func (d *Driver) notifyPMAllStoriesTerminal(ctx context.Context) error {
 	if d.pmAllTerminalNotified {
@@ -843,6 +843,7 @@ func (d *Driver) notifyPMAllStoriesTerminal(ctx context.Context) error {
 	specID := ""
 	totalStories := 0
 	var failedDetails []proto.FailedStoryDetail
+	var skippedDetails []proto.SkippedStoryDetail
 
 	if d.queue != nil {
 		allStories := d.queue.GetAllStories()
@@ -851,21 +852,28 @@ func (d *Driver) notifyPMAllStoriesTerminal(ctx context.Context) error {
 			specID = allStories[0].SpecID
 		}
 		for _, s := range allStories {
-			if s.GetStatus() == StatusFailed {
+			switch s.GetStatus() {
+			case StatusFailed:
 				failedDetails = append(failedDetails, proto.FailedStoryDetail{
 					StoryID: s.ID,
 					Title:   s.Title,
 					Reason:  s.LastFailReason,
+				})
+			case StatusSkipped:
+				skippedDetails = append(skippedDetails, proto.SkippedStoryDetail{
+					StoryID: s.ID,
+					Title:   s.Title,
 				})
 			}
 		}
 	}
 
 	payload := &proto.AllStoriesTerminalPayload{
-		SpecID:        specID,
-		TotalStories:  totalStories,
-		FailedStories: failedDetails,
-		Timestamp:     time.Now().UTC().Format(time.RFC3339),
+		SpecID:         specID,
+		TotalStories:   totalStories,
+		FailedStories:  failedDetails,
+		SkippedStories: skippedDetails,
+		Timestamp:      time.Now().UTC().Format(time.RFC3339),
 	}
 
 	notifyMsg := proto.NewAgentMsg(proto.MsgTypeRESPONSE, d.GetAgentID(), "pm-001")
@@ -877,8 +885,8 @@ func (d *Driver) notifyPMAllStoriesTerminal(ctx context.Context) error {
 	}
 
 	d.pmAllTerminalNotified = true
-	d.resolveAllIncidents(ctx, "all_terminal", fmt.Sprintf("All stories terminal (%d failed)", len(failedDetails)))
-	d.logger.Info("📋 Notified PM that all %d stories are terminal (%d failed, spec=%s)", totalStories, len(failedDetails), specID)
+	d.resolveAllIncidents(ctx, "all_terminal", fmt.Sprintf("All stories terminal (%d failed, %d skipped)", len(failedDetails), len(skippedDetails)))
+	d.logger.Info("📋 Notified PM that all %d stories are terminal (%d failed, %d skipped, spec=%s)", totalStories, len(failedDetails), len(skippedDetails), specID)
 	return nil
 }
 
@@ -1038,7 +1046,7 @@ func (d *Driver) notifyPMOfClarificationNeeded(ctx context.Context, story *Queue
 		Title:            fmt.Sprintf("Clarification needed: %s", story.Title),
 		Summary:          question,
 		AffectedStoryIDs: heldStoryIDs,
-		AllowedActions:   []proto.IncidentAction{proto.IncidentActionResume, proto.IncidentActionChangeRequest},
+		AllowedActions:   []proto.IncidentAction{proto.IncidentActionResume},
 		Blocking:         true,
 		OpenedAt:         time.Now().UTC().Format(time.RFC3339),
 	}

--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -821,6 +821,7 @@ func (d *Driver) notifyPMAllStoriesComplete(ctx context.Context) error {
 	}
 
 	d.pmAllCompleteNotified = true
+	d.resolveAllIncidents(ctx, "all_terminal", "All stories completed successfully")
 	d.logger.Info("🎉 Notified PM that all %d stories are complete (spec=%s)", totalStories, specID)
 	return nil
 }
@@ -870,6 +871,7 @@ func (d *Driver) notifyPMAllStoriesTerminal(ctx context.Context) error {
 	}
 
 	d.pmAllTerminalNotified = true
+	d.resolveAllIncidents(ctx, "all_terminal", fmt.Sprintf("All stories terminal (%d failed)", len(failedDetails)))
 	d.logger.Info("📋 Notified PM that all %d stories are terminal (%d failed, spec=%s)", totalStories, len(failedDetails), specID)
 	return nil
 }
@@ -903,13 +905,30 @@ func (d *Driver) notifyPMOfBlockedStory(ctx context.Context, story *QueuedStory,
 	} else {
 		d.logger.Info("📬 Notified PM of blocked story %s (kind=%s, willRetry=%v)", story.ID, fi.Kind, willRetry)
 	}
+
+	// Open durable incident for abandoned stories (not retries)
+	if !willRetry {
+		incident := &proto.Incident{
+			ID:             fmt.Sprintf("incident-story_blocked-%s-%s", story.ID, fi.ID),
+			Kind:           proto.IncidentKindStoryBlocked,
+			Scope:          "story",
+			StoryID:        story.ID,
+			FailureID:      fi.ID,
+			Title:          fmt.Sprintf("Story abandoned: %s", story.Title),
+			Summary:        fi.Explanation,
+			AllowedActions: []proto.IncidentAction{proto.IncidentActionTryAgain, proto.IncidentActionChangeRequest, proto.IncidentActionSkip, proto.IncidentActionResume},
+			Blocking:       true,
+			OpenedAt:       time.Now().UTC().Format(time.RFC3339),
+		}
+		d.openIncident(ctx, incident)
+	}
 }
 
 // handleRepairComplete processes a repair_complete signal from PM.
 // Releases held stories and resumes dispatch if it was suppressed.
 // Returns StateDispatching if stories were released so the caller can
 // return it as the next state, or "" to let the default path continue.
-func (d *Driver) handleRepairComplete(_ context.Context, msg *proto.AgentMsg) proto.State {
+func (d *Driver) handleRepairComplete(ctx context.Context, msg *proto.AgentMsg) proto.State {
 	typedPayload := msg.GetTypedPayload()
 	if typedPayload == nil {
 		d.logger.Warn("Repair complete message has no payload")
@@ -923,6 +942,13 @@ func (d *Driver) handleRepairComplete(_ context.Context, msg *proto.AgentMsg) pr
 	}
 
 	d.logger.Info("🔧 Repair complete signal received: %s", repair.Reason)
+
+	// Resolve incidents associated with this repair
+	if repair.FailureID != "" {
+		d.resolveIncidentsByFailureID(ctx, repair.FailureID, "manual", "User indicated repair complete: "+repair.Reason)
+	} else {
+		d.resolveAllIncidents(ctx, "manual", "User indicated repair complete: "+repair.Reason)
+	}
 
 	// Release held stories
 	var released []string
@@ -995,6 +1021,22 @@ func (d *Driver) notifyPMOfClarificationNeeded(ctx context.Context, story *Queue
 	} else {
 		d.logger.Info("❓ Sent clarification request to PM for story %s (%s: %s)", story.ID, fi.ResolvedKind, question)
 	}
+
+	// Open durable clarification incident
+	incident := &proto.Incident{
+		ID:               fmt.Sprintf("incident-clarification-%s-%s", story.ID, fi.ID),
+		Kind:             proto.IncidentKindClarification,
+		Scope:            "story",
+		StoryID:          story.ID,
+		FailureID:        fi.ID,
+		Title:            fmt.Sprintf("Clarification needed: %s", story.Title),
+		Summary:          question,
+		AffectedStoryIDs: heldStoryIDs,
+		AllowedActions:   []proto.IncidentAction{proto.IncidentActionResume, proto.IncidentActionChangeRequest},
+		Blocking:         true,
+		OpenedAt:         time.Now().UTC().Format(time.RFC3339),
+	}
+	d.openIncident(ctx, incident)
 }
 
 // Response formatting methods using templates

--- a/pkg/architect/request.go
+++ b/pkg/architect/request.go
@@ -123,6 +123,12 @@ func (d *Driver) handleRequest(ctx context.Context) (proto.State, error) {
 				return repairNextState, nil
 			}
 			response = nil // No response needed
+		case proto.RequestKindExecution:
+			execNextState := d.handleExecutionRequest(ctx, requestMsg)
+			if execNextState != "" {
+				return execNextState, nil
+			}
+			response = nil
 		default:
 			return StateError, fmt.Errorf("unknown request kind: %s", requestKind)
 		}
@@ -1037,6 +1043,23 @@ func (d *Driver) notifyPMOfClarificationNeeded(ctx context.Context, story *Queue
 		OpenedAt:         time.Now().UTC().Format(time.RFC3339),
 	}
 	d.openIncident(ctx, incident)
+}
+
+// handleExecutionRequest dispatches execution requests by payload kind.
+func (d *Driver) handleExecutionRequest(ctx context.Context, msg *proto.AgentMsg) proto.State {
+	typedPayload := msg.GetTypedPayload()
+	if typedPayload == nil {
+		d.logger.Warn("Execution request has no payload")
+		return ""
+	}
+
+	switch typedPayload.Kind {
+	case proto.PayloadKindIncidentAction:
+		return d.handleIncidentAction(ctx, msg)
+	default:
+		d.logger.Warn("Unknown execution request payload kind: %s", typedPayload.Kind)
+		return ""
+	}
 }
 
 // Response formatting methods using templates

--- a/pkg/architect/resume.go
+++ b/pkg/architect/resume.go
@@ -25,10 +25,14 @@ func (d *Driver) SerializeState(_ context.Context, _ *sql.DB, sessionID string) 
 	// Get current state from state machine.
 	currentState := d.GetCurrentState()
 
+	// Serialize open incidents.
+	openIncidentsJSON := d.collectOpenIncidentsJSON()
+
 	// Build architect state.
 	state := &persistence.ArchitectState{
-		SessionID: sessionID,
-		State:     string(currentState),
+		SessionID:         sessionID,
+		State:             string(currentState),
+		OpenIncidentsJSON: openIncidentsJSON,
 	}
 
 	// Build per-agent contexts.
@@ -85,6 +89,17 @@ func (d *Driver) RestoreState(_ context.Context, db *sql.DB, sessionID string) e
 		}
 		// The escalation handler manages its own state via files.
 		// We would need to add a method to restore counts if needed.
+	}
+
+	// Restore open incidents.
+	if state.OpenIncidentsJSON != nil {
+		var incidents map[string]*proto.Incident
+		if unmarshalErr := json.Unmarshal([]byte(*state.OpenIncidentsJSON), &incidents); unmarshalErr != nil {
+			d.logger.Warn("Failed to unmarshal open incidents: %v", unmarshalErr)
+		} else {
+			d.openIncidents = incidents
+			d.syncIncidentsToStateData()
+		}
 	}
 
 	// Restore per-agent contexts.
@@ -156,9 +171,11 @@ func (d *Driver) Checkpoint(sessionID string) {
 
 	// Build architect state
 	currentState := d.GetCurrentState()
+	openIncidentsJSON := d.collectOpenIncidentsJSON()
 	state := &persistence.ArchitectState{
-		SessionID: sessionID,
-		State:     string(currentState),
+		SessionID:         sessionID,
+		State:             string(currentState),
+		OpenIncidentsJSON: openIncidentsJSON,
 	}
 
 	// Build per-agent contexts

--- a/pkg/architect/resume.go
+++ b/pkg/architect/resume.go
@@ -97,8 +97,10 @@ func (d *Driver) RestoreState(_ context.Context, db *sql.DB, sessionID string) e
 		if unmarshalErr := json.Unmarshal([]byte(*state.OpenIncidentsJSON), &incidents); unmarshalErr != nil {
 			d.logger.Warn("Failed to unmarshal open incidents: %v", unmarshalErr)
 		} else {
+			d.incidentsMu.Lock()
 			d.openIncidents = incidents
-			d.syncIncidentsToStateData()
+			d.syncIncidentsToStateDataLocked()
+			d.incidentsMu.Unlock()
 		}
 	}
 

--- a/pkg/architect/state_keys.go
+++ b/pkg/architect/state_keys.go
@@ -49,6 +49,9 @@ const (
 
 	// Lifecycle tracking.
 	StateKeyStartedAt = "started_at" // time.Time - when architect started
+
+	// Incident tracking (durable asks & incidents system).
+	StateKeyOpenIncidents = "open_incidents" // string (JSON) - mirrored for FSM visibility
 )
 
 // Dynamic state key patterns (use with fmt.Sprintf).

--- a/pkg/dispatch/dispatcher.go
+++ b/pkg/dispatch/dispatcher.go
@@ -1181,6 +1181,17 @@ func (d *Dispatcher) GetLease(agentID string) string {
 	return storyID
 }
 
+// GetLeasedStoryIDs returns the set of story IDs that are currently leased to any agent.
+func (d *Dispatcher) GetLeasedStoryIDs() map[string]bool {
+	d.leasesMutex.Lock()
+	defer d.leasesMutex.Unlock()
+	result := make(map[string]bool, len(d.leases))
+	for _, storyID := range d.leases {
+		result[storyID] = true
+	}
+	return result
+}
+
 // ClearLease removes an agent's story assignment.
 func (d *Dispatcher) ClearLease(agentID string) {
 	d.leasesMutex.Lock()

--- a/pkg/dispatch/dispatcher_test.go
+++ b/pkg/dispatch/dispatcher_test.go
@@ -554,6 +554,23 @@ func TestLeaseOperations(t *testing.T) {
 
 	// Test clearing non-existent lease (should not panic)
 	dispatcher.ClearLease("non-existent")
+
+	// Test GetLeasedStoryIDs
+	dispatcher.SetLease("agent-001", "story-001")
+	dispatcher.SetLease("agent-002", "story-002")
+	leased := dispatcher.GetLeasedStoryIDs()
+	if len(leased) != 2 {
+		t.Errorf("Expected 2 leased stories, got %d", len(leased))
+	}
+	if !leased["story-001"] || !leased["story-002"] {
+		t.Errorf("Expected story-001 and story-002 in leased set, got %v", leased)
+	}
+
+	dispatcher.ClearLease("agent-001")
+	leased = dispatcher.GetLeasedStoryIDs()
+	if len(leased) != 1 || !leased["story-002"] {
+		t.Errorf("Expected only story-002 in leased set after clear, got %v", leased)
+	}
 }
 
 func TestSendRequeue(t *testing.T) {

--- a/pkg/persistence/failure_ops.go
+++ b/pkg/persistence/failure_ops.go
@@ -251,6 +251,7 @@ type SessionSummary struct {
 	StoriesTotal     int    `json:"stories_total"`
 	StoriesCompleted int    `json:"stories_completed"`
 	StoriesFailed    int    `json:"stories_failed"`
+	StoriesSkipped   int    `json:"stories_skipped"`
 	StoriesHeld      int    `json:"stories_held"`
 }
 
@@ -295,6 +296,8 @@ func QuerySessionSummary(db *sql.DB, sessionID string) (*SessionSummary, error) 
 			summary.StoriesCompleted += count
 		case StatusFailed:
 			summary.StoriesFailed += count
+		case StatusSkipped:
+			summary.StoriesSkipped += count
 		case StatusOnHold:
 			summary.StoriesHeld += count
 		}

--- a/pkg/persistence/models.go
+++ b/pkg/persistence/models.go
@@ -92,6 +92,7 @@ const (
 	StatusDone       = "done"
 	StatusOnHold     = "on_hold"
 	StatusFailed     = "failed"
+	StatusSkipped    = "skipped"
 )
 
 // GenerateSpecID generates a new UUID for a spec.

--- a/pkg/persistence/schema.go
+++ b/pkg/persistence/schema.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CurrentSchemaVersion defines the current schema version for migration support.
-const CurrentSchemaVersion = 21
+const CurrentSchemaVersion = 22
 
 // InitializeDatabase creates and initializes the SQLite database with the required schema.
 // This function is idempotent and safe to call multiple times.
@@ -133,6 +133,8 @@ func runMigration(db *sql.DB, version int) error {
 		return migrateToVersion20(db)
 	case 21:
 		return migrateToVersion21(db)
+	case 22:
+		return migrateToVersion22(db)
 	default:
 		return fmt.Errorf("unknown migration version: %d", version)
 	}
@@ -952,6 +954,26 @@ func migrateToVersion21(db *sql.DB) error {
 	return nil
 }
 
+// migrateToVersion22 adds durable asks and incidents columns for PM and architect state.
+func migrateToVersion22(db *sql.DB) error {
+	if !tableHasColumn(db, "pm_state", "current_ask_json") {
+		if _, err := db.Exec("ALTER TABLE pm_state ADD COLUMN current_ask_json TEXT"); err != nil {
+			return fmt.Errorf("failed to add current_ask_json to pm_state: %w", err)
+		}
+	}
+	if !tableHasColumn(db, "pm_state", "open_incidents_json") {
+		if _, err := db.Exec("ALTER TABLE pm_state ADD COLUMN open_incidents_json TEXT"); err != nil {
+			return fmt.Errorf("failed to add open_incidents_json to pm_state: %w", err)
+		}
+	}
+	if !tableHasColumn(db, "architect_state", "open_incidents_json") {
+		if _, err := db.Exec("ALTER TABLE architect_state ADD COLUMN open_incidents_json TEXT"); err != nil {
+			return fmt.Errorf("failed to add open_incidents_json to architect_state: %w", err)
+		}
+	}
+	return nil
+}
+
 // tableHasColumn checks if a table has a column with the given name using PRAGMA table_info.
 func tableHasColumn(db *sql.DB, table, column string) bool {
 	rows, err := db.Query("PRAGMA table_info(" + table + ")")
@@ -1260,6 +1282,7 @@ func createSchema(db *sql.DB) error {
 			session_id TEXT NOT NULL PRIMARY KEY,
 			state TEXT NOT NULL,
 			escalation_counts_json TEXT,
+			open_incidents_json TEXT,
 			updated_at DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 		)`,
 
@@ -1269,6 +1292,8 @@ func createSchema(db *sql.DB) error {
 			state TEXT NOT NULL,
 			spec_content TEXT,
 			bootstrap_params_json TEXT,
+			current_ask_json TEXT,
+			open_incidents_json TEXT,
 			updated_at DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 		)`,
 

--- a/pkg/persistence/schema.go
+++ b/pkg/persistence/schema.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CurrentSchemaVersion defines the current schema version for migration support.
-const CurrentSchemaVersion = 22
+const CurrentSchemaVersion = 23
 
 // InitializeDatabase creates and initializes the SQLite database with the required schema.
 // This function is idempotent and safe to call multiple times.
@@ -135,6 +135,8 @@ func runMigration(db *sql.DB, version int) error {
 		return migrateToVersion21(db)
 	case 22:
 		return migrateToVersion22(db)
+	case 23:
+		return migrateToVersion23(db)
 	default:
 		return fmt.Errorf("unknown migration version: %d", version)
 	}
@@ -712,6 +714,8 @@ func migrateToVersion17(db *sql.DB) error {
 // Maintenance stories are tracked separately for querying when maintenance last ran.
 // Uses a single connection to ensure PRAGMA foreign_keys state is consistent,
 // since database/sql connection pooling can route statements to different connections.
+//
+//nolint:dupl // Table-swap migrations are intentionally self-contained per version
 func migrateToVersion18(db *sql.DB) error {
 	ctx := context.Background()
 
@@ -840,7 +844,7 @@ func migrateToVersion20(db *sql.DB) error {
 			spec_id TEXT REFERENCES specs(id),
 			title TEXT NOT NULL,
 			content TEXT NOT NULL,
-			status TEXT DEFAULT 'new' CHECK (status IN ('new','pending','dispatched','planning','coding','done','on_hold','failed')),
+			status TEXT DEFAULT 'new' CHECK (status IN ('new','pending','dispatched','planning','coding','done','on_hold','failed','skipped')),
 			priority INTEGER DEFAULT 0,
 			approved_plan TEXT,
 			created_at DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
@@ -974,6 +978,72 @@ func migrateToVersion22(db *sql.DB) error {
 	return nil
 }
 
+// migrateToVersion23 adds 'skipped' to the stories status CHECK constraint.
+// Uses table-swap pattern (same as v20).
+//
+//nolint:dupl // Table-swap migrations are intentionally self-contained per version
+func migrateToVersion23(db *sql.DB) error {
+	ctx := context.Background()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection for migration: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		return fmt.Errorf("failed to disable foreign keys: %w", err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, `PRAGMA foreign_keys = ON`)
+	}()
+
+	migrations := []string{
+		`CREATE TABLE IF NOT EXISTS stories_new (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			spec_id TEXT REFERENCES specs(id),
+			title TEXT NOT NULL,
+			content TEXT NOT NULL,
+			status TEXT DEFAULT 'new' CHECK (status IN ('new','pending','dispatched','planning','coding','done','on_hold','failed','skipped')),
+			priority INTEGER DEFAULT 0,
+			approved_plan TEXT,
+			created_at DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+			started_at DATETIME,
+			completed_at DATETIME,
+			assigned_agent TEXT,
+			tokens_used BIGINT DEFAULT 0,
+			cost_usd DECIMAL(10,4) DEFAULT 0.0,
+			metadata TEXT,
+			story_type TEXT DEFAULT 'app' CHECK (story_type IN ('devops', 'app', 'maintenance')),
+			pr_id TEXT,
+			commit_hash TEXT,
+			completion_summary TEXT,
+			hold_reason TEXT,
+			hold_since DATETIME,
+			hold_owner TEXT,
+			hold_note TEXT,
+			blocked_by_failure_id TEXT
+		)`,
+		`INSERT INTO stories_new SELECT * FROM stories`,
+		`DROP TABLE stories`,
+		`ALTER TABLE stories_new RENAME TO stories`,
+		`CREATE INDEX IF NOT EXISTS idx_stories_session ON stories(session_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_stories_status ON stories(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_stories_agent ON stories(assigned_agent)`,
+		`CREATE INDEX IF NOT EXISTS idx_stories_type ON stories(story_type)`,
+		`CREATE INDEX IF NOT EXISTS idx_stories_spec ON stories(spec_id)`,
+	}
+
+	for _, migration := range migrations {
+		if _, err := conn.ExecContext(ctx, migration); err != nil {
+			return fmt.Errorf("failed to execute stories migration: %s: %w", migration, err)
+		}
+	}
+
+	return nil
+}
+
 // tableHasColumn checks if a table has a column with the given name using PRAGMA table_info.
 func tableHasColumn(db *sql.DB, table, column string) bool {
 	rows, err := db.Query("PRAGMA table_info(" + table + ")")
@@ -1037,7 +1107,7 @@ func createSchema(db *sql.DB) error {
 			spec_id TEXT REFERENCES specs(id),
 			title TEXT NOT NULL,
 			content TEXT NOT NULL,
-			status TEXT DEFAULT 'new' CHECK (status IN ('new','pending','dispatched','planning','coding','done','on_hold','failed')),
+			status TEXT DEFAULT 'new' CHECK (status IN ('new','pending','dispatched','planning','coding','done','on_hold','failed','skipped')),
 			priority INTEGER DEFAULT 0,
 			approved_plan TEXT,
 			created_at DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),

--- a/pkg/persistence/schema_test.go
+++ b/pkg/persistence/schema_test.go
@@ -1,0 +1,75 @@
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMigrationV22_AddsDurableAsksAndIncidentsColumns(t *testing.T) {
+	// Create a real on-disk database (InitializeDatabase runs all migrations)
+	tempDir, err := os.MkdirTemp("", "schema_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	dbPath := filepath.Join(tempDir, "test.db")
+	db, err := InitializeDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("InitializeDatabase failed: %v", err)
+	}
+	defer db.Close()
+
+	// Verify pm_state.current_ask_json exists
+	if !tableHasColumn(db, "pm_state", "current_ask_json") {
+		t.Error("pm_state should have current_ask_json column after migration v22")
+	}
+
+	// Verify pm_state.open_incidents_json exists
+	if !tableHasColumn(db, "pm_state", "open_incidents_json") {
+		t.Error("pm_state should have open_incidents_json column after migration v22")
+	}
+
+	// Verify architect_state.open_incidents_json exists
+	if !tableHasColumn(db, "architect_state", "open_incidents_json") {
+		t.Error("architect_state should have open_incidents_json column after migration v22")
+	}
+}
+
+func TestMigrationV22_Idempotent(t *testing.T) {
+	// Verify that running InitializeDatabase twice does not fail
+	// (migrations should be idempotent via tableHasColumn guards)
+	tempDir, err := os.MkdirTemp("", "schema_idempotent_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	dbPath := filepath.Join(tempDir, "test.db")
+
+	// First initialization
+	db1, err := InitializeDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("First InitializeDatabase failed: %v", err)
+	}
+	db1.Close()
+
+	// Second initialization on same database file
+	db2, err := InitializeDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("Second InitializeDatabase failed (migration not idempotent): %v", err)
+	}
+	defer db2.Close()
+
+	// Columns should still be present
+	if !tableHasColumn(db2, "pm_state", "current_ask_json") {
+		t.Error("pm_state.current_ask_json missing after second initialization")
+	}
+	if !tableHasColumn(db2, "pm_state", "open_incidents_json") {
+		t.Error("pm_state.open_incidents_json missing after second initialization")
+	}
+	if !tableHasColumn(db2, "architect_state", "open_incidents_json") {
+		t.Error("architect_state.open_incidents_json missing after second initialization")
+	}
+}

--- a/pkg/persistence/sessions.go
+++ b/pkg/persistence/sessions.go
@@ -147,7 +147,7 @@ func scanSession(row *sql.Row) (*Session, error) {
 // ResumableSessionInfo contains a resumable session along with story statistics.
 type ResumableSessionInfo struct {
 	Session           *Session
-	IncompleteStories int // Count of stories not in 'done' or 'failed' status
+	IncompleteStories int // Count of stories not in 'done', 'failed', or 'skipped' status
 	DoneStories       int // Count of completed stories
 }
 
@@ -178,7 +178,7 @@ func GetResumableSession(db *sql.DB) (*Session, error) {
 // 1. Its status is 'shutdown', 'crashed', or 'active' (not 'completed')
 //   - 'active' sessions are treated as crashed (the process died unexpectedly)
 //
-// 2. It has at least one incomplete story (status not in 'done', 'failed')
+// 2. It has at least one incomplete story (status not in 'done', 'failed', 'skipped')
 //
 // If an 'active' session is found, its status is updated to 'crashed' before returning.
 // Returns nil, nil if no resumable session exists (this is not an error condition).
@@ -216,7 +216,7 @@ func GetMostRecentResumableSession(db *sql.DB) (*ResumableSessionInfo, error) {
 	var incompleteCount, doneCount int
 	err = db.QueryRow(`
 		SELECT
-			COALESCE(SUM(CASE WHEN status NOT IN ('done', 'failed') THEN 1 ELSE 0 END), 0) as incomplete,
+			COALESCE(SUM(CASE WHEN status NOT IN ('done', 'failed', 'skipped') THEN 1 ELSE 0 END), 0) as incomplete,
 			COALESCE(SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END), 0) as done
 		FROM stories
 		WHERE session_id = ?

--- a/pkg/persistence/sessions.go
+++ b/pkg/persistence/sessions.go
@@ -65,6 +65,7 @@ type ArchitectState struct {
 	SessionID            string    `json:"session_id"`
 	State                string    `json:"state"`
 	EscalationCountsJSON *string   `json:"escalation_counts_json,omitempty"`
+	OpenIncidentsJSON    *string   `json:"open_incidents_json,omitempty"`
 	UpdatedAt            time.Time `json:"updated_at"`
 }
 
@@ -76,6 +77,8 @@ type PMState struct {
 	State               string    `json:"state"`
 	SpecContent         *string   `json:"spec_content,omitempty"`
 	BootstrapParamsJSON *string   `json:"bootstrap_params_json,omitempty"`
+	CurrentAskJSON      *string   `json:"current_ask_json,omitempty"`
+	OpenIncidentsJSON   *string   `json:"open_incidents_json,omitempty"`
 	UpdatedAt           time.Time `json:"updated_at"`
 }
 
@@ -416,13 +419,14 @@ func GetAllCoderStates(db *sql.DB, sessionID string) ([]CoderState, error) {
 // SaveArchitectState saves or updates the architect's state for resume.
 func SaveArchitectState(db *sql.DB, state *ArchitectState) error {
 	_, err := db.Exec(`
-		INSERT INTO architect_state (session_id, state, escalation_counts_json, updated_at)
-		VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+		INSERT INTO architect_state (session_id, state, escalation_counts_json, open_incidents_json, updated_at)
+		VALUES (?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 		ON CONFLICT(session_id) DO UPDATE SET
 			state = excluded.state,
 			escalation_counts_json = excluded.escalation_counts_json,
+			open_incidents_json = excluded.open_incidents_json,
 			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-	`, state.SessionID, state.State, state.EscalationCountsJSON)
+	`, state.SessionID, state.State, state.EscalationCountsJSON, state.OpenIncidentsJSON)
 	if err != nil {
 		return fmt.Errorf("failed to save architect state: %w", err)
 	}
@@ -433,13 +437,13 @@ func SaveArchitectState(db *sql.DB, state *ArchitectState) error {
 // Returns ErrSessionNotFound if no state exists for the architect.
 func GetArchitectState(db *sql.DB, sessionID string) (*ArchitectState, error) {
 	row := db.QueryRow(`
-		SELECT session_id, state, escalation_counts_json, updated_at
+		SELECT session_id, state, escalation_counts_json, open_incidents_json, updated_at
 		FROM architect_state
 		WHERE session_id = ?
 	`, sessionID)
 
 	var state ArchitectState
-	err := row.Scan(&state.SessionID, &state.State, &state.EscalationCountsJSON, &state.UpdatedAt)
+	err := row.Scan(&state.SessionID, &state.State, &state.EscalationCountsJSON, &state.OpenIncidentsJSON, &state.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrSessionNotFound
 	}
@@ -452,14 +456,16 @@ func GetArchitectState(db *sql.DB, sessionID string) (*ArchitectState, error) {
 // SavePMState saves or updates the PM's state for resume.
 func SavePMState(db *sql.DB, state *PMState) error {
 	_, err := db.Exec(`
-		INSERT INTO pm_state (session_id, state, spec_content, bootstrap_params_json, updated_at)
-		VALUES (?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+		INSERT INTO pm_state (session_id, state, spec_content, bootstrap_params_json, current_ask_json, open_incidents_json, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 		ON CONFLICT(session_id) DO UPDATE SET
 			state = excluded.state,
 			spec_content = excluded.spec_content,
 			bootstrap_params_json = excluded.bootstrap_params_json,
+			current_ask_json = excluded.current_ask_json,
+			open_incidents_json = excluded.open_incidents_json,
 			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-	`, state.SessionID, state.State, state.SpecContent, state.BootstrapParamsJSON)
+	`, state.SessionID, state.State, state.SpecContent, state.BootstrapParamsJSON, state.CurrentAskJSON, state.OpenIncidentsJSON)
 	if err != nil {
 		return fmt.Errorf("failed to save PM state: %w", err)
 	}
@@ -470,13 +476,13 @@ func SavePMState(db *sql.DB, state *PMState) error {
 // Returns ErrSessionNotFound if no state exists for the PM.
 func GetPMState(db *sql.DB, sessionID string) (*PMState, error) {
 	row := db.QueryRow(`
-		SELECT session_id, state, spec_content, bootstrap_params_json, updated_at
+		SELECT session_id, state, spec_content, bootstrap_params_json, current_ask_json, open_incidents_json, updated_at
 		FROM pm_state
 		WHERE session_id = ?
 	`, sessionID)
 
 	var state PMState
-	err := row.Scan(&state.SessionID, &state.State, &state.SpecContent, &state.BootstrapParamsJSON, &state.UpdatedAt)
+	err := row.Scan(&state.SessionID, &state.State, &state.SpecContent, &state.BootstrapParamsJSON, &state.CurrentAskJSON, &state.OpenIncidentsJSON, &state.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrSessionNotFound
 	}

--- a/pkg/pm/STATES.md
+++ b/pkg/pm/STATES.md
@@ -209,9 +209,20 @@ PM uses LLM reasoning to decide when to:
 **Purpose:** Wait for user's response in chat
 
 **Behavior:**
-- Polls chat channel for new messages (1-second intervals)
+- Polls chat channel for new messages (500ms timeout intervals)
 - Transitions to WORKING when new messages arrive
 - Uses chat middleware to track read position
+- On user message arrival, resolves the active `UserAsk` (if any)
+- Also receives architect notifications on `replyCh` (story completions, incidents)
+
+### Durable Ask Lifecycle
+
+PM maintains at most one active `UserAsk` — a PM-owned conversational obligation:
+- **Created** when `chat_ask_user` tool is called (in WORKING → SignalAwaitUser handler)
+- **Resolved** when user sends a chat message (in AWAIT_USER poll check)
+- **Superseded** if PM issues a new `chat_ask_user` before prior ask is resolved
+- **Persisted** via `PMState.CurrentAskJSON` column and mirrored to `StateKeyCurrentAsk` state data
+- User replies resolve asks; they do NOT resolve architect-owned incidents
 
 ### WORKING State
 
@@ -221,6 +232,9 @@ PM uses LLM reasoning to decide when to:
 - `list_files` - List files in workspace
 - `await_user` - Wait for user input (triggers AWAIT_USER transition)
 - `spec_submit` - Generate spec for preview (triggers PREVIEW transition)
+
+**Pending Items Injection:**
+On each entry to WORKING, `maybeInjectPendingItemsSummary()` checks for unresolved asks and incidents. Uses a hash (`StateKeyPendingSummaryHash`) to avoid re-injecting the same summary on re-entry loops.
 
 **LLM Reasoning Flow:**
 1. PM receives conversation history and any architect feedback

--- a/pkg/pm/await_user.go
+++ b/pkg/pm/await_user.go
@@ -119,7 +119,7 @@ func (d *Driver) handleAllStoriesCompleteNotification(payload *proto.MessagePayl
 }
 
 // handleAllStoriesTerminalNotification processes the all_stories_terminal notification.
-// Clears in_flight so PM can accept new specs and informs user of failures.
+// Clears in_flight so PM can accept new specs and informs user of failures/skips.
 func (d *Driver) handleAllStoriesTerminalNotification(payload *proto.MessagePayload) (proto.State, error) {
 	terminal, err := payload.ExtractAllStoriesTerminal()
 	if err != nil {
@@ -127,19 +127,29 @@ func (d *Driver) handleAllStoriesTerminalNotification(payload *proto.MessagePayl
 		return StateAwaitUser, nil
 	}
 
-	d.logger.Info("📋 All stories terminal: %d total, %d failed (spec: %s)",
-		terminal.TotalStories, len(terminal.FailedStories), terminal.SpecID)
+	d.logger.Info("📋 All stories terminal: %d total, %d failed, %d skipped (spec: %s)",
+		terminal.TotalStories, len(terminal.FailedStories), len(terminal.SkippedStories), terminal.SpecID)
 
 	d.SetStateData(StateKeyInFlight, false)
 
 	msg := fmt.Sprintf(
-		"Development work is complete but %d out of %d stories failed. ",
-		len(terminal.FailedStories), terminal.TotalStories)
-	for i := range terminal.FailedStories {
-		fs := &terminal.FailedStories[i]
-		msg += fmt.Sprintf("\n- %s (%s): %s", fs.StoryID, fs.Title, fs.Reason)
+		"Development work is complete but %d out of %d stories did not succeed. ",
+		len(terminal.FailedStories)+len(terminal.SkippedStories), terminal.TotalStories)
+	if len(terminal.FailedStories) > 0 {
+		msg += fmt.Sprintf("\n\nFailed stories (%d):", len(terminal.FailedStories))
+		for i := range terminal.FailedStories {
+			fs := &terminal.FailedStories[i]
+			msg += fmt.Sprintf("\n- %s (%s): %s", fs.StoryID, fs.Title, fs.Reason)
+		}
 	}
-	msg += "\n\nUse chat_ask_user to inform the user about the failed stories and ask how they'd like to proceed."
+	if len(terminal.SkippedStories) > 0 {
+		msg += fmt.Sprintf("\n\nSkipped stories (%d):", len(terminal.SkippedStories))
+		for i := range terminal.SkippedStories {
+			ss := &terminal.SkippedStories[i]
+			msg += fmt.Sprintf("\n- %s (%s)", ss.StoryID, ss.Title)
+		}
+	}
+	msg += "\n\nUse chat_ask_user to inform the user about the outcome and ask how they'd like to proceed."
 
 	d.contextManager.AddMessage("user", msg)
 	return StateWorking, nil

--- a/pkg/pm/await_user.go
+++ b/pkg/pm/await_user.go
@@ -58,40 +58,9 @@ func (d *Driver) handleArchitectNotification(msg *proto.AgentMsg) (proto.State, 
 
 	switch typedPayload.Kind {
 	case proto.PayloadKindStoryComplete:
-		// Individual story completion - log and inform user
-		storyComplete, err := typedPayload.ExtractStoryComplete()
-		if err != nil {
-			d.logger.Error("❌ Failed to parse story_complete payload: %v", err)
-			return StateAwaitUser, nil
+		if err := d.handleStoryCompleteNotification(typedPayload); err != nil {
+			return StateAwaitUser, nil //nolint:nilerr // parse failure already logged, stay in AWAIT_USER
 		}
-
-		if storyComplete.IsHotfix {
-			d.logger.Info("🔧 Hotfix completed: %s - %s", storyComplete.StoryID, storyComplete.Title)
-		} else {
-			d.logger.Info("✅ Story completed: %s - %s", storyComplete.StoryID, storyComplete.Title)
-		}
-
-		// Check if demo should become available after this story
-		// Stories may create bootstrap components (Dockerfile, Makefile, etc.)
-		if !d.demoAvailable {
-			d.logger.Debug("Story completed, checking if bootstrap is now complete...")
-			//nolint:contextcheck // Bootstrap detection is a quick local operation, context.Background() is appropriate
-			d.detectAndStoreBootstrapRequirements(context.Background())
-		}
-
-		// Inject message so PM can inform user
-		completionMsg := fmt.Sprintf(
-			"A story has been completed by the development team. Story: %q (ID: %s). ",
-			storyComplete.Title, storyComplete.StoryID)
-		if storyComplete.IsHotfix {
-			completionMsg += "This was a hotfix request. "
-		}
-		if storyComplete.Summary != "" {
-			completionMsg += fmt.Sprintf("Summary: %s ", storyComplete.Summary)
-		}
-		completionMsg += "Use chat_ask_user to inform the user about this progress."
-
-		d.contextManager.AddMessage("user", completionMsg)
 		return StateWorking, nil
 
 	case proto.PayloadKindAllStoriesComplete:
@@ -111,6 +80,9 @@ func (d *Driver) handleArchitectNotification(msg *proto.AgentMsg) (proto.State, 
 
 	case proto.PayloadKindIncidentResolved:
 		return d.handleIncidentResolved(typedPayload)
+
+	case proto.PayloadKindIncidentActionResult:
+		return d.handleIncidentActionResult(typedPayload)
 
 	default:
 		d.logger.Warn("⚠️ Unhandled architect notification kind: %s", typedPayload.Kind)

--- a/pkg/pm/await_user.go
+++ b/pkg/pm/await_user.go
@@ -36,6 +36,7 @@ func (d *Driver) handleAwaitUser(ctx context.Context) (proto.State, error) {
 		// Timeout - check for user messages
 		if d.chatService.HaveNewMessages(d.GetAgentID()) {
 			d.logger.Info("📬 New user messages received, PM resuming work")
+			d.resolveCurrentAsk()
 			return StateWorking, nil
 		}
 		// No messages on either channel, stay in AWAIT_USER
@@ -104,6 +105,12 @@ func (d *Driver) handleArchitectNotification(msg *proto.AgentMsg) (proto.State, 
 
 	case proto.PayloadKindClarificationRequest:
 		return d.handleClarificationRequest(typedPayload)
+
+	case proto.PayloadKindIncidentOpened:
+		return d.handleIncidentOpened(typedPayload)
+
+	case proto.PayloadKindIncidentResolved:
+		return d.handleIncidentResolved(typedPayload)
 
 	default:
 		d.logger.Warn("⚠️ Unhandled architect notification kind: %s", typedPayload.Kind)

--- a/pkg/pm/driver.go
+++ b/pkg/pm/driver.go
@@ -86,6 +86,11 @@ const (
 	// StateKeyAwaitingSpecType tracks which type of spec the PM is awaiting
 	// architect response for. Values: "bootstrap", "user", "hotfix".
 	StateKeyAwaitingSpecType = "awaiting_spec_type"
+
+	// Incident/ask tracking (durable asks & incidents system).
+	StateKeyCurrentAsk         = "current_ask"          // string (JSON) - active UserAsk or empty
+	StateKeyOpenIncidents      = "open_incidents"       // string (JSON) - mirrored incidents from architect
+	StateKeyPendingSummaryHash = "pending_summary_hash" // string - hash for change-detected injection
 )
 
 // Driver implements the PM (Product Manager) agent.
@@ -102,9 +107,11 @@ type Driver struct {
 	chatService             *chat.Service    // Chat service for polling new messages
 	executor                execpkg.Executor // PM executor for running tools
 	workDir                 string
-	replyCh                 <-chan *proto.AgentMsg // Receives RESULT messages from architect
-	toolProvider            ToolProvider           // Tool provider for spec_submit tool
-	demoAvailable           bool                   // True when bootstrap is complete (no missing components)
+	replyCh                 <-chan *proto.AgentMsg     // Receives RESULT messages from architect
+	toolProvider            ToolProvider               // Tool provider for spec_submit tool
+	demoAvailable           bool                       // True when bootstrap is complete (no missing components)
+	currentAsk              *proto.UserAsk             // At most one active ask (PM-owned)
+	openIncidents           map[string]*proto.Incident // Mirrored from architect (architect-owned)
 }
 
 // NewPM creates a new PM agent with all dependencies initialized.
@@ -260,6 +267,7 @@ func NewDriver(
 		persistenceChannel: persistenceChannel,
 		executor:           executor,
 		workDir:            workDir,
+		openIncidents:      make(map[string]*proto.Incident),
 	}
 }
 

--- a/pkg/pm/driver.go
+++ b/pkg/pm/driver.go
@@ -221,6 +221,7 @@ func NewPM(
 		executor:           pmExecutor,
 		workDir:            workDir,
 		toolProvider:       toolProvider,
+		openIncidents:      make(map[string]*proto.Incident),
 	}
 
 	// Now create LLM client with context (passing driver as StateProvider)

--- a/pkg/pm/incidents.go
+++ b/pkg/pm/incidents.go
@@ -1,0 +1,147 @@
+package pm
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"orchestrator/pkg/proto"
+)
+
+// syncAskToStateData mirrors the current ask to a state data key for FSM visibility.
+func (d *Driver) syncAskToStateData() {
+	if d.currentAsk == nil {
+		d.SetStateData(StateKeyCurrentAsk, "")
+		return
+	}
+	raw, err := json.Marshal(d.currentAsk)
+	if err != nil {
+		d.logger.Warn("Failed to marshal current ask for state data: %v", err)
+		return
+	}
+	d.SetStateData(StateKeyCurrentAsk, string(raw))
+}
+
+// syncIncidentsToStateData mirrors open incidents to a state data key for FSM visibility.
+func (d *Driver) syncIncidentsToStateData() {
+	if len(d.openIncidents) == 0 {
+		d.SetStateData(StateKeyOpenIncidents, "")
+		return
+	}
+	raw, err := json.Marshal(d.openIncidents)
+	if err != nil {
+		d.logger.Warn("Failed to marshal open incidents for state data: %v", err)
+		return
+	}
+	d.SetStateData(StateKeyOpenIncidents, string(raw))
+}
+
+// handleIncidentOpened processes an incident_opened notification from the architect.
+func (d *Driver) handleIncidentOpened(payload *proto.MessagePayload) (proto.State, error) {
+	incident, err := payload.ExtractIncidentOpened()
+	if err != nil {
+		d.logger.Warn("Failed to extract incident_opened payload: %v", err)
+		return StateWorking, nil
+	}
+
+	d.openIncidents[incident.ID] = incident
+	d.syncIncidentsToStateData()
+
+	d.logger.Info("Received incident_opened: %s (%s)", incident.ID, incident.Title)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "[SYSTEM] New incident reported by architect:\n\n")
+	fmt.Fprintf(&sb, "INCIDENT [%s]: %s\n", incident.ID, incident.Title)
+	fmt.Fprintf(&sb, "  %s\n", incident.Summary)
+	if len(incident.AllowedActions) > 0 {
+		fmt.Fprintf(&sb, "  Suggested actions: %v\n", incident.AllowedActions)
+	}
+	sb.WriteString("\nPlease inform the user about this situation and ask how they'd like to proceed.")
+
+	d.contextManager.AddMessage("user", sb.String())
+
+	return StateWorking, nil
+}
+
+// handleIncidentResolved processes an incident_resolved notification from the architect.
+func (d *Driver) handleIncidentResolved(payload *proto.MessagePayload) (proto.State, error) {
+	resolved, err := payload.ExtractIncidentResolved()
+	if err != nil {
+		d.logger.Warn("Failed to extract incident_resolved payload: %v", err)
+		return StateWorking, nil
+	}
+
+	delete(d.openIncidents, resolved.IncidentID)
+	d.syncIncidentsToStateData()
+
+	d.logger.Info("Incident resolved: %s (%s)", resolved.IncidentID, resolved.Resolution)
+
+	msg := fmt.Sprintf("[SYSTEM] Incident %s has been resolved: %s", resolved.IncidentID, resolved.Message)
+	d.contextManager.AddMessage("user", msg)
+
+	return StateWorking, nil
+}
+
+// maybeInjectPendingItemsSummary injects a summary of pending asks/incidents into context,
+// but only when the digest changes to avoid bloating context on handleWorking re-entry.
+func (d *Driver) maybeInjectPendingItemsSummary() {
+	summary := d.buildPendingSummary()
+	if summary == "" {
+		d.SetStateData(StateKeyPendingSummaryHash, "")
+		return
+	}
+
+	hash := sha256Hex(summary)
+	prevHash := ""
+	if v, ok := d.GetStateValue(StateKeyPendingSummaryHash); ok {
+		if s, ok := v.(string); ok {
+			prevHash = s
+		}
+	}
+	if hash == prevHash {
+		return
+	}
+
+	d.SetStateData(StateKeyPendingSummaryHash, hash)
+	d.contextManager.AddMessage("user", summary)
+}
+
+// buildPendingSummary constructs the pending items summary text.
+// Returns empty string if nothing is pending.
+func (d *Driver) buildPendingSummary() string {
+	if d.currentAsk == nil && len(d.openIncidents) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("[SYSTEM] Pending items requiring attention:\n\n")
+
+	for _, inc := range d.openIncidents {
+		fmt.Fprintf(&sb, "INCIDENT [%s]: %s\n  %s\n  Allowed actions: %v\n\n",
+			inc.ID, inc.Title, inc.Summary, inc.AllowedActions)
+	}
+
+	if d.currentAsk != nil {
+		fmt.Fprintf(&sb, "UNANSWERED QUESTION [%s]: %s\n\n", d.currentAsk.ID, d.currentAsk.Prompt)
+	}
+
+	sb.WriteString("Use chat_ask_user to address these items with the user. Present the situation clearly and ask how they'd like to proceed.")
+	return sb.String()
+}
+
+// resolveCurrentAsk resolves the active ask (if any) when the user responds.
+func (d *Driver) resolveCurrentAsk() {
+	if d.currentAsk == nil {
+		return
+	}
+	d.currentAsk.ResolvedAt = time.Now().UTC().Format(time.RFC3339)
+	d.currentAsk = nil
+	d.syncAskToStateData()
+}
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%x", h)
+}

--- a/pkg/pm/incidents.go
+++ b/pkg/pm/incidents.go
@@ -4,10 +4,12 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	"orchestrator/pkg/proto"
+	"orchestrator/pkg/utils"
 )
 
 // syncAskToStateData mirrors the current ask to a state data key for FSM visibility.
@@ -96,7 +98,7 @@ func (d *Driver) maybeInjectPendingItemsSummary() {
 	hash := sha256Hex(summary)
 	prevHash := ""
 	if v, ok := d.GetStateValue(StateKeyPendingSummaryHash); ok {
-		if s, ok := v.(string); ok {
+		if s, ok := utils.SafeAssert[string](v); ok {
 			prevHash = s
 		}
 	}
@@ -118,7 +120,13 @@ func (d *Driver) buildPendingSummary() string {
 	var sb strings.Builder
 	sb.WriteString("[SYSTEM] Pending items requiring attention:\n\n")
 
-	for _, inc := range d.openIncidents {
+	ids := make([]string, 0, len(d.openIncidents))
+	for id := range d.openIncidents {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		inc := d.openIncidents[id]
 		fmt.Fprintf(&sb, "INCIDENT [%s]: %s\n  %s\n  Allowed actions: %v\n\n",
 			inc.ID, inc.Title, inc.Summary, inc.AllowedActions)
 	}

--- a/pkg/pm/incidents.go
+++ b/pkg/pm/incidents.go
@@ -86,6 +86,27 @@ func (d *Driver) handleIncidentResolved(payload *proto.MessagePayload) (proto.St
 	return StateWorking, nil
 }
 
+// handleIncidentActionResult processes the architect's response to an incident_action request.
+func (d *Driver) handleIncidentActionResult(payload *proto.MessagePayload) (proto.State, error) {
+	result, err := payload.ExtractIncidentActionResult()
+	if err != nil {
+		d.logger.Warn("Failed to extract incident_action_result payload: %v", err)
+		return StateWorking, nil
+	}
+
+	if result.Success {
+		d.logger.Info("Incident action succeeded: %s (%s)", result.IncidentID, result.Message)
+		msg := fmt.Sprintf("[SYSTEM] Incident action accepted for %s: %s", result.IncidentID, result.Message)
+		d.contextManager.AddMessage("user", msg)
+	} else {
+		d.logger.Warn("Incident action failed: %s (%s)", result.IncidentID, result.Message)
+		msg := fmt.Sprintf("[SYSTEM] Incident action failed for %s: %s. The incident remains open — you may need to ask the user for more information.", result.IncidentID, result.Message)
+		d.contextManager.AddMessage("user", msg)
+	}
+
+	return StateWorking, nil
+}
+
 // maybeInjectPendingItemsSummary injects a summary of pending asks/incidents into context,
 // but only when the digest changes to avoid bloating context on handleWorking re-entry.
 func (d *Driver) maybeInjectPendingItemsSummary() {

--- a/pkg/pm/incidents_test.go
+++ b/pkg/pm/incidents_test.go
@@ -1,0 +1,149 @@
+package pm
+
+import (
+	"strings"
+	"testing"
+
+	"orchestrator/pkg/agent"
+	"orchestrator/pkg/contextmgr"
+	"orchestrator/pkg/logx"
+	"orchestrator/pkg/proto"
+)
+
+// createIncidentTestDriver creates a minimal PM driver with openIncidents initialized.
+func createIncidentTestDriver() *Driver {
+	sm := agent.NewBaseStateMachine("pm-test", StateWorking, nil, validTransitions)
+	return &Driver{
+		BaseStateMachine: sm,
+		contextManager:   contextmgr.NewContextManager(),
+		logger:           logx.NewLogger("pm-test"),
+		workDir:          "/tmp/test-pm",
+		openIncidents:    make(map[string]*proto.Incident),
+	}
+}
+
+func TestBuildPendingSummary_NothingPending(t *testing.T) {
+	d := createIncidentTestDriver()
+
+	summary := d.buildPendingSummary()
+	if summary != "" {
+		t.Errorf("expected empty string for no pending items, got %q", summary)
+	}
+}
+
+func TestBuildPendingSummary_IncidentOnly(t *testing.T) {
+	d := createIncidentTestDriver()
+	d.openIncidents["inc-001"] = &proto.Incident{
+		ID:             "inc-001",
+		Title:          "Build environment corrupted",
+		Summary:        "Docker image missing gcc",
+		AllowedActions: []proto.IncidentAction{proto.IncidentActionTryAgain},
+	}
+
+	summary := d.buildPendingSummary()
+	if summary == "" {
+		t.Fatal("expected non-empty summary when incident is present")
+	}
+	if !strings.Contains(summary, "inc-001") {
+		t.Errorf("summary should contain incident ID, got: %s", summary)
+	}
+	if !strings.Contains(summary, "Build environment corrupted") {
+		t.Errorf("summary should contain incident title, got: %s", summary)
+	}
+	if !strings.Contains(summary, "Docker image missing gcc") {
+		t.Errorf("summary should contain incident summary, got: %s", summary)
+	}
+	if !strings.Contains(summary, "INCIDENT") {
+		t.Errorf("summary should contain INCIDENT label, got: %s", summary)
+	}
+	// Should not contain UNANSWERED QUESTION since no ask is set
+	if strings.Contains(summary, "UNANSWERED QUESTION") {
+		t.Errorf("summary should not contain UNANSWERED QUESTION when no ask is set, got: %s", summary)
+	}
+}
+
+func TestBuildPendingSummary_AskOnly(t *testing.T) {
+	d := createIncidentTestDriver()
+	d.currentAsk = &proto.UserAsk{
+		ID:       "ask-001",
+		Prompt:   "What database engine should we use?",
+		Kind:     "decision_required",
+		OpenedAt: "2026-04-19T10:00:00Z",
+	}
+
+	summary := d.buildPendingSummary()
+	if summary == "" {
+		t.Fatal("expected non-empty summary when ask is present")
+	}
+	if !strings.Contains(summary, "ask-001") {
+		t.Errorf("summary should contain ask ID, got: %s", summary)
+	}
+	if !strings.Contains(summary, "What database engine should we use?") {
+		t.Errorf("summary should contain ask prompt, got: %s", summary)
+	}
+	if !strings.Contains(summary, "UNANSWERED QUESTION") {
+		t.Errorf("summary should contain UNANSWERED QUESTION label, got: %s", summary)
+	}
+	// Should not contain INCIDENT since no incidents are open
+	if strings.Contains(summary, "INCIDENT") {
+		t.Errorf("summary should not contain INCIDENT when no incidents are open, got: %s", summary)
+	}
+}
+
+func TestBuildPendingSummary_BothAskAndIncident(t *testing.T) {
+	d := createIncidentTestDriver()
+	d.openIncidents["inc-001"] = &proto.Incident{
+		ID:             "inc-001",
+		Title:          "Story blocked",
+		Summary:        "Dependency unavailable",
+		AllowedActions: []proto.IncidentAction{proto.IncidentActionSkip, proto.IncidentActionResume},
+	}
+	d.currentAsk = &proto.UserAsk{
+		ID:       "ask-002",
+		Prompt:   "Should we proceed without the dependency?",
+		Kind:     "clarification",
+		OpenedAt: "2026-04-19T10:05:00Z",
+	}
+
+	summary := d.buildPendingSummary()
+	if summary == "" {
+		t.Fatal("expected non-empty summary when both ask and incident are present")
+	}
+	if !strings.Contains(summary, "INCIDENT") {
+		t.Errorf("summary should contain INCIDENT, got: %s", summary)
+	}
+	if !strings.Contains(summary, "UNANSWERED QUESTION") {
+		t.Errorf("summary should contain UNANSWERED QUESTION, got: %s", summary)
+	}
+	if !strings.Contains(summary, "inc-001") {
+		t.Errorf("summary should contain incident ID, got: %s", summary)
+	}
+	if !strings.Contains(summary, "ask-002") {
+		t.Errorf("summary should contain ask ID, got: %s", summary)
+	}
+	if !strings.Contains(summary, "Pending items requiring attention") {
+		t.Errorf("summary should contain header text, got: %s", summary)
+	}
+}
+
+func TestSha256Hex_Determinism(t *testing.T) {
+	input := "test input for hashing"
+
+	hash1 := sha256Hex(input)
+	hash2 := sha256Hex(input)
+
+	if hash1 != hash2 {
+		t.Errorf("sha256Hex is not deterministic: %q != %q", hash1, hash2)
+	}
+
+	// Verify it's a valid hex string of expected length (SHA-256 = 64 hex chars)
+	if len(hash1) != 64 {
+		t.Errorf("expected 64 hex chars, got %d", len(hash1))
+	}
+
+	// Different input should produce different output
+	hash3 := sha256Hex("different input")
+	if hash1 == hash3 {
+		t.Error("different inputs should produce different hashes")
+	}
+}

--- a/pkg/pm/incidents_test.go
+++ b/pkg/pm/incidents_test.go
@@ -126,6 +126,36 @@ func TestBuildPendingSummary_BothAskAndIncident(t *testing.T) {
 	}
 }
 
+func TestBuildPendingSummary_DeterministicOrder(t *testing.T) {
+	d := createIncidentTestDriver()
+	d.openIncidents["inc-zzz"] = &proto.Incident{
+		ID: "inc-zzz", Title: "Zulu incident", Summary: "last alphabetically",
+		AllowedActions: []proto.IncidentAction{proto.IncidentActionResume},
+	}
+	d.openIncidents["inc-aaa"] = &proto.Incident{
+		ID: "inc-aaa", Title: "Alpha incident", Summary: "first alphabetically",
+		AllowedActions: []proto.IncidentAction{proto.IncidentActionTryAgain},
+	}
+	d.openIncidents["inc-mmm"] = &proto.Incident{
+		ID: "inc-mmm", Title: "Middle incident", Summary: "middle alphabetically",
+		AllowedActions: []proto.IncidentAction{proto.IncidentActionSkip},
+	}
+
+	first := d.buildPendingSummary()
+	for i := 0; i < 20; i++ {
+		if got := d.buildPendingSummary(); got != first {
+			t.Fatalf("buildPendingSummary is nondeterministic: iteration %d differs", i)
+		}
+	}
+
+	aaaIdx := strings.Index(first, "inc-aaa")
+	mmmIdx := strings.Index(first, "inc-mmm")
+	zzzIdx := strings.Index(first, "inc-zzz")
+	if aaaIdx > mmmIdx || mmmIdx > zzzIdx {
+		t.Errorf("incidents should appear in sorted order: aaa@%d, mmm@%d, zzz@%d", aaaIdx, mmmIdx, zzzIdx)
+	}
+}
+
 func TestSha256Hex_Determinism(t *testing.T) {
 	input := "test input for hashing"
 

--- a/pkg/pm/resume.go
+++ b/pkg/pm/resume.go
@@ -35,12 +35,17 @@ func (d *Driver) SerializeState(_ context.Context, _ *sql.DB, sessionID string) 
 	// Serialize bootstrap params from state data.
 	bootstrapParamsJSON := d.collectBootstrapParamsJSON()
 
+	// Serialize durable asks/incidents.
+	currentAskJSON, openIncidentsJSON := d.collectAsksAndIncidentsJSON()
+
 	// Build PM state.
 	state := &persistence.PMState{
 		SessionID:           sessionID,
 		State:               string(currentState),
 		SpecContent:         specContent,
 		BootstrapParamsJSON: bootstrapParamsJSON,
+		CurrentAskJSON:      currentAskJSON,
+		OpenIncidentsJSON:   openIncidentsJSON,
 	}
 
 	// Build context if available.
@@ -104,6 +109,26 @@ func (d *Driver) RestoreState(_ context.Context, db *sql.DB, sessionID string) e
 		}
 	}
 
+	// Restore durable asks/incidents.
+	if state.CurrentAskJSON != nil {
+		var ask proto.UserAsk
+		if unmarshalErr := json.Unmarshal([]byte(*state.CurrentAskJSON), &ask); unmarshalErr != nil {
+			d.logger.Warn("Failed to unmarshal current ask: %v", unmarshalErr)
+		} else {
+			d.currentAsk = &ask
+			d.syncAskToStateData()
+		}
+	}
+	if state.OpenIncidentsJSON != nil {
+		var incidents map[string]*proto.Incident
+		if unmarshalErr := json.Unmarshal([]byte(*state.OpenIncidentsJSON), &incidents); unmarshalErr != nil {
+			d.logger.Warn("Failed to unmarshal open incidents: %v", unmarshalErr)
+		} else {
+			d.openIncidents = incidents
+			d.syncIncidentsToStateData()
+		}
+	}
+
 	// Restore context manager.
 	contexts, err := persistence.GetAgentContexts(db, sessionID, d.GetAgentID())
 	if err != nil {
@@ -147,12 +172,17 @@ func (d *Driver) Checkpoint(sessionID string) {
 	// Serialize bootstrap params from state data.
 	bootstrapParamsJSON := d.collectBootstrapParamsJSON()
 
+	// Serialize durable asks/incidents.
+	currentAskJSON, openIncidentsJSON := d.collectAsksAndIncidentsJSON()
+
 	// Build PM state
 	state := &persistence.PMState{
 		SessionID:           sessionID,
 		State:               string(currentState),
 		SpecContent:         specContent,
 		BootstrapParamsJSON: bootstrapParamsJSON,
+		CurrentAskJSON:      currentAskJSON,
+		OpenIncidentsJSON:   openIncidentsJSON,
 	}
 
 	// Build context if available
@@ -184,6 +214,29 @@ func (d *Driver) Checkpoint(sessionID string) {
 	default:
 		d.logger.Warn("Persistence channel full, checkpoint skipped")
 	}
+}
+
+// collectAsksAndIncidentsJSON serializes the current ask and open incidents as JSON strings.
+func (d *Driver) collectAsksAndIncidentsJSON() (currentAskJSON, openIncidentsJSON *string) {
+	if d.currentAsk != nil {
+		data, err := json.Marshal(d.currentAsk)
+		if err != nil {
+			d.logger.Warn("Failed to marshal current ask: %v", err)
+		} else {
+			s := string(data)
+			currentAskJSON = &s
+		}
+	}
+	if len(d.openIncidents) > 0 {
+		data, err := json.Marshal(d.openIncidents)
+		if err != nil {
+			d.logger.Warn("Failed to marshal open incidents: %v", err)
+		} else {
+			s := string(data)
+			openIncidentsJSON = &s
+		}
+	}
+	return
 }
 
 // collectBootstrapParamsJSON collects bootstrap-related state data and returns it as JSON.

--- a/pkg/pm/working.go
+++ b/pkg/pm/working.go
@@ -59,6 +59,9 @@ func (d *Driver) handleWorking(ctx context.Context) (proto.State, error) {
 		// No notifications, continue working
 	}
 
+	// Inject pending items summary if the digest has changed
+	d.maybeInjectPendingItemsSummary()
+
 	// Get conversation state
 	turnCount := utils.GetStateValueOr[int](d.BaseStateMachine, StateKeyTurnCount, 0)
 	expertise := utils.GetStateValueOr[string](d.BaseStateMachine, StateKeyUserExpertise, DefaultExpertise)
@@ -441,6 +444,18 @@ func (d *Driver) callLLMWithTools(ctx context.Context, prompt string) (string, e
 			case tools.SignalAwaitUser:
 				// chat_ask_user was called - transition to AWAIT_USER state
 				d.logger.Info("⏸️  PM waiting for user response via chat_ask_user")
+				// Create durable UserAsk from the tool's message
+				if effectData, ok := utils.SafeAssert[map[string]any](out.EffectData); ok {
+					if askMsg := utils.GetMapFieldOr[string](effectData, "message", ""); askMsg != "" {
+						d.currentAsk = &proto.UserAsk{
+							ID:       fmt.Sprintf("ask-decision-%s", time.Now().UTC().Format("20060102T150405Z")),
+							Prompt:   askMsg,
+							Kind:     "decision_required",
+							OpenedAt: time.Now().UTC().Format(time.RFC3339),
+						}
+						d.syncAskToStateData()
+					}
+				}
 				return tools.SignalAwaitUser, nil
 
 			case tools.SignalReleaseHeld:

--- a/pkg/pm/working.go
+++ b/pkg/pm/working.go
@@ -483,6 +483,7 @@ func (d *Driver) callLLMWithTools(ctx context.Context, prompt string) (string, e
 				incidentID := utils.GetMapFieldOr[string](effectData, "incident_id", "")
 				action := utils.GetMapFieldOr[string](effectData, "action", "")
 				reason := utils.GetMapFieldOr[string](effectData, "reason", "")
+				content := utils.GetMapFieldOr[string](effectData, "content", "")
 
 				// Validate action is allowed for this incident
 				if inc, exists := d.openIncidents[incidentID]; exists {
@@ -505,6 +506,7 @@ func (d *Driver) callLLMWithTools(ctx context.Context, prompt string) (string, e
 					IncidentID: incidentID,
 					Action:     action,
 					Reason:     reason,
+					Content:    content,
 				}))
 				if dispErr := d.dispatcher.DispatchMessage(actionMsg); dispErr != nil {
 					d.logger.Error("❌ Failed to send incident_action to architect: %v", dispErr)

--- a/pkg/pm/working.go
+++ b/pkg/pm/working.go
@@ -485,19 +485,22 @@ func (d *Driver) callLLMWithTools(ctx context.Context, prompt string) (string, e
 				reason := utils.GetMapFieldOr[string](effectData, "reason", "")
 				content := utils.GetMapFieldOr[string](effectData, "content", "")
 
-				// Validate action is allowed for this incident
-				if inc, exists := d.openIncidents[incidentID]; exists {
-					allowed := false
-					for _, a := range inc.AllowedActions {
-						if string(a) == action {
-							allowed = true
-							break
-						}
+				// Validate incident exists and action is allowed
+				inc, exists := d.openIncidents[incidentID]
+				if !exists {
+					d.logger.Warn("Incident %s not found in open incidents for action %q", incidentID, action)
+					return "", fmt.Errorf("incident %s is not open or does not exist", incidentID)
+				}
+				allowed := false
+				for _, a := range inc.AllowedActions {
+					if string(a) == action {
+						allowed = true
+						break
 					}
-					if !allowed {
-						d.logger.Warn("Action %q not in AllowedActions for incident %s", action, incidentID)
-						return "", fmt.Errorf("action %q not allowed for incident %s", action, incidentID)
-					}
+				}
+				if !allowed {
+					d.logger.Warn("Action %q not in AllowedActions for incident %s", action, incidentID)
+					return "", fmt.Errorf("action %q not allowed for incident %s", action, incidentID)
 				}
 
 				d.logger.Info("🔧 Incident action '%s' for %s: %s", action, incidentID, reason)

--- a/pkg/pm/working.go
+++ b/pkg/pm/working.go
@@ -478,6 +478,41 @@ func (d *Driver) callLLMWithTools(ctx context.Context, prompt string) (string, e
 				}
 				return "", nil
 
+			case tools.SignalIncidentAction:
+				effectData, _ := utils.SafeAssert[map[string]any](out.EffectData)
+				incidentID := utils.GetMapFieldOr[string](effectData, "incident_id", "")
+				action := utils.GetMapFieldOr[string](effectData, "action", "")
+				reason := utils.GetMapFieldOr[string](effectData, "reason", "")
+
+				// Validate action is allowed for this incident
+				if inc, exists := d.openIncidents[incidentID]; exists {
+					allowed := false
+					for _, a := range inc.AllowedActions {
+						if string(a) == action {
+							allowed = true
+							break
+						}
+					}
+					if !allowed {
+						d.logger.Warn("Action %q not in AllowedActions for incident %s", action, incidentID)
+						return "", fmt.Errorf("action %q not allowed for incident %s", action, incidentID)
+					}
+				}
+
+				d.logger.Info("🔧 Incident action '%s' for %s: %s", action, incidentID, reason)
+				actionMsg := proto.NewAgentMsg(proto.MsgTypeREQUEST, d.GetAgentID(), "architect")
+				actionMsg.SetTypedPayload(proto.NewIncidentActionPayload(&proto.IncidentActionPayload{
+					IncidentID: incidentID,
+					Action:     action,
+					Reason:     reason,
+				}))
+				if dispErr := d.dispatcher.DispatchMessage(actionMsg); dispErr != nil {
+					d.logger.Error("❌ Failed to send incident_action to architect: %v", dispErr)
+				} else {
+					d.logger.Info("✅ Sent incident_action to architect (%s on %s)", action, incidentID)
+				}
+				return "", nil
+
 			default:
 				return "", fmt.Errorf("unknown ProcessEffect signal: %s", out.Signal)
 			}

--- a/pkg/proto/incident.go
+++ b/pkg/proto/incident.go
@@ -1,0 +1,56 @@
+package proto
+
+// IncidentKind identifies the type of operational incident.
+type IncidentKind string
+
+// Incident kind constants.
+const (
+	IncidentKindStoryBlocked  IncidentKind = "story_blocked"
+	IncidentKindClarification IncidentKind = "clarification_needed"
+	IncidentKindSystemIdle    IncidentKind = "system_idle"
+)
+
+// IncidentAction represents a recovery action a user can take on an incident.
+// In Phase 1 these are advisory metadata only (no incident_action tool yet).
+type IncidentAction string
+
+// Incident action constants.
+const (
+	IncidentActionTryAgain      IncidentAction = "try_again"
+	IncidentActionChangeRequest IncidentAction = "change_request"
+	IncidentActionSkip          IncidentAction = "skip"
+	IncidentActionResume        IncidentAction = "resume"
+)
+
+// Incident represents an architect-owned operational blocker.
+// Incidents are opened by the architect and closed by architect-side recovery.
+// User replies do NOT automatically resolve incidents — only asks.
+type Incident struct {
+	ID               string           `json:"id"`
+	Kind             IncidentKind     `json:"kind"`
+	Scope            string           `json:"scope"` // "story" | "system"
+	StoryID          string           `json:"story_id,omitempty"`
+	SpecID           string           `json:"spec_id,omitempty"`
+	FailureID        string           `json:"failure_id,omitempty"`
+	Title            string           `json:"title"`
+	Summary          string           `json:"summary"`
+	Details          string           `json:"details,omitempty"`
+	AffectedStoryIDs []string         `json:"affected_story_ids,omitempty"`
+	AllowedActions   []IncidentAction `json:"allowed_actions"`
+	Blocking         bool             `json:"blocking"`
+	OpenedAt         string           `json:"opened_at"`
+	ResolvedAt       string           `json:"resolved_at,omitempty"`
+	Resolution       string           `json:"resolution,omitempty"`
+}
+
+// UserAsk represents a PM-owned conversational obligation.
+// Asks are created when PM uses chat_ask_user and resolved when the user replies.
+// At most one ask is active at a time.
+type UserAsk struct {
+	ID                string `json:"id"`
+	Prompt            string `json:"prompt"`
+	Kind              string `json:"kind"` // "interview_question" | "clarification" | "decision_required"
+	RelatedIncidentID string `json:"related_incident_id,omitempty"`
+	OpenedAt          string `json:"opened_at"`
+	ResolvedAt        string `json:"resolved_at,omitempty"`
+}

--- a/pkg/proto/incident_test.go
+++ b/pkg/proto/incident_test.go
@@ -173,3 +173,112 @@ func TestIncidentActionConstants(t *testing.T) {
 		t.Errorf("IncidentActionResume = %q", IncidentActionResume)
 	}
 }
+
+func TestIncidentActionPayload_RoundTrip(t *testing.T) {
+	original := &IncidentActionPayload{
+		IncidentID: "inc-042",
+		Action:     "resume",
+		Reason:     "Docker daemon restarted, environment should be healthy now",
+	}
+
+	payload := NewIncidentActionPayload(original)
+	if payload.Kind != PayloadKindIncidentAction {
+		t.Errorf("expected kind %q, got %q", PayloadKindIncidentAction, payload.Kind)
+	}
+
+	extracted, err := payload.ExtractIncidentAction()
+	if err != nil {
+		t.Fatalf("ExtractIncidentAction failed: %v", err)
+	}
+
+	if extracted.IncidentID != original.IncidentID {
+		t.Errorf("IncidentID: got %q, want %q", extracted.IncidentID, original.IncidentID)
+	}
+	if extracted.Action != original.Action {
+		t.Errorf("Action: got %q, want %q", extracted.Action, original.Action)
+	}
+	if extracted.Reason != original.Reason {
+		t.Errorf("Reason: got %q, want %q", extracted.Reason, original.Reason)
+	}
+}
+
+func TestIncidentActionResultPayload_RoundTrip(t *testing.T) {
+	original := &IncidentActionResultPayload{
+		IncidentID: "inc-042",
+		Action:     "resume",
+		Success:    true,
+		Message:    "Incident resolved, 2 stories released from hold",
+	}
+
+	payload := NewIncidentActionResultPayload(original)
+	if payload.Kind != PayloadKindIncidentActionResult {
+		t.Errorf("expected kind %q, got %q", PayloadKindIncidentActionResult, payload.Kind)
+	}
+
+	extracted, err := payload.ExtractIncidentActionResult()
+	if err != nil {
+		t.Fatalf("ExtractIncidentActionResult failed: %v", err)
+	}
+
+	if extracted.IncidentID != original.IncidentID {
+		t.Errorf("IncidentID: got %q, want %q", extracted.IncidentID, original.IncidentID)
+	}
+	if extracted.Action != original.Action {
+		t.Errorf("Action: got %q, want %q", extracted.Action, original.Action)
+	}
+	if extracted.Success != original.Success {
+		t.Errorf("Success: got %v, want %v", extracted.Success, original.Success)
+	}
+	if extracted.Message != original.Message {
+		t.Errorf("Message: got %q, want %q", extracted.Message, original.Message)
+	}
+}
+
+func TestIncidentActionResultPayload_Failure(t *testing.T) {
+	original := &IncidentActionResultPayload{
+		IncidentID: "inc-099",
+		Action:     "resume",
+		Success:    false,
+		Message:    "Incident inc-099 not found or already resolved",
+	}
+
+	payload := NewIncidentActionResultPayload(original)
+	extracted, err := payload.ExtractIncidentActionResult()
+	if err != nil {
+		t.Fatalf("ExtractIncidentActionResult failed: %v", err)
+	}
+
+	if extracted.Success {
+		t.Error("expected Success=false for failed action result")
+	}
+	if extracted.Message != original.Message {
+		t.Errorf("Message: got %q, want %q", extracted.Message, original.Message)
+	}
+}
+
+func TestIncidentActionPayload_WrongKind(t *testing.T) {
+	// Create an incident_opened payload, then try to extract as incident_action
+	payload := NewIncidentOpenedPayload(&Incident{
+		ID:    "inc-001",
+		Title: "test incident",
+	})
+
+	_, err := payload.ExtractIncidentAction()
+	if err == nil {
+		t.Error("expected error when extracting incident_action from incident_opened payload")
+	}
+}
+
+func TestIncidentActionResultPayload_WrongKind(t *testing.T) {
+	// Create an incident_action payload, then try to extract as incident_action_result
+	payload := NewIncidentActionPayload(&IncidentActionPayload{
+		IncidentID: "inc-001",
+		Action:     "resume",
+		Reason:     "test",
+	})
+
+	_, err := payload.ExtractIncidentActionResult()
+	if err == nil {
+		t.Error("expected error when extracting incident_action_result from incident_action payload")
+	}
+}

--- a/pkg/proto/incident_test.go
+++ b/pkg/proto/incident_test.go
@@ -282,3 +282,43 @@ func TestIncidentActionResultPayload_WrongKind(t *testing.T) {
 		t.Error("expected error when extracting incident_action_result from incident_action payload")
 	}
 }
+
+func TestIncidentActionPayload_WithContent_RoundTrip(t *testing.T) {
+	original := &IncidentActionPayload{
+		IncidentID: "inc-100",
+		Action:     "change_request",
+		Reason:     "User wants different approach",
+		Content:    "Please use PostgreSQL instead of SQLite for the database layer.",
+	}
+
+	payload := NewIncidentActionPayload(original)
+	extracted, err := payload.ExtractIncidentAction()
+	if err != nil {
+		t.Fatalf("ExtractIncidentAction failed: %v", err)
+	}
+
+	if extracted.Content != original.Content {
+		t.Errorf("Content: got %q, want %q", extracted.Content, original.Content)
+	}
+	if extracted.Action != original.Action {
+		t.Errorf("Action: got %q, want %q", extracted.Action, original.Action)
+	}
+}
+
+func TestIncidentActionPayload_ContentOmittedWhenEmpty(t *testing.T) {
+	original := &IncidentActionPayload{
+		IncidentID: "inc-101",
+		Action:     "resume",
+		Reason:     "Fixed the issue",
+	}
+
+	payload := NewIncidentActionPayload(original)
+	extracted, err := payload.ExtractIncidentAction()
+	if err != nil {
+		t.Fatalf("ExtractIncidentAction failed: %v", err)
+	}
+
+	if extracted.Content != "" {
+		t.Errorf("Content should be empty for resume, got %q", extracted.Content)
+	}
+}

--- a/pkg/proto/incident_test.go
+++ b/pkg/proto/incident_test.go
@@ -1,0 +1,175 @@
+package proto
+
+import (
+	"testing"
+)
+
+func TestIncidentOpenedPayload_RoundTrip(t *testing.T) {
+	original := &Incident{
+		ID:               "inc-001",
+		Kind:             IncidentKindStoryBlocked,
+		Scope:            "story",
+		StoryID:          "story-42",
+		SpecID:           "spec-7",
+		FailureID:        "fail-abc",
+		Title:            "Build environment corrupted",
+		Summary:          "Docker image missing required build tools after update",
+		Details:          "gcc not found in PATH; apt cache stale",
+		AffectedStoryIDs: []string{"story-42", "story-43"},
+		AllowedActions:   []IncidentAction{IncidentActionTryAgain, IncidentActionChangeRequest},
+		Blocking:         true,
+		OpenedAt:         "2026-04-19T10:00:00Z",
+	}
+
+	payload := NewIncidentOpenedPayload(original)
+	if payload.Kind != PayloadKindIncidentOpened {
+		t.Errorf("expected kind %q, got %q", PayloadKindIncidentOpened, payload.Kind)
+	}
+
+	extracted, err := payload.ExtractIncidentOpened()
+	if err != nil {
+		t.Fatalf("ExtractIncidentOpened failed: %v", err)
+	}
+
+	if extracted.ID != original.ID {
+		t.Errorf("ID: got %q, want %q", extracted.ID, original.ID)
+	}
+	if extracted.Kind != original.Kind {
+		t.Errorf("Kind: got %q, want %q", extracted.Kind, original.Kind)
+	}
+	if extracted.Scope != original.Scope {
+		t.Errorf("Scope: got %q, want %q", extracted.Scope, original.Scope)
+	}
+	if extracted.StoryID != original.StoryID {
+		t.Errorf("StoryID: got %q, want %q", extracted.StoryID, original.StoryID)
+	}
+	if extracted.SpecID != original.SpecID {
+		t.Errorf("SpecID: got %q, want %q", extracted.SpecID, original.SpecID)
+	}
+	if extracted.FailureID != original.FailureID {
+		t.Errorf("FailureID: got %q, want %q", extracted.FailureID, original.FailureID)
+	}
+	if extracted.Title != original.Title {
+		t.Errorf("Title: got %q, want %q", extracted.Title, original.Title)
+	}
+	if extracted.Summary != original.Summary {
+		t.Errorf("Summary: got %q, want %q", extracted.Summary, original.Summary)
+	}
+	if extracted.Details != original.Details {
+		t.Errorf("Details: got %q, want %q", extracted.Details, original.Details)
+	}
+	if len(extracted.AffectedStoryIDs) != len(original.AffectedStoryIDs) {
+		t.Fatalf("AffectedStoryIDs length: got %d, want %d", len(extracted.AffectedStoryIDs), len(original.AffectedStoryIDs))
+	}
+	for i, id := range extracted.AffectedStoryIDs {
+		if id != original.AffectedStoryIDs[i] {
+			t.Errorf("AffectedStoryIDs[%d]: got %q, want %q", i, id, original.AffectedStoryIDs[i])
+		}
+	}
+	if len(extracted.AllowedActions) != len(original.AllowedActions) {
+		t.Fatalf("AllowedActions length: got %d, want %d", len(extracted.AllowedActions), len(original.AllowedActions))
+	}
+	for i, action := range extracted.AllowedActions {
+		if action != original.AllowedActions[i] {
+			t.Errorf("AllowedActions[%d]: got %q, want %q", i, action, original.AllowedActions[i])
+		}
+	}
+	if extracted.Blocking != original.Blocking {
+		t.Errorf("Blocking: got %v, want %v", extracted.Blocking, original.Blocking)
+	}
+	if extracted.OpenedAt != original.OpenedAt {
+		t.Errorf("OpenedAt: got %q, want %q", extracted.OpenedAt, original.OpenedAt)
+	}
+	if extracted.ResolvedAt != original.ResolvedAt {
+		t.Errorf("ResolvedAt: got %q, want %q", extracted.ResolvedAt, original.ResolvedAt)
+	}
+	if extracted.Resolution != original.Resolution {
+		t.Errorf("Resolution: got %q, want %q", extracted.Resolution, original.Resolution)
+	}
+}
+
+func TestIncidentResolvedPayload_RoundTrip(t *testing.T) {
+	original := &IncidentResolvedPayload{
+		IncidentID: "inc-001",
+		Resolution: "work_resumed",
+		Message:    "Docker image rebuilt successfully; stories unblocked",
+		Timestamp:  "2026-04-19T10:15:00Z",
+	}
+
+	payload := NewIncidentResolvedPayload(original)
+	if payload.Kind != PayloadKindIncidentResolved {
+		t.Errorf("expected kind %q, got %q", PayloadKindIncidentResolved, payload.Kind)
+	}
+
+	extracted, err := payload.ExtractIncidentResolved()
+	if err != nil {
+		t.Fatalf("ExtractIncidentResolved failed: %v", err)
+	}
+
+	if extracted.IncidentID != original.IncidentID {
+		t.Errorf("IncidentID: got %q, want %q", extracted.IncidentID, original.IncidentID)
+	}
+	if extracted.Resolution != original.Resolution {
+		t.Errorf("Resolution: got %q, want %q", extracted.Resolution, original.Resolution)
+	}
+	if extracted.Message != original.Message {
+		t.Errorf("Message: got %q, want %q", extracted.Message, original.Message)
+	}
+	if extracted.Timestamp != original.Timestamp {
+		t.Errorf("Timestamp: got %q, want %q", extracted.Timestamp, original.Timestamp)
+	}
+}
+
+func TestIncidentOpenedPayload_WrongKind(t *testing.T) {
+	// Create a story_complete payload, then try to extract as incident_opened
+	payload := NewStoryCompletePayload(&StoryCompletePayload{
+		StoryID:   "story-1",
+		Title:     "test",
+		Timestamp: "2026-04-19T10:00:00Z",
+	})
+
+	_, err := payload.ExtractIncidentOpened()
+	if err == nil {
+		t.Error("expected error when extracting incident_opened from story_complete payload")
+	}
+}
+
+func TestIncidentResolvedPayload_WrongKind(t *testing.T) {
+	// Create an incident_opened payload, then try to extract as incident_resolved
+	payload := NewIncidentOpenedPayload(&Incident{
+		ID:    "inc-001",
+		Title: "test incident",
+	})
+
+	_, err := payload.ExtractIncidentResolved()
+	if err == nil {
+		t.Error("expected error when extracting incident_resolved from incident_opened payload")
+	}
+}
+
+func TestIncidentKindConstants(t *testing.T) {
+	if string(IncidentKindStoryBlocked) != "story_blocked" {
+		t.Errorf("IncidentKindStoryBlocked = %q", IncidentKindStoryBlocked)
+	}
+	if string(IncidentKindClarification) != "clarification_needed" {
+		t.Errorf("IncidentKindClarification = %q", IncidentKindClarification)
+	}
+	if string(IncidentKindSystemIdle) != "system_idle" {
+		t.Errorf("IncidentKindSystemIdle = %q", IncidentKindSystemIdle)
+	}
+}
+
+func TestIncidentActionConstants(t *testing.T) {
+	if string(IncidentActionTryAgain) != "try_again" {
+		t.Errorf("IncidentActionTryAgain = %q", IncidentActionTryAgain)
+	}
+	if string(IncidentActionChangeRequest) != "change_request" {
+		t.Errorf("IncidentActionChangeRequest = %q", IncidentActionChangeRequest)
+	}
+	if string(IncidentActionSkip) != "skip" {
+		t.Errorf("IncidentActionSkip = %q", IncidentActionSkip)
+	}
+	if string(IncidentActionResume) != "resume" {
+		t.Errorf("IncidentActionResume = %q", IncidentActionResume)
+	}
+}

--- a/pkg/proto/message_test.go
+++ b/pkg/proto/message_test.go
@@ -627,6 +627,40 @@ func TestAllStoriesTerminalPayload_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestAllStoriesTerminalPayload_WithSkipped_RoundTrip(t *testing.T) {
+	original := &AllStoriesTerminalPayload{
+		SpecID:       "spec-99",
+		TotalStories: 4,
+		FailedStories: []FailedStoryDetail{
+			{StoryID: "s2", Title: "Fix auth", Reason: "git corruption"},
+		},
+		SkippedStories: []SkippedStoryDetail{
+			{StoryID: "s3", Title: "Add caching"},
+			{StoryID: "s4", Title: "Add monitoring"},
+		},
+		Timestamp: "2026-04-19T12:00:00Z",
+	}
+
+	payload := NewAllStoriesTerminalPayload(original)
+	extracted, err := payload.ExtractAllStoriesTerminal()
+	if err != nil {
+		t.Fatalf("ExtractAllStoriesTerminal failed: %v", err)
+	}
+
+	if len(extracted.SkippedStories) != 2 {
+		t.Fatalf("SkippedStories: expected 2, got %d", len(extracted.SkippedStories))
+	}
+	if extracted.SkippedStories[0].StoryID != "s3" {
+		t.Errorf("SkippedStories[0].StoryID: expected s3, got %s", extracted.SkippedStories[0].StoryID)
+	}
+	if extracted.SkippedStories[1].Title != "Add monitoring" {
+		t.Errorf("SkippedStories[1].Title: expected 'Add monitoring', got %s", extracted.SkippedStories[1].Title)
+	}
+	if len(extracted.FailedStories) != 1 {
+		t.Errorf("FailedStories: expected 1, got %d", len(extracted.FailedStories))
+	}
+}
+
 func TestAllStoriesTerminalPayload_WrongKind(t *testing.T) {
 	payload := NewAllStoriesCompletePayload(&AllStoriesCompletePayload{})
 	_, err := payload.ExtractAllStoriesTerminal()

--- a/pkg/proto/payload.go
+++ b/pkg/proto/payload.go
@@ -41,14 +41,16 @@ const (
 	PayloadKindShutdown PayloadKind = "shutdown"
 
 	// Notification payloads.
-	PayloadKindStoryComplete        PayloadKind = "story_complete"        // Story completion notification
-	PayloadKindAllStoriesComplete   PayloadKind = "all_stories_complete"  // All stories completed notification
-	PayloadKindStoryBlocked         PayloadKind = "story_blocked"         // Story blocked/failed notification
-	PayloadKindClarificationRequest PayloadKind = "clarification_request" // Request PM to relay clarification to human
-	PayloadKindAllStoriesTerminal   PayloadKind = "all_stories_terminal"  // All stories terminal (some failed) notification
-	PayloadKindRepairComplete       PayloadKind = "repair_complete"       // Signal that system repair is done
-	PayloadKindIncidentOpened       PayloadKind = "incident_opened"       // Architect opened a durable incident
-	PayloadKindIncidentResolved     PayloadKind = "incident_resolved"     // Architect resolved a durable incident
+	PayloadKindStoryComplete        PayloadKind = "story_complete"         // Story completion notification
+	PayloadKindAllStoriesComplete   PayloadKind = "all_stories_complete"   // All stories completed notification
+	PayloadKindStoryBlocked         PayloadKind = "story_blocked"          // Story blocked/failed notification
+	PayloadKindClarificationRequest PayloadKind = "clarification_request"  // Request PM to relay clarification to human
+	PayloadKindAllStoriesTerminal   PayloadKind = "all_stories_terminal"   // All stories terminal (some failed) notification
+	PayloadKindRepairComplete       PayloadKind = "repair_complete"        // Signal that system repair is done
+	PayloadKindIncidentOpened       PayloadKind = "incident_opened"        // Architect opened a durable incident
+	PayloadKindIncidentResolved     PayloadKind = "incident_resolved"      // Architect resolved a durable incident
+	PayloadKindIncidentAction       PayloadKind = "incident_action"        // PM requests action on an incident
+	PayloadKindIncidentActionResult PayloadKind = "incident_action_result" // Architect returns action outcome to PM
 
 	// Generic key-value payloads for miscellaneous data.
 	PayloadKindGeneric PayloadKind = "generic"
@@ -539,6 +541,64 @@ func (p *MessagePayload) ExtractIncidentResolved() (*IncidentResolvedPayload, er
 	var result IncidentResolvedPayload
 	if err := json.Unmarshal(p.Data, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal incident resolved payload: %w", err)
+	}
+	return &result, nil
+}
+
+// IncidentActionPayload requests an action on an open incident.
+// Phase 1.5 supports only the "resume" action.
+type IncidentActionPayload struct {
+	IncidentID string `json:"incident_id"`
+	Action     string `json:"action"` // "resume"
+	Reason     string `json:"reason"`
+}
+
+// NewIncidentActionPayload creates a payload for incident action requests.
+func NewIncidentActionPayload(data *IncidentActionPayload) *MessagePayload {
+	raw, _ := json.Marshal(data)
+	return &MessagePayload{
+		Kind: PayloadKindIncidentAction,
+		Data: raw,
+	}
+}
+
+// ExtractIncidentAction extracts an incident action payload.
+func (p *MessagePayload) ExtractIncidentAction() (*IncidentActionPayload, error) {
+	if p.Kind != PayloadKindIncidentAction {
+		return nil, fmt.Errorf("expected incident_action payload, got %s", p.Kind)
+	}
+	var result IncidentActionPayload
+	if err := json.Unmarshal(p.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal incident action payload: %w", err)
+	}
+	return &result, nil
+}
+
+// IncidentActionResultPayload returns the outcome of an incident action to PM.
+type IncidentActionResultPayload struct {
+	IncidentID string `json:"incident_id"`
+	Action     string `json:"action"`
+	Success    bool   `json:"success"`
+	Message    string `json:"message"`
+}
+
+// NewIncidentActionResultPayload creates a payload for incident action results.
+func NewIncidentActionResultPayload(data *IncidentActionResultPayload) *MessagePayload {
+	raw, _ := json.Marshal(data)
+	return &MessagePayload{
+		Kind: PayloadKindIncidentActionResult,
+		Data: raw,
+	}
+}
+
+// ExtractIncidentActionResult extracts an incident action result payload.
+func (p *MessagePayload) ExtractIncidentActionResult() (*IncidentActionResultPayload, error) {
+	if p.Kind != PayloadKindIncidentActionResult {
+		return nil, fmt.Errorf("expected incident_action_result payload, got %s", p.Kind)
+	}
+	var result IncidentActionResultPayload
+	if err := json.Unmarshal(p.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal incident action result payload: %w", err)
 	}
 	return &result, nil
 }

--- a/pkg/proto/payload.go
+++ b/pkg/proto/payload.go
@@ -505,7 +505,7 @@ func (p *MessagePayload) ExtractRepairComplete() (*RepairCompletePayload, error)
 // IncidentResolvedPayload contains data for an incident resolution notification.
 type IncidentResolvedPayload struct {
 	IncidentID string `json:"incident_id"`
-	Resolution string `json:"resolution"` // "work_resumed" | "story_requeued" | "all_terminal" | "manual"
+	Resolution string `json:"resolution"` // "work_resumed" | "story_requeued" | "all_terminal" | "manual" | "resumed" | "skipped" | "change_request"
 	Message    string `json:"message"`
 	Timestamp  string `json:"timestamp"`
 }

--- a/pkg/proto/payload.go
+++ b/pkg/proto/payload.go
@@ -47,6 +47,8 @@ const (
 	PayloadKindClarificationRequest PayloadKind = "clarification_request" // Request PM to relay clarification to human
 	PayloadKindAllStoriesTerminal   PayloadKind = "all_stories_terminal"  // All stories terminal (some failed) notification
 	PayloadKindRepairComplete       PayloadKind = "repair_complete"       // Signal that system repair is done
+	PayloadKindIncidentOpened       PayloadKind = "incident_opened"       // Architect opened a durable incident
+	PayloadKindIncidentResolved     PayloadKind = "incident_resolved"     // Architect resolved a durable incident
 
 	// Generic key-value payloads for miscellaneous data.
 	PayloadKindGeneric PayloadKind = "generic"
@@ -487,6 +489,56 @@ func (p *MessagePayload) ExtractRepairComplete() (*RepairCompletePayload, error)
 	var result RepairCompletePayload
 	if err := json.Unmarshal(p.Data, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal repair complete payload: %w", err)
+	}
+	return &result, nil
+}
+
+// IncidentResolvedPayload contains data for an incident resolution notification.
+type IncidentResolvedPayload struct {
+	IncidentID string `json:"incident_id"`
+	Resolution string `json:"resolution"` // "work_resumed" | "story_requeued" | "all_terminal" | "manual"
+	Message    string `json:"message"`
+	Timestamp  string `json:"timestamp"`
+}
+
+// NewIncidentOpenedPayload creates a payload wrapping an Incident struct.
+func NewIncidentOpenedPayload(incident *Incident) *MessagePayload {
+	raw, _ := json.Marshal(incident)
+	return &MessagePayload{
+		Kind: PayloadKindIncidentOpened,
+		Data: raw,
+	}
+}
+
+// ExtractIncidentOpened extracts an incident from an incident_opened payload.
+func (p *MessagePayload) ExtractIncidentOpened() (*Incident, error) {
+	if p.Kind != PayloadKindIncidentOpened {
+		return nil, fmt.Errorf("expected incident_opened payload, got %s", p.Kind)
+	}
+	var result Incident
+	if err := json.Unmarshal(p.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal incident opened payload: %w", err)
+	}
+	return &result, nil
+}
+
+// NewIncidentResolvedPayload creates a payload for incident resolution notifications.
+func NewIncidentResolvedPayload(data *IncidentResolvedPayload) *MessagePayload {
+	raw, _ := json.Marshal(data)
+	return &MessagePayload{
+		Kind: PayloadKindIncidentResolved,
+		Data: raw,
+	}
+}
+
+// ExtractIncidentResolved extracts an incident resolution payload.
+func (p *MessagePayload) ExtractIncidentResolved() (*IncidentResolvedPayload, error) {
+	if p.Kind != PayloadKindIncidentResolved {
+		return nil, fmt.Errorf("expected incident_resolved payload, got %s", p.Kind)
+	}
+	var result IncidentResolvedPayload
+	if err := json.Unmarshal(p.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal incident resolved payload: %w", err)
 	}
 	return &result, nil
 }

--- a/pkg/proto/payload.go
+++ b/pkg/proto/payload.go
@@ -364,12 +364,19 @@ type FailedStoryDetail struct {
 	Reason  string `json:"reason"`
 }
 
-// AllStoriesTerminalPayload is sent when all stories are done or failed (not all successful).
+// SkippedStoryDetail summarizes one skipped story for the terminal notification.
+type SkippedStoryDetail struct {
+	StoryID string `json:"story_id"`
+	Title   string `json:"title"`
+}
+
+// AllStoriesTerminalPayload is sent when all stories are done, failed, or skipped (not all successful).
 type AllStoriesTerminalPayload struct {
-	SpecID        string              `json:"spec_id"`
-	TotalStories  int                 `json:"total_stories"`
-	FailedStories []FailedStoryDetail `json:"failed_stories"`
-	Timestamp     string              `json:"timestamp"`
+	SpecID         string               `json:"spec_id"`
+	TotalStories   int                  `json:"total_stories"`
+	FailedStories  []FailedStoryDetail  `json:"failed_stories"`
+	SkippedStories []SkippedStoryDetail `json:"skipped_stories,omitempty"`
+	Timestamp      string               `json:"timestamp"`
 }
 
 // NewAllStoriesTerminalPayload creates a payload for the all-stories-terminal notification.
@@ -546,11 +553,11 @@ func (p *MessagePayload) ExtractIncidentResolved() (*IncidentResolvedPayload, er
 }
 
 // IncidentActionPayload requests an action on an open incident.
-// Phase 1.5 supports only the "resume" action.
 type IncidentActionPayload struct {
 	IncidentID string `json:"incident_id"`
-	Action     string `json:"action"` // "resume"
-	Reason     string `json:"reason"`
+	Action     string `json:"action"`            // "resume", "try_again", "skip", "change_request"
+	Reason     string `json:"reason"`            // Why the action is being taken
+	Content    string `json:"content,omitempty"` // For change_request: user-supplied changes to apply
 }
 
 // NewIncidentActionPayload creates a payload for incident action requests.

--- a/pkg/proto/unified_protocol.go
+++ b/pkg/proto/unified_protocol.go
@@ -219,6 +219,8 @@ func GetRequestKind(msg *AgentMsg) (RequestKind, bool) {
 		return RequestKindHotfix, true
 	case PayloadKindRepairComplete:
 		return RequestKindRepairComplete, true
+	case PayloadKindIncidentAction:
+		return RequestKindExecution, true
 	default:
 		return "", false
 	}

--- a/pkg/proto/unified_protocol_test.go
+++ b/pkg/proto/unified_protocol_test.go
@@ -1,0 +1,172 @@
+package proto
+
+import (
+	"testing"
+)
+
+func TestGetRequestKind_IncidentAction(t *testing.T) {
+	msg := NewAgentMsg(MsgTypeREQUEST, "pm-001", "architect")
+	msg.SetTypedPayload(NewIncidentActionPayload(&IncidentActionPayload{
+		IncidentID: "inc-042",
+		Action:     "resume",
+		Reason:     "Environment repaired",
+	}))
+
+	kind, ok := GetRequestKind(msg)
+	if !ok {
+		t.Fatal("GetRequestKind returned false for incident_action REQUEST")
+	}
+	if kind != RequestKindExecution {
+		t.Errorf("expected RequestKindExecution, got %q", kind)
+	}
+}
+
+func TestGetRequestKind_NonRequest(t *testing.T) {
+	msg := NewAgentMsg(MsgTypeRESPONSE, "architect", "pm-001")
+	msg.SetTypedPayload(NewIncidentActionResultPayload(&IncidentActionResultPayload{
+		IncidentID: "inc-042",
+		Action:     "resume",
+		Success:    true,
+		Message:    "done",
+	}))
+
+	_, ok := GetRequestKind(msg)
+	if ok {
+		t.Error("GetRequestKind should return false for RESPONSE message type")
+	}
+}
+
+func TestGetRequestKind_NilPayload(t *testing.T) {
+	msg := NewAgentMsg(MsgTypeREQUEST, "pm-001", "architect")
+	// No payload set
+
+	_, ok := GetRequestKind(msg)
+	if ok {
+		t.Error("GetRequestKind should return false when payload is nil")
+	}
+}
+
+func TestGetRequestKind_KnownKinds(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      *MessagePayload
+		expectedKind RequestKind
+	}{
+		{
+			name: "question_request",
+			payload: NewQuestionRequestPayload(&QuestionRequestPayload{
+				Text: "How should I approach this?",
+			}),
+			expectedKind: RequestKindQuestion,
+		},
+		{
+			name: "approval_request",
+			payload: NewApprovalRequestPayload(&ApprovalRequestPayload{
+				ApprovalType: ApprovalTypePlan,
+				Content:      "implementation plan",
+			}),
+			expectedKind: RequestKindApproval,
+		},
+		{
+			name: "merge_request",
+			payload: NewMergeRequestPayload(&MergeRequestPayload{
+				StoryID:    "story-1",
+				BranchName: "feature/test",
+			}),
+			expectedKind: RequestKindMerge,
+		},
+		{
+			name: "requeue_request",
+			payload: NewRequeueRequestPayload(&RequeueRequestPayload{
+				StoryID: "story-1",
+				AgentID: "coder-001",
+				Reason:  "error",
+			}),
+			expectedKind: RequestKindRequeue,
+		},
+		{
+			name: "hotfix_request",
+			payload: NewHotfixRequestPayload(&HotfixRequestPayload{
+				Analysis: "urgent fix",
+				Platform: "go",
+			}),
+			expectedKind: RequestKindHotfix,
+		},
+		{
+			name: "incident_action",
+			payload: NewIncidentActionPayload(&IncidentActionPayload{
+				IncidentID: "inc-001",
+				Action:     "resume",
+				Reason:     "fixed",
+			}),
+			expectedKind: RequestKindExecution,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := NewAgentMsg(MsgTypeREQUEST, "sender", "receiver")
+			msg.SetTypedPayload(tt.payload)
+
+			kind, ok := GetRequestKind(msg)
+			if !ok {
+				t.Fatalf("GetRequestKind returned false for %s", tt.name)
+			}
+			if kind != tt.expectedKind {
+				t.Errorf("expected %q, got %q", tt.expectedKind, kind)
+			}
+		})
+	}
+}
+
+func TestGetResponseKind_KnownKinds(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      *MessagePayload
+		expectedKind ResponseKind
+	}{
+		{
+			name: "question_response",
+			payload: NewQuestionResponsePayload(&QuestionResponsePayload{
+				AnswerText: "Do X then Y",
+			}),
+			expectedKind: ResponseKindQuestion,
+		},
+		{
+			name: "approval_response",
+			payload: NewApprovalResponsePayload(&ApprovalResult{
+				Status: ApprovalStatusApproved,
+			}),
+			expectedKind: ResponseKindApproval,
+		},
+		{
+			name: "merge_response",
+			payload: NewMergeResponsePayload(&MergeResponsePayload{
+				Status: "merged",
+			}),
+			expectedKind: ResponseKindMerge,
+		},
+		{
+			name: "requeue_response",
+			payload: NewRequeueResponsePayload(&RequeueResponsePayload{
+				Accepted: true,
+			}),
+			expectedKind: ResponseKindRequeue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := NewAgentMsg(MsgTypeRESPONSE, "sender", "receiver")
+			msg.SetTypedPayload(tt.payload)
+
+			kind, ok := GetResponseKind(msg)
+			if !ok {
+				t.Fatalf("GetResponseKind returned false for %s", tt.name)
+			}
+			if kind != tt.expectedKind {
+				t.Errorf("expected %q, got %q", tt.expectedKind, kind)
+			}
+		})
+	}
+}

--- a/pkg/tools/constants.go
+++ b/pkg/tools/constants.go
@@ -65,6 +65,7 @@ const (
 	ToolChatAskUser     = "chat_ask_user"
 	ToolBootstrap       = "bootstrap"
 	ToolMaestroMdSubmit = "maestro_md_submit"
+	ToolIncidentAction  = "incident_action"
 
 	// Research tools.
 	// Note: ToolWebSearch is defined in web_search.go to keep tool name with its implementation.
@@ -202,6 +203,7 @@ var (
 		ToolWebSearch,
 		ToolWebFetch,
 		ToolReleaseHeldStories,
+		ToolIncidentAction,
 	}
 
 	// PMMaestroMdTools - tools for MAESTRO.md generation phase.

--- a/pkg/tools/incident_action_tool.go
+++ b/pkg/tools/incident_action_tool.go
@@ -19,7 +19,6 @@ func getIncidentActionSchema() InputSchema {
 }
 
 // IncidentActionTool allows PM to request an action on an open incident.
-// Phase 1.5 supports only the "resume" action.
 type IncidentActionTool struct {
 	agentCtx *AgentContext
 }
@@ -38,7 +37,7 @@ func (t *IncidentActionTool) Name() string {
 func (t *IncidentActionTool) Definition() ToolDefinition {
 	return ToolDefinition{
 		Name:        ToolIncidentAction,
-		Description: "Request an action on an open incident. Currently only 'resume' is supported, which tells the development system to retry or resume work related to the incident.",
+		Description: "Request an action on an open incident. Actions: resume (retry/resume work), try_again (same as resume), skip (abandon the story), change_request (modify the story and retry).",
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
@@ -48,12 +47,16 @@ func (t *IncidentActionTool) Definition() ToolDefinition {
 				},
 				"action": {
 					Type:        "string",
-					Description: "The action to take. Currently only 'resume' is supported.",
-					Enum:        []string{"resume"},
+					Description: "The action to take: 'resume' to retry/resume, 'try_again' to retry, 'skip' to permanently abandon the story, 'change_request' to modify the story requirements and retry.",
+					Enum:        []string{"resume", "try_again", "skip", "change_request"},
 				},
 				"reason": {
 					Type:        "string",
-					Description: "Brief explanation of why this action is being taken (e.g., 'user requested retry', 'underlying issue resolved')",
+					Description: "Brief explanation of why this action is being taken",
+				},
+				"content": {
+					Type:        "string",
+					Description: "Required when action is 'change_request': describes what changes the user wants made to the story requirements before retrying.",
 				},
 			},
 			Required: []string{"incident_id", "action", "reason"},
@@ -73,13 +76,19 @@ func (t *IncidentActionTool) Exec(_ context.Context, args map[string]any) (*Exec
 		return nil, fmt.Errorf("action is required")
 	}
 
-	if action != "resume" {
-		return nil, fmt.Errorf("unsupported action %q: only 'resume' is supported", action)
+	validActions := map[string]bool{"resume": true, "try_again": true, "skip": true, "change_request": true}
+	if !validActions[action] {
+		return nil, fmt.Errorf("unsupported action %q: valid actions are resume, try_again, skip, change_request", action)
 	}
 
 	reason, ok := utils.SafeAssert[string](args["reason"])
 	if !ok || reason == "" {
 		return nil, fmt.Errorf("reason is required")
+	}
+
+	content, _ := utils.SafeAssert[string](args["content"])
+	if action == "change_request" && content == "" {
+		return nil, fmt.Errorf("content is required when action is 'change_request'")
 	}
 
 	return &ExecResult{
@@ -90,6 +99,7 @@ func (t *IncidentActionTool) Exec(_ context.Context, args map[string]any) (*Exec
 				"incident_id": incidentID,
 				"action":      action,
 				"reason":      reason,
+				"content":     content,
 			},
 		},
 	}, nil
@@ -101,12 +111,15 @@ func (t *IncidentActionTool) PromptDocumentation() string {
 
 Request an action on an open incident reported by the development system.
 
-Currently only the 'resume' action is supported. Use this when the user wants to retry
-work that has stalled or failed. The system will attempt to recover and resume work
-associated with the incident.
+Actions:
+- resume: Signal that the blocking condition has been resolved and work should resume.
+- try_again: Retry the failed or stalled work (same recovery as resume).
+- skip: Permanently abandon the story. Cannot be used if other stories depend on it.
+- change_request: Modify the story requirements before retrying. Requires the 'content' parameter describing the changes. Resets the retry budget for a fresh start.
 
 Parameters:
-- incident_id (required): The incident ID from the incident summary (e.g., "incident-system_idle-system-20260419T154212Z")
-- action (required): The action to take (currently only "resume")
-- reason (required): Why this action is being taken (e.g., "user requested retry")`
+- incident_id (required): The incident ID from the incident summary
+- action (required): One of "resume", "try_again", "skip", "change_request"
+- reason (required): Why this action is being taken
+- content (required for change_request): Description of what changes the user wants made`
 }

--- a/pkg/tools/incident_action_tool.go
+++ b/pkg/tools/incident_action_tool.go
@@ -1,0 +1,112 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"orchestrator/pkg/utils"
+)
+
+// createIncidentActionTool is the factory function for the tool registry.
+func createIncidentActionTool(ctx *AgentContext) (Tool, error) {
+	return NewIncidentActionTool(ctx), nil
+}
+
+// getIncidentActionSchema returns the input schema for registry metadata.
+func getIncidentActionSchema() InputSchema {
+	t := NewIncidentActionTool(nil)
+	return t.Definition().InputSchema
+}
+
+// IncidentActionTool allows PM to request an action on an open incident.
+// Phase 1.5 supports only the "resume" action.
+type IncidentActionTool struct {
+	agentCtx *AgentContext
+}
+
+// NewIncidentActionTool creates a new incident_action tool.
+func NewIncidentActionTool(agentCtx *AgentContext) *IncidentActionTool {
+	return &IncidentActionTool{agentCtx: agentCtx}
+}
+
+// Name returns the tool name.
+func (t *IncidentActionTool) Name() string {
+	return ToolIncidentAction
+}
+
+// Definition returns the MCP tool definition.
+func (t *IncidentActionTool) Definition() ToolDefinition {
+	return ToolDefinition{
+		Name:        ToolIncidentAction,
+		Description: "Request an action on an open incident. Currently only 'resume' is supported, which tells the development system to retry or resume work related to the incident.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"incident_id": {
+					Type:        "string",
+					Description: "The ID of the incident to act on (from the incident summary injected into context)",
+				},
+				"action": {
+					Type:        "string",
+					Description: "The action to take. Currently only 'resume' is supported.",
+					Enum:        []string{"resume"},
+				},
+				"reason": {
+					Type:        "string",
+					Description: "Brief explanation of why this action is being taken (e.g., 'user requested retry', 'underlying issue resolved')",
+				},
+			},
+			Required: []string{"incident_id", "action", "reason"},
+		},
+	}
+}
+
+// Exec executes the incident_action tool.
+func (t *IncidentActionTool) Exec(_ context.Context, args map[string]any) (*ExecResult, error) {
+	incidentID, ok := utils.SafeAssert[string](args["incident_id"])
+	if !ok || incidentID == "" {
+		return nil, fmt.Errorf("incident_id is required")
+	}
+
+	action, ok := utils.SafeAssert[string](args["action"])
+	if !ok || action == "" {
+		return nil, fmt.Errorf("action is required")
+	}
+
+	if action != "resume" {
+		return nil, fmt.Errorf("unsupported action %q: only 'resume' is supported", action)
+	}
+
+	reason, ok := utils.SafeAssert[string](args["reason"])
+	if !ok || reason == "" {
+		return nil, fmt.Errorf("reason is required")
+	}
+
+	return &ExecResult{
+		Content: fmt.Sprintf("Incident action '%s' sent for %s: %s", action, incidentID, reason),
+		ProcessEffect: &ProcessEffect{
+			Signal: SignalIncidentAction,
+			Data: map[string]any{
+				"incident_id": incidentID,
+				"action":      action,
+				"reason":      reason,
+			},
+		},
+	}, nil
+}
+
+// PromptDocumentation returns prompt-friendly docs for the tool.
+func (t *IncidentActionTool) PromptDocumentation() string {
+	return `## incident_action
+
+Request an action on an open incident reported by the development system.
+
+Currently only the 'resume' action is supported. Use this when the user wants to retry
+work that has stalled or failed. The system will attempt to recover and resume work
+associated with the incident.
+
+Parameters:
+- incident_id (required): The incident ID from the incident summary (e.g., "incident-system_idle-system-20260419T154212Z")
+- action (required): The action to take (currently only "resume")
+- reason (required): Why this action is being taken (e.g., "user requested retry")`
+}

--- a/pkg/tools/mcp.go
+++ b/pkg/tools/mcp.go
@@ -80,6 +80,7 @@ const (
 	SignalBootstrapComplete = "BOOTSTRAP_COMPLETE"  // bootstrap tool completed configuration
 	SignalAwaitUser         = "AWAIT_USER"          // chat_ask_user tool waiting for human response
 	SignalReleaseHeld       = "RELEASE_HELD"        // release_held_stories tool: signal architect to release held stories
+	SignalIncidentAction    = "INCIDENT_ACTION"     // incident_action tool: signal architect to act on an incident
 	SignalMaestroMdComplete = "MAESTRO_MD_COMPLETE" // maestro_md_submit tool completed
 
 	// Architect signals.

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -939,6 +939,11 @@ func init() {
 		Description: "Release held stories after a system repair or prerequisite issue is resolved",
 		InputSchema: getReleaseHeldStoriesSchema(),
 	})
+	Register(ToolIncidentAction, createIncidentActionTool, &ToolMeta{
+		Name:        ToolIncidentAction,
+		Description: "Request an action on an open incident (resume stalled or failed work)",
+		InputSchema: getIncidentActionSchema(),
+	})
 
 	// Register research tools
 	Register(ToolWebSearch, createWebSearchTool, &ToolMeta{


### PR DESCRIPTION
## Summary

Fixes #200 (PM silent in AWAIT_USER) and #201 (architect silent when system idle). Implements a three-phase durable incident system:

- **Phase 1**: Durable asks (PM remembers pending questions across resume) and incidents (architect detects idle system, blocked stories, clarification needs). Edge-triggered notifications to PM with structured open/close lifecycle.
- **Phase 1.5**: `incident_action` tool giving PM structured recovery actions (`resume`) instead of free-form text.
- **Phase 2**: Full action semantics — `try_again`, `skip` (new `StatusSkipped` terminal state with reverse-dependency gating), and `change_request` (annotate + reset budgets + retry). Belt-and-suspenders validation at both creation time and handler time.

Key design: "waiting on user" is now a durable product-state object, not a timer problem. See `docs/DURABLE_ASKS_AND_INCIDENTS.md` for full design.

## Test plan

- [x] 14 queue tests: SkipStory variants, GetNonTerminalDependents, AllStoriesTerminal/Completed with skipped, SetStatus guard, ResetAllBudgets, HasHeldStoriesForFailure
- [x] 5 proto tests: Content round-trip, SkippedStories round-trip, incident action constants
- [x] 6 PM tests: buildPendingSummary variants, deterministic ordering, sha256 determinism
- [x] Schema migration v23 test (table-swap for StatusSkipped)
- [x] Dispatcher GetLeasedStoryIDs test
- [x] `make build` (includes lint) passes
- [x] `make test` — all unit tests pass
- [x] Pre-push integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)