### PR TITLE
Support MAESTRO_-prefixed env vars for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ This project is developed and actively maintained by Snapdragon Partners. Tokens
 > export GOOGLE_SEARCH_CX=...  # Your Custom Search Engine ID
 > ```
 >
+> **Tip:** If you use Claude Code or other tools that read `ANTHROPIC_API_KEY`, you can set `MAESTRO_ANTHROPIC_API_KEY` instead — Maestro checks `MAESTRO_`-prefixed env vars first, letting you use different keys for Maestro and other tools. This works for all providers: `MAESTRO_OPENAI_API_KEY`, `MAESTRO_GOOGLE_GENAI_API_KEY`, `MAESTRO_GITHUB_TOKEN`.
+>
 > **Option B: Configure via Web UI** (easier)
 >
 > Skip this step entirely and just run Maestro. If any required API keys are missing, Maestro will automatically open a setup page in the Web UI where you can paste your keys into a browser form. Keys are encrypted and stored locally.

--- a/pkg/config/secrets.go
+++ b/pkg/config/secrets.go
@@ -119,10 +119,15 @@ func SetDecryptedSecrets(secrets *StructuredSecrets) {
 }
 
 // GetSecret returns a secret value by name using precedence:
-// 1. User secrets (in memory)
-// 2. System secrets (in memory)
-// 3. Environment variables.
+// 1. MAESTRO_-prefixed environment variable (explicit Maestro override)
+// 2. User secrets (in memory)
+// 3. System secrets (in memory)
+// 4. Standard environment variable.
 func GetSecret(name string) (string, error) {
+	if value := os.Getenv("MAESTRO_" + name); value != "" {
+		return value, nil
+	}
+
 	decryptedSecretsMux.RLock()
 	if decryptedSecrets != nil {
 		// User secrets take precedence over system secrets
@@ -148,7 +153,12 @@ func GetSecret(name string) (string, error) {
 // GetSystemSecret returns a secret value for Maestro's own use (API keys, tokens).
 // Only checks system secrets and environment variables — never user secrets.
 // User secrets are for container injection only and should not be used by Maestro itself.
+// Precedence: MAESTRO_-prefixed env var > system secrets > standard env var.
 func GetSystemSecret(name string) (string, error) {
+	if value := os.Getenv("MAESTRO_" + name); value != "" {
+		return value, nil
+	}
+
 	decryptedSecretsMux.RLock()
 	if decryptedSecrets != nil {
 		if value, exists := decryptedSecrets.System[name]; exists && value != "" {

--- a/pkg/config/secrets_test.go
+++ b/pkg/config/secrets_test.go
@@ -195,6 +195,85 @@ func TestGetSecretPrecedence(t *testing.T) {
 	}
 }
 
+func TestGetSecretMaestroPrefixPrecedence(t *testing.T) {
+	defer func() {
+		SetDecryptedSecrets(nil)
+		os.Unsetenv("TEST_KEY")
+		os.Unsetenv("MAESTRO_TEST_KEY")
+	}()
+
+	// MAESTRO_ env var beats user secrets, system secrets, and standard env var
+	SetDecryptedSecrets(&StructuredSecrets{
+		System: map[string]string{"TEST_KEY": "from-system"},
+		User:   map[string]string{"TEST_KEY": "from-user"},
+	})
+	os.Setenv("TEST_KEY", "from-env")
+	os.Setenv("MAESTRO_TEST_KEY", "from-maestro-env")
+
+	secret, err := GetSecret("TEST_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "from-maestro-env" {
+		t.Errorf("expected MAESTRO_ env var to win, got: %q", secret)
+	}
+
+	// Without MAESTRO_ prefix, falls back to user secret
+	os.Unsetenv("MAESTRO_TEST_KEY")
+	secret, err = GetSecret("TEST_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "from-user" {
+		t.Errorf("expected user secret without MAESTRO_ prefix, got: %q", secret)
+	}
+}
+
+func TestGetSystemSecretMaestroPrefixPrecedence(t *testing.T) {
+	defer func() {
+		SetDecryptedSecrets(nil)
+		os.Unsetenv("TEST_KEY")
+		os.Unsetenv("MAESTRO_TEST_KEY")
+	}()
+
+	// MAESTRO_ env var beats system secrets and standard env var
+	SetDecryptedSecrets(&StructuredSecrets{
+		System: map[string]string{"TEST_KEY": "from-system"},
+	})
+	os.Setenv("TEST_KEY", "from-env")
+	os.Setenv("MAESTRO_TEST_KEY", "from-maestro-env")
+
+	secret, err := GetSystemSecret("TEST_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "from-maestro-env" {
+		t.Errorf("expected MAESTRO_ env var to win, got: %q", secret)
+	}
+
+	// Without MAESTRO_ prefix, falls back to system secret (not env var)
+	os.Unsetenv("MAESTRO_TEST_KEY")
+	secret, err = GetSystemSecret("TEST_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "from-system" {
+		t.Errorf("expected system secret without MAESTRO_ prefix, got: %q", secret)
+	}
+
+	// Without system secret, falls back to standard env var
+	SetDecryptedSecrets(&StructuredSecrets{
+		System: map[string]string{},
+	})
+	secret, err = GetSystemSecret("TEST_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "from-env" {
+		t.Errorf("expected standard env var as final fallback, got: %q", secret)
+	}
+}
+
 func TestProjectPasswordMemory(t *testing.T) {
 	// Clear any existing password
 	ClearProjectPassword()

--- a/pkg/config/secrets_test.go
+++ b/pkg/config/secrets_test.go
@@ -196,82 +196,91 @@ func TestGetSecretPrecedence(t *testing.T) {
 }
 
 func TestGetSecretMaestroPrefixPrecedence(t *testing.T) {
-	defer func() {
-		SetDecryptedSecrets(nil)
-		os.Unsetenv("TEST_KEY")
-		os.Unsetenv("MAESTRO_TEST_KEY")
-	}()
+	t.Run("maestro env wins over all", func(t *testing.T) {
+		t.Cleanup(func() { SetDecryptedSecrets(nil) })
+		SetDecryptedSecrets(&StructuredSecrets{
+			System: map[string]string{"TEST_KEY": "from-system"},
+			User:   map[string]string{"TEST_KEY": "from-user"},
+		})
+		t.Setenv("TEST_KEY", "from-env")
+		t.Setenv("MAESTRO_TEST_KEY", "from-maestro-env")
 
-	// MAESTRO_ env var beats user secrets, system secrets, and standard env var
-	SetDecryptedSecrets(&StructuredSecrets{
-		System: map[string]string{"TEST_KEY": "from-system"},
-		User:   map[string]string{"TEST_KEY": "from-user"},
+		secret, err := GetSecret("TEST_KEY")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret != "from-maestro-env" {
+			t.Errorf("expected MAESTRO_ env var to win, got: %q", secret)
+		}
 	})
-	os.Setenv("TEST_KEY", "from-env")
-	os.Setenv("MAESTRO_TEST_KEY", "from-maestro-env")
 
-	secret, err := GetSecret("TEST_KEY")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if secret != "from-maestro-env" {
-		t.Errorf("expected MAESTRO_ env var to win, got: %q", secret)
-	}
+	t.Run("falls back to user secret without maestro env", func(t *testing.T) {
+		t.Cleanup(func() { SetDecryptedSecrets(nil) })
+		SetDecryptedSecrets(&StructuredSecrets{
+			System: map[string]string{"TEST_KEY": "from-system"},
+			User:   map[string]string{"TEST_KEY": "from-user"},
+		})
+		t.Setenv("TEST_KEY", "from-env")
 
-	// Without MAESTRO_ prefix, falls back to user secret
-	os.Unsetenv("MAESTRO_TEST_KEY")
-	secret, err = GetSecret("TEST_KEY")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if secret != "from-user" {
-		t.Errorf("expected user secret without MAESTRO_ prefix, got: %q", secret)
-	}
+		secret, err := GetSecret("TEST_KEY")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret != "from-user" {
+			t.Errorf("expected user secret without MAESTRO_ prefix, got: %q", secret)
+		}
+	})
 }
 
 func TestGetSystemSecretMaestroPrefixPrecedence(t *testing.T) {
-	defer func() {
-		SetDecryptedSecrets(nil)
-		os.Unsetenv("TEST_KEY")
-		os.Unsetenv("MAESTRO_TEST_KEY")
-	}()
+	t.Run("maestro env wins over system secret and env", func(t *testing.T) {
+		t.Cleanup(func() { SetDecryptedSecrets(nil) })
+		SetDecryptedSecrets(&StructuredSecrets{
+			System: map[string]string{"TEST_KEY": "from-system"},
+		})
+		t.Setenv("TEST_KEY", "from-env")
+		t.Setenv("MAESTRO_TEST_KEY", "from-maestro-env")
 
-	// MAESTRO_ env var beats system secrets and standard env var
-	SetDecryptedSecrets(&StructuredSecrets{
-		System: map[string]string{"TEST_KEY": "from-system"},
+		secret, err := GetSystemSecret("TEST_KEY")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret != "from-maestro-env" {
+			t.Errorf("expected MAESTRO_ env var to win, got: %q", secret)
+		}
 	})
-	os.Setenv("TEST_KEY", "from-env")
-	os.Setenv("MAESTRO_TEST_KEY", "from-maestro-env")
 
-	secret, err := GetSystemSecret("TEST_KEY")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if secret != "from-maestro-env" {
-		t.Errorf("expected MAESTRO_ env var to win, got: %q", secret)
-	}
+	t.Run("falls back to system secret without maestro env", func(t *testing.T) {
+		t.Cleanup(func() { SetDecryptedSecrets(nil) })
+		SetDecryptedSecrets(&StructuredSecrets{
+			System: map[string]string{"TEST_KEY": "from-system"},
+		})
+		t.Setenv("TEST_KEY", "from-env")
 
-	// Without MAESTRO_ prefix, falls back to system secret (not env var)
-	os.Unsetenv("MAESTRO_TEST_KEY")
-	secret, err = GetSystemSecret("TEST_KEY")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if secret != "from-system" {
-		t.Errorf("expected system secret without MAESTRO_ prefix, got: %q", secret)
-	}
-
-	// Without system secret, falls back to standard env var
-	SetDecryptedSecrets(&StructuredSecrets{
-		System: map[string]string{},
+		secret, err := GetSystemSecret("TEST_KEY")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret != "from-system" {
+			t.Errorf("expected system secret without MAESTRO_ prefix, got: %q", secret)
+		}
 	})
-	secret, err = GetSystemSecret("TEST_KEY")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if secret != "from-env" {
-		t.Errorf("expected standard env var as final fallback, got: %q", secret)
-	}
+
+	t.Run("falls back to standard env var without secrets", func(t *testing.T) {
+		t.Cleanup(func() { SetDecryptedSecrets(nil) })
+		SetDecryptedSecrets(&StructuredSecrets{
+			System: map[string]string{},
+		})
+		t.Setenv("TEST_KEY", "from-env")
+
+		secret, err := GetSystemSecret("TEST_KEY")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if secret != "from-env" {
+			t.Errorf("expected standard env var as final fallback, got: %q", secret)
+		}
+	})
 }
 
 func TestProjectPasswordMemory(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `MAESTRO_`-prefixed environment variable support for all API keys (`MAESTRO_ANTHROPIC_API_KEY`, `MAESTRO_OPENAI_API_KEY`, `MAESTRO_GOOGLE_GENAI_API_KEY`, `MAESTRO_GITHUB_TOKEN`)
- `MAESTRO_`-prefixed env vars take highest precedence, allowing users to set separate keys for Maestro vs other tools (e.g., Claude Code) that read the standard env vars
- Only 6 lines of production code change — all callers inherit the new behavior through `GetSecret()` / `GetSystemSecret()`

## Test plan
- [x] New unit tests for `GetSecret` MAESTRO_ prefix precedence
- [x] New unit tests for `GetSystemSecret` MAESTRO_ prefix precedence
- [x] Existing precedence tests still pass (backward compat)
- [x] Full test suite passes (`make test`)
- [x] Integration tests pass (pre-push hook)
- [ ] Manual: set `MAESTRO_ANTHROPIC_API_KEY`, unset `ANTHROPIC_API_KEY`, verify Maestro uses the prefixed key

🤖 Generated with [Claude Code](https://claude.com/claude-code)