### PR TITLE
chore(dependabot): ignore LLM provider SDKs (owned by maestro-llms)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,17 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # LLM provider SDKs are now indirect deps owned by maestro-llms (the
+    # cut-over removed all direct imports). Their versions are pinned by
+    # maestro-llms's own go.mod and validated by its CI; bumping them here
+    # would only force an untested transitive version under the toolkit.
+    # Bump them in the maestro-llms repo instead — Maestro inherits via the
+    # (still dependabot-tracked) maestro-llms dependency. These churn often,
+    # which was a motivation for the extraction.
+    ignore:
+      - dependency-name: "github.com/anthropics/anthropic-sdk-go"
+      - dependency-name: "github.com/openai/openai-go"
+      - dependency-name: "google.golang.org/genai"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Post maestro-llms cut-over (#223), `anthropic-sdk-go` / `openai-go` / `genai` have **zero direct imports** in Maestro — they're indirect deps whose versions are pinned and CI-validated by `maestro-llms`. Dependabot bumping them in Maestro's go.mod only forces an untested transitive version *under* the toolkit (invisible to maestro-llms CI).

Adds `ignore` rules for the three so dependabot stops generating misdirected PRs (e.g. #216, #212, being closed). The dependency that matters — `github.com/SnapdragonPartners/maestro-llms` — stays tracked, and SDK bumps flow in through it once adopted upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)