### PR TITLE
ci: cache golangci-lint, pin lint version, drop redundant step and unused secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,16 @@ jobs:
       # setup-go caches Go's module/build caches but not golangci-lint's
       # analysis cache, which otherwise runs cold every time (~1-2 min).
       # Keyed per-commit with a prefix restore-key so each run reuses the
-      # most recent cache and saves an updated one.
+      # most recent cache and saves an updated one. The Makefile (which pins
+      # the golangci-lint version) and lint config are hashed into the key so
+      # a version bump or config change starts from a fresh cache.
       - name: Cache golangci-lint analysis
         uses: actions/cache@v4
         with:
           path: ~/.cache/golangci-lint
-          key: golangci-lint-${{ runner.os }}-${{ github.sha }}
+          key: golangci-lint-${{ runner.os }}-${{ hashFiles('Makefile', '.golangci.yaml') }}-${{ github.sha }}
           restore-keys: |
-            golangci-lint-${{ runner.os }}-
+            golangci-lint-${{ runner.os }}-${{ hashFiles('Makefile', '.golangci.yaml') }}-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,15 @@ jobs:
       - name: Build (includes lint)
         run: make build
 
-      # No secrets: unit tests must not be able to make live API calls.
-      # Integration tests (which need keys) run in the pre-push hook, not CI.
+      # Dummy keys, not real secrets: some unit tests construct LLM clients,
+      # which requires config.GetAPIKey to find a non-empty value, but no
+      # unit test may make a live call — with dummy keys an accidental one
+      # fails loudly (401) instead of silently spending money. Integration
+      # tests (which need real keys) run in the pre-push hook, not CI.
       - name: Test
         run: make test
+        env:
+          GITHUB_TOKEN: dummy-ci-key
+          ANTHROPIC_API_KEY: dummy-ci-key
+          OPENAI_API_KEY: dummy-ci-key
+          GOOGLE_GENAI_API_KEY: dummy-ci-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,27 @@ jobs:
           go-version-file: go.mod  # automatically uses the Go version from your go.mod
           cache: true
 
+      # setup-go caches Go's module/build caches but not golangci-lint's
+      # analysis cache, which otherwise runs cold every time (~1-2 min).
+      # Keyed per-commit with a prefix restore-key so each run reuses the
+      # most recent cache and saves an updated one.
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            golangci-lint-${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           go mod download
 
-      - name: Build
+      # make build runs lint as a prerequisite, so no separate lint step.
+      - name: Build (includes lint)
         run: make build
 
-      - name: Lint
-        run: make lint
-
+      # No secrets: unit tests must not be able to make live API calls.
+      # Integration tests (which need keys) run in the pre-push hook, not CI.
       - name: Test
         run: make test
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_GENAI_API_KEY: ${{ secrets.GOOGLE_GENAI_API_KEY }}
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       # Dummy keys, not real secrets: some unit tests construct LLM clients,
       # which requires config.GetAPIKey to find a non-empty value, but no
       # unit test may make a live call — with dummy keys an accidental one
-      # fails loudly (401) instead of silently spending money. Integration
-      # tests (which need real keys) run in the pre-push hook, not CI.
+      # fails loudly (401) instead of silently spending money. Real secrets
+      # belong on a dedicated integration job (template below), never here.
       - name: Test
         run: make test
         env:
@@ -52,3 +52,25 @@ jobs:
           ANTHROPIC_API_KEY: dummy-ci-key
           OPENAI_API_KEY: dummy-ci-key
           GOOGLE_GENAI_API_KEY: dummy-ci-key
+
+  # Template for when e2e/integration tests move into CI (today they run only
+  # in the pre-push hook). Real API-key secrets go on this job — keeping them
+  # off the unit-test job above is deliberate, so unit tests can never make
+  # live calls. Consider a manual/scheduled trigger rather than every PR push,
+  # since these tests spend real API tokens.
+  #
+  # integration:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v7
+  #     - uses: actions/setup-go@v6
+  #       with:
+  #         go-version-file: go.mod
+  #         cache: true
+  #     - run: make build-mcp-proxy  # go:embed needs the proxy binaries
+  #     - run: make test-integration
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  #         GOOGLE_GENAI_API_KEY: ${{ secrets.GOOGLE_GENAI_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,15 @@ check-coverage:
 		echo "🎉 All key packages meet 80% coverage threshold"; \
 	fi
 
+# Pinned so lint results are reproducible across CI runs and dev machines;
+# @latest silently changes lint behavior (and busts CI caches) on new releases.
+GOLANGCI_LINT_VERSION := v1.64.8
+
 # Install golangci-lint if not present
 install-lint:
 	@which golangci-lint > /dev/null || { \
-		echo "Installing golangci-lint..."; \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."; \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
 	}
 
 # Install goimports if not present

--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,16 @@ check-coverage:
 # @latest silently changes lint behavior (and busts CI caches) on new releases.
 GOLANGCI_LINT_VERSION := v1.64.8
 
-# Install golangci-lint if not present
+# Install golangci-lint if not present; warn (don't force-reinstall) on a
+# version mismatch — a PATH-shadowing install (e.g. homebrew) would win over
+# a reinstall anyway, so a loud warning beats a silent no-op loop.
 install-lint:
 	@which golangci-lint > /dev/null || { \
 		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."; \
 		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
 	}
+	@golangci-lint version 2>/dev/null | grep -q "$(GOLANGCI_LINT_VERSION)" || \
+		echo "⚠️  golangci-lint on PATH is not $(GOLANGCI_LINT_VERSION); lint results may differ from CI"
 
 # Install goimports if not present
 install-goimports:


### PR DESCRIPTION
## Summary

Follow-up to #237 — the CI streamlining assessed there. Baseline CI job is ~4.5 min, of which the Build step is ~2.5 min, mostly golangci-lint running cold every time.

- **Cache `~/.cache/golangci-lint`** — `setup-go` caches Go's module/build caches but not golangci-lint's analysis cache. Per-commit cache key with a prefix restore-key so each run restores the most recent cache and saves an updated one. Expected to cut the Build step roughly in half.
- **Pin golangci-lint to v1.64.8** (the version currently in use) — `@latest` silently changes lint behavior on new releases and would bust the new cache on unrelated PRs.
- **Drop the standalone Lint step** — `make build` already runs lint as a prerequisite; the separate step only took 1s because the Build step had just warmed the cache.
- **Drop API-key secrets from the Test step** — no unit test requires a real key (tests referencing those env vars save/restore them for config-logic testing), and this guarantees unit tests can never silently make paid LLM calls in CI. Integration tests, which do need keys, run via the pre-push hook, not CI.

Note: the first run on this PR still lints cold (no cache to restore yet); the speedup shows up from the second run onward.

## Testing

- `make lint` / `make build` / `make test` pass locally with the pinned version.
- Workflow YAML validated; CI on this PR exercises the new workflow itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)