### PR TITLE
docs(v2): Phase 0 scope and plan

### DIFF
--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -10,6 +10,7 @@ specifications, and stories.
 
 - [Roadmap](roadmap.md) - main v2 roadmap draft.
 - [Build Process](build-process.md) - interim working agreement for how v2 gets built (author/reviewer/operator roles, branching, review cadence, testing).
+- [Phase 0 Scope And Plan](phase-0.md) - the first phase artifact under the build process: deliverables, PR sequence, exit checklist.
 - [Research Synthesis](research-synthesis.md) - synthesis of the external research corpus and early Maestro v2 ideas.
 - [Provenance Matrix](provenance-matrix.md) - where major ideas came from: Maestro v1, client/lived experience, research corpus, or Codex synthesis.
 - [ADR Backlog](adr-backlog.md) - concepts that should probably become ADRs before implementation.

--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -10,7 +10,9 @@ specifications, and stories.
 
 - [Roadmap](roadmap.md) - main v2 roadmap draft.
 - [Build Process](build-process.md) - interim working agreement for how v2 gets built (author/reviewer/operator roles, branching, review cadence, testing).
-- [Phase 0 Scope And Plan](phase-0.md) - the first phase artifact under the build process: deliverables, PR sequence, exit checklist.
+- [Phase 0 Scope And Plan](phase_0/scope-and-plan.md) - the first phase artifact under the build process: deliverables, PR sequence, exit checklist.
+
+Per-phase working artifacts (scope/plan, spike reports, inventories) live in `phase_x/` directories matching the branch namespace; cross-phase documents stay at this root. Accepted decisions land in `docs/adr/`.
 - [Research Synthesis](research-synthesis.md) - synthesis of the external research corpus and early Maestro v2 ideas.
 - [Provenance Matrix](provenance-matrix.md) - where major ideas came from: Maestro v1, client/lived experience, research corpus, or Codex synthesis.
 - [ADR Backlog](adr-backlog.md) - concepts that should probably become ADRs before implementation.

--- a/docs/v2/build-process.md
+++ b/docs/v2/build-process.md
@@ -17,7 +17,8 @@ An artifact is Accepted when both Codex and DR have approved it.
 - Each phase begins with a scope and a plan, each reviewed and approved by both Codex and DR.
 - The working doc set stays deliberately small — there is no Maestro apparatus yet to manage a large one.
 - Each phase gets a branch (or more than one, only if the plan says so).
-- Branch naming: `v2/phase_x/XXX` (e.g. `v2/phase_0/adr-taxonomy`); bug-fix branches use `v2/fix/XXX`.
+- Branch naming: `v2/phase_x/XXX` (e.g. `v2/phase_0/adr-taxonomy`); bug-fix branches use `v2/fix/XXX`. Never reuse a prior leaf branch name as a namespace prefix (git ref collision).
+- Per-phase working artifacts live in `docs/v2/phase_x/`, mirroring the branch namespace; cross-phase docs stay at the `docs/v2/` root; Accepted decisions land in `docs/adr/`.
 - Never more than one feature/dev branch open at a time. Parallel branches are acceptable only for bug fixes. This bounds the human operator's review load, not the author's throughput.
 - Smaller PRs get a single end-of-work review. Larger PRs get review checkpoints defined in the plan.
 

--- a/docs/v2/phase_0/scope-and-plan.md
+++ b/docs/v2/phase_0/scope-and-plan.md
@@ -6,9 +6,9 @@ status = "draft"
 
 # Phase 0: v2 Design Groundwork — Scope And Plan
 
-Status: draft. Per [build-process.md](build-process.md), the scope and the plan each require Codex and DR approval before Phase 0 work items start.
+Status: draft. Per [build-process.md](../build-process.md), the scope and the plan each require Codex and DR approval before Phase 0 work items start.
 
-Goal (from the [roadmap](roadmap.md)): decide the conceptual shape before code churn.
+Goal (from the [roadmap](../roadmap.md)): decide the conceptual shape before code churn.
 
 ## Scope
 
@@ -18,7 +18,7 @@ In scope:
 - The two Phase 0 spikes: toolloop ownership, and the disposable project folder.
 - The port-vs-rewrite inventory at package grain (roadmap D8), informed by the spikes.
 - Documentation reset: archive stale docs, adopt the front-matter convention, make remaining repo docs agent-ingestible.
-- Reconciled, dependency-ordered ADR backlog (supersedes the interim priority list in [v1-adr-alignment.md](v1-adr-alignment.md)).
+- Reconciled, dependency-ordered ADR backlog (supersedes the interim priority list in [v1-adr-alignment.md](../v1-adr-alignment.md)).
 - Breaking-change principles (D7 is agreed; recorded alongside the inventory).
 
 Out of scope:

--- a/docs/v2/phase_0/scope-and-plan.md
+++ b/docs/v2/phase_0/scope-and-plan.md
@@ -8,6 +8,8 @@ status = "draft"
 
 Status: draft. Per [build-process.md](../build-process.md), the scope and the plan each require Codex and DR approval before Phase 0 work items start.
 
+Status lifecycle (applies to all phase artifacts): `draft` while under review; flipped to `live` after both approvals, as the final commit before merge and before any work items start; `archive` when the phase completes and the document becomes a historical record. Work item 1 formalizes this lifecycle as part of the front-matter convention.
+
 Goal (from the [roadmap](../roadmap.md)): decide the conceptual shape before code churn.
 
 ## Scope
@@ -59,13 +61,15 @@ Sequencing notes:
 
 ## Exit Checklist
 
-Maps one-to-one to the roadmap's Phase 0 exit criteria:
+The roadmap's Phase 0 exit criteria, plus the Phase 0 scope items that are not themselves roadmap exit criteria:
 
 - [ ] Taxonomy, artifact model (including artifact scope), branch strategy, data plane, and reviewer/partner ADRs Accepted. (Items 2–5.)
 - [ ] Phase 1-blocking ADR Accepted before any Phase 1 implementation: golden story schema / benchmark runner, including the D9 mechanism and the Phase 1 target strategy. (Item 7.)
 - [ ] The v2 MVP boundary (D1) and the port-vs-rewrite inventory (D8) written down and agreed. (Items 2 and 10; D1 is ratified inside the taxonomy ADR.)
 - [ ] Documentation reset done: stale docs archived, remaining repo docs safe for agent ingestion. (Items 1 and 11.)
 - [ ] Reconciled ADR backlog. (Item 12.)
+- [ ] Intake/triage contract ADR Accepted (item 6); both spike reports delivered (items 8–9).
+- [ ] All remaining table deliverables completed, or explicitly deferred by agreement of DR and Codex.
 
 ## Risks
 
@@ -73,8 +77,10 @@ Maps one-to-one to the roadmap's Phase 0 exit criteria:
 - **Spike scope creep.** Spikes produce a report and a recommendation, never a refactor. Throwaway code stays on the spike branch.
 - **Review bottleneck.** Serial PRs are deliberate (bounded operator load); the spikes are the pressure-relief valve when a review stalls.
 
-## Open Questions For Reviewers
+## Reviewer Questions — Resolutions
 
-1. ADR numbering: continue the single sequence (0017+) in `docs/adr/` with the v1 notes marked historical, or start a v2 series (`docs/adr/v2/0001+`)? Recommendation: continue the single sequence — one authority trail, no ambiguity about which series wins. Decided in item 1.
-2. Item 2 bundles three ADRs in one PR. Acceptable for review coherence, or split into three serial PRs?
-3. Should the doc reset (item 11) land before the ADRs so they're written into a clean tree, or after so the archive plan can account for everything the ADRs supersede? Recommendation: after, as sequenced.
+Codex has answered (2026-07-12); DR confirmation rides on this document's approval.
+
+1. ADR numbering: **continue the single sequence (0017+)** in `docs/adr/` with the v1 notes marked historical. Codex concurs: a second v2 series creates avoidable authority ambiguity. Formalized in item 1.
+2. Item 2 bundling three conceptual ADRs in one PR: **acceptable**, with the stated review checkpoint after the taxonomy ADR — the three are coupled enough that reviewing together beats serial churn.
+3. Doc reset ordering: **after the ADRs**, as sequenced — the archive plan should be informed by the accepted decisions it applies.

--- a/docs/v2/phase_0/scope-and-plan.md
+++ b/docs/v2/phase_0/scope-and-plan.md
@@ -1,0 +1,80 @@
++++
+title = "Maestro v2 Phase 0: Scope And Plan"
+edit_date = "2026-07-12"
+status = "draft"
++++
+
+# Phase 0: v2 Design Groundwork — Scope And Plan
+
+Status: draft. Per [build-process.md](build-process.md), the scope and the plan each require Codex and DR approval before Phase 0 work items start.
+
+Goal (from the [roadmap](roadmap.md)): decide the conceptual shape before code churn.
+
+## Scope
+
+In scope:
+
+- The Phase 0 ADR set (below), each Accepted per the build process.
+- The two Phase 0 spikes: toolloop ownership, and the disposable project folder.
+- The port-vs-rewrite inventory at package grain (roadmap D8), informed by the spikes.
+- Documentation reset: archive stale docs, adopt the front-matter convention, make remaining repo docs agent-ingestible.
+- Reconciled, dependency-ordered ADR backlog (supersedes the interim priority list in [v1-adr-alignment.md](v1-adr-alignment.md)).
+- Breaking-change principles (D7 is agreed; recorded alongside the inventory).
+
+Out of scope:
+
+- Implementation code. Spike code is throwaway and never merges.
+- Golden story and runner *implementation* (Phase 1) — but their ADR is in scope and Phase 0 exit-blocking.
+- The final intake executor design (pre-Phase-5 spike). Phase 0 fixes only the intake artifact contract and orchestrator seam.
+- Postgres DDL and migrations (Phase 2). Phase 0 decides the stack and schema families only.
+- Any renaming or refactoring of v1 code.
+
+The v2 product thesis and MPH definition already exist in the roadmap and README; Phase 0 ratifies them by reference in the ADRs rather than producing a separate memo.
+
+## Deliverables And PR Sequence
+
+One short-lived branch per item (`v2/phase_0/XXX`), one open at a time, single end-of-work review each per the build process. Order respects dependencies; sizes are rough (S under a day of review-ready work, M a few days).
+
+| # | Branch suffix | Deliverable | Size |
+|---|---|---|---|
+| 0 | `scope-and-plan` | This document, Accepted. | S |
+| 1 | `adr-lifecycle` | ADR: v2 documentation authority and ADR lifecycle — numbering, what Accepted means (Codex + DR approval), TOML front-matter convention, and the archive plan for stale docs (plan only; execution is item 11). | S |
+| 2 | `adr-taxonomy` | Three coupled conceptual ADRs: taxonomy (Product/Feature/Epic/Story/Work Group/Workbench, incl. collapsible hierarchy and MPH by reference); Orchestrator boundary (no-inference rule, v1 kernel/supervisor/dispatcher lineage); Reviewer vs Partner/Supervisor incl. the symmetric review invariant. | M |
+| 3 | `adr-artifacts` | ADR: Management/Audit artifacts, the scope model (`scope_type`/`scope_id` + lineage), minimal signatures, agent instances. | M |
+| 4 | `adr-data-plane` | ADR: Postgres/sqlc/golang-migrate, Docker-local default, multi-user scope boundaries, repo-vs-database split (D5). | M |
+| 5 | `adr-branching` | ADR: branch hierarchy (Story → Epic → default), rebase as a harness function, and the working branch-naming convention (including the leaf-vs-namespace rule learned on #239). | S |
+| 6 | `adr-intake-contract` | ADR: intake/triage artifact contract with the executor deliberately unbound (D2). | S |
+| 7 | `adr-benchmark` | ADR: golden stories and benchmark runner — black-box contract, self-contained persistence, D9 sampling/budget mechanism (numeric values provisional until first instrumented runs), Phase 1 target strategy (minimally patched v1 path), `golden-minimal`/`golden-all` build tags. **Phase 1-blocking.** | M |
+| 8 | `spike-toolloop` | Spike report: is a Maestro-owned toolloop distinct from the `maestro-llms` toolloop still justified? Recommendation only; no refactor. | M |
+| 9 | `spike-project-folder` | Spike report: how much non-disposable state can leave the user's filesystem for the data plane (or the repo, where it is a true project artifact)? Includes the bootstrap-mode / `.maestro/` question. | S |
+| 10 | `port-inventory` | The D8 port/rework/rewrite/drop inventory at package grain over the actual v1 package list, using both spike results. Records breaking-change principles. | M |
+| 11 | `doc-reset` | Execute the archive plan from item 1; apply front-matter to live docs. | M |
+| 12 | `backlog-reconcile` | Reconciled, dependency-ordered ADR backlog; Phase 0 exit checklist review against the roadmap. | S |
+
+Sequencing notes:
+
+- Items 8 and 9 have no ADR dependencies and are the designated slack: if an ADR review stalls, a spike proceeds without violating the one-branch rule (the stalled branch closes or merges first).
+- Item 2 bundles three closely coupled conceptual ADRs for review coherence. If it runs large, the plan's checkpoint mechanism applies: review checkpoint after the taxonomy ADR before the other two are drafted.
+- Item 7 is deliberately last of the ADRs: it consumes the artifact model (3), data plane families (4), and branching (5).
+
+## Exit Checklist
+
+Maps one-to-one to the roadmap's Phase 0 exit criteria:
+
+- [ ] Taxonomy, artifact model (including artifact scope), branch strategy, data plane, and reviewer/partner ADRs Accepted. (Items 2–5.)
+- [ ] Phase 1-blocking ADR Accepted before any Phase 1 implementation: golden story schema / benchmark runner, including the D9 mechanism and the Phase 1 target strategy. (Item 7.)
+- [ ] The v2 MVP boundary (D1) and the port-vs-rewrite inventory (D8) written down and agreed. (Items 2 and 10; D1 is ratified inside the taxonomy ADR.)
+- [ ] Documentation reset done: stale docs archived, remaining repo docs safe for agent ingestion. (Items 1 and 11.)
+- [ ] Reconciled ADR backlog. (Item 12.)
+
+## Risks
+
+- **ADR sprawl.** The Phase 0 set is capped at the table above; every other backlog candidate stays in the backlog for later phases. New ADR needs discovered mid-phase go to the backlog, not the phase.
+- **Spike scope creep.** Spikes produce a report and a recommendation, never a refactor. Throwaway code stays on the spike branch.
+- **Review bottleneck.** Serial PRs are deliberate (bounded operator load); the spikes are the pressure-relief valve when a review stalls.
+
+## Open Questions For Reviewers
+
+1. ADR numbering: continue the single sequence (0017+) in `docs/adr/` with the v1 notes marked historical, or start a v2 series (`docs/adr/v2/0001+`)? Recommendation: continue the single sequence — one authority trail, no ambiguity about which series wins. Decided in item 1.
+2. Item 2 bundles three ADRs in one PR. Acceptable for review coherence, or split into three serial PRs?
+3. Should the doc reset (item 11) land before the ADRs so they're written into a clean tree, or after so the archive plan can account for everything the ADRs supersede? Recommendation: after, as sequenced.


### PR DESCRIPTION
## Summary

The first phase artifact under the v2 build process (`docs/v2/build-process.md`): the Phase 0 scope and plan, requiring both Codex and DR approval before Phase 0 work items begin.

### Contents

- **Scope**: the Phase 0 ADR set, the two spikes (toolloop ownership, disposable project folder), the D8 port-vs-rewrite inventory, the documentation reset, and backlog reconciliation. Explicit non-goals: implementation code, golden-story implementation (Phase 1), the intake executor design (pre-Phase-5 spike), Postgres DDL (Phase 2).
- **Plan**: 13 serial work items, one `v2/phase_0/*` branch each, dependency-ordered, with sizes. The benchmark-runner ADR (item 7) is marked Phase 1-blocking per the roadmap exit criteria. Spikes serve as review-stall slack without violating the one-branch rule.
- **Exit checklist** mapping one-to-one to the roadmap's Phase 0 exit criteria.
- **Three open questions for reviewers**: ADR numbering (recommend continuing 0017+ in a single sequence), whether item 2 may bundle the three conceptual ADRs in one PR, and doc-reset ordering (recommend after the ADRs).

### Also in this PR

- New convention: per-phase working artifacts live in `docs/v2/phase_x/` mirroring the branch namespace; cross-phase docs stay at the `docs/v2/` root; Accepted decisions land in `docs/adr/`. Recorded in `build-process.md` and the docs/v2 README.
- Branch-naming rule added from the #239 lesson: never reuse a prior leaf branch name as a namespace prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)