### PR TITLE
docs(adr): ADR 0017 — v2 documentation authority and lifecycle (Phase 0, item 1)

### DIFF
--- a/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
+++ b/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
@@ -1,0 +1,70 @@
++++
+title = "ADR 0017: v2 Documentation Authority And Lifecycle"
+edit_date = "2026-07-12"
+status = "draft"
++++
+
+# 0017. v2 Documentation Authority And Lifecycle
+
+Status: Proposed
+
+## Context
+
+Maestro v2 is a breaking redesign built by an agent fleet under one human operator ([build-process](../v2/build-process.md)). Agents consume repo documentation as ground truth, so documentation authority must be deterministic: which document wins when two disagree, and which documents carry no authority at all.
+
+The repo currently holds three generations of documentation: ADRs 0001–0016 (proposed current-state notes about v1, never accepted as binding), the v2 planning set under `docs/v2/`, and roughly 130 v1-era specs, plans, and TODO files under `docs/` and `docs/specs/` of widely varying staleness. The v1 codebase is deprecated (`v1-freeze`) but remains the running implementation until v2 replaces it, so "what does the code do" and "what is the v2 design" have different authoritative sources during the transition.
+
+## Decision
+
+### ADR numbering and status
+
+- One ADR sequence. v2 decisions continue at 0017. ADRs 0001–0016 are historical v1 current-state notes: useful context, never binding, and never to be Accepted. A v2 ADR that replaces one marks it Superseded explicitly.
+- ADR lifecycle: `Proposed` → `Accepted` (requires both Codex and DR approval; the status flips as the final commit on the PR, and merge waits until that commit is visible) → `Superseded` or `Rejected`.
+- v2 ADR template: Status, Context, Decision, Consequences, Related Documents, plus optional Implementation Notes. (The v1 template's mandatory "Current Implementation" section is dropped — v2 ADRs often precede implementation.)
+
+### Front-matter
+
+All markdown documents under `docs/` that are created or substantively edited from now on carry Hugo-style TOML front-matter with three fields: `title`, `edit_date`, and `status` ∈ {`draft`, `live`, `archive`}.
+
+The doc status and the ADR status are two views of one state: Proposed ↔ `draft`, Accepted ↔ `live`, Superseded/Rejected ↔ `archive`. Phase artifacts follow the lifecycle defined in the [Phase 0 plan](../v2/phase_0/scope-and-plan.md): `draft` under review, `live` after both approvals, `archive` when the phase closes.
+
+### Documentation authority
+
+Authority depends on the question being asked.
+
+For current runtime behavior (the code as it runs today):
+
+1. Code and tests.
+2. Canonical FSM docs: `pkg/pm/STATES.md`, `pkg/architect/STATES.md`, `pkg/coder/STATES.md`.
+3. Implementation summaries: `CLAUDE.md`, `README.md`.
+
+For v2 design intent:
+
+1. Accepted ADRs (0017+).
+2. `live` phase artifacts in `docs/v2/phase_x/`.
+3. The roadmap and cross-phase documents in `docs/v2/`.
+4. Historical ADRs 0001–0016.
+
+Documents with `status = "archive"` carry no authority for any question; they are history. When a v2 ADR and current code disagree, both are right about different things: the code describes the present, the ADR describes the committed direction.
+
+### Archive plan
+
+Executed in Phase 0 work item 11 (`doc-reset`); this ADR fixes the rules and the keep list.
+
+- Archived documents move to `docs/archive/`, preserving filenames, and receive `status = "archive"` front-matter. Git history preserves original paths; no redirects are maintained.
+- Keep list (remain live at their current locations): `docs/adr/`, `docs/v2/`, `docs/wiki/` (human-facing set, pending the wiki/docs-site decision), and the operational docs referenced by `CLAUDE.md` and `README.md` — currently `GIT.md`, `TESTING_STRATEGY.md`, `MAESTRO_LLMS_MIGRATION.md`, `ARCHITECT_CONTEXT.md`, `MAESTRO_CHAT_SPEC.md`, `HOTFIX_MODE_SPEC.md`, `MODES.md`, `AIRPLANE_MODE.md`, `MAINTENANCE_MODE_SPEC.md`, `OLLAMA.md`, `DOC_GRAPH.md`, plus `BENCHMARK_HOWTO.md` and `BENCHMARKS.md` as Phase 1 seeds and `WELCOME_TO_MAESTRO.md`. Kept v1 docs get front-matter with `status = "live"` and remain authoritative only for current runtime behavior.
+- Everything else under `docs/` root and all of `docs/specs/` archives: these are v1 design specs, plans, and TODOs whose decisions are either implemented (the code is now the authority) or abandoned.
+- `docs/screenshots/` archives unless referenced by a kept document.
+- Item 11 produces the exact file-by-file manifest as `docs/v2/phase_0/doc-reset-manifest.md`, reviewed like any other work item. Files whose disposition is unclear default to archive — recovery from git or `docs/archive/` is cheap; stale authority is not.
+
+## Consequences
+
+- Agents get a deterministic answer to "which document wins," at the cost of maintaining front-matter discipline going forward.
+- ADRs 0001–0016 stay useful as v1 context without ever being mistaken for v2 decisions.
+- The keep list makes `CLAUDE.md`/`README.md` references the de facto liveness test for v1 docs; both files should be updated in item 11 if their references change.
+- Roughly 110 files move in item 11 — a large but mechanical diff, reviewed via the manifest rather than file-by-file.
+
+## Related Documents
+
+- [ADR 0001](0001-documentation-authority-and-adr-lifecycle.md) — the v1 authority order this ADR supersedes for v2 questions (0001 remains an accurate historical note about v1 practice).
+- [Roadmap Phase 0](../v2/roadmap.md), [Phase 0 scope and plan](../v2/phase_0/scope-and-plan.md), [build-process](../v2/build-process.md).

--- a/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
+++ b/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
@@ -39,8 +39,12 @@ ADR files are the one exception to archive-means-move: they never relocate (stab
 
 New documents under `docs/` are named `type_slug.md`: a lowercase single-word type, an underscore, then a kebab-case slug (`spike_toolloop.md`, `plan_scope.md`, `inventory_port.md`). Everything before the first underscore is the type — machine-parseable without ambiguity, sorts a flat directory into type groups, and mirrors the v2 artifact model's `artifact_type`, which these documents will eventually feed via knowledge ingestion.
 
+These documents are primarily LLM-facing, which sets the design principle: predictability and self-description before opening. A regular convention lets an agent guess paths instead of spending tool calls exploring, and a self-describing name plus front-matter means type and authority are known from a directory listing and the first five lines of the file. Status deliberately stays out of filenames — a status transition must not break links or remembered paths.
+
 - Seed types: `plan`, `spike`, `inventory`, `manifest`, `requirements`, `design`, `process`, `research`, `notes`. Extend by use; prefer reuse over coinage.
 - Front-matter gains a fourth field, `type`, matching the filename prefix so name and metadata cannot drift apart.
+- Slugs favor full explicit words over abbreviations — filename tokens are cheap and orientation is not (`inventory_port-vs-rewrite.md`, not `inventory_pvr.md`).
+- Every directory under `docs/` maintains a `README.md` index with a one-line description per document — the highest-leverage aid for LLM readers, who consult one small index instead of opening files to find the right one. Item 11 creates the missing indexes.
 - Exceptions: ADRs keep the established `NNNN-slug.md` form (the sequence number is their type marker), and `README.md` remains `README.md`.
 - Existing documents are renamed to the convention during item 11 (`doc-reset`), where cross-references are rewritten anyway (e.g. `scope-and-plan.md` → `plan_scope.md`, `build-process.md` → `process_build.md`); new documents follow it immediately.
 

--- a/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
+++ b/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
@@ -24,7 +24,7 @@ The repo currently holds three generations of documentation: ADRs 0001–0016 (p
 
 ### Front-matter
 
-All markdown documents under `docs/` that are created or substantively edited from now on carry Hugo-style TOML front-matter with three fields: `title`, `edit_date`, and `status` ∈ {`draft`, `live`, `deprecated`, `archive`}.
+All markdown documents under `docs/` that are created or substantively edited from now on carry Hugo-style TOML front-matter with `title`, `edit_date`, `status` ∈ {`draft`, `live`, `deprecated`, `archive`}, and — for documents following the file-naming convention below — `type`.
 
 - `draft` — under review; not yet authoritative.
 - `live` — actively maintained, v2-era authority. Live status is earned by review, not by being referenced.
@@ -34,6 +34,15 @@ All markdown documents under `docs/` that are created or substantively edited fr
 The doc status and the ADR status are two views of one state: Proposed ↔ `draft`, Accepted ↔ `live`, Superseded/Rejected ↔ `archive`; the historical v1 notes (0001–0016) are `deprecated`. Phase artifacts follow the lifecycle defined in the [Phase 0 plan](../v2/phase_0/scope-and-plan.md): `draft` under review, `live` after both approvals, `archive` when the phase closes.
 
 ADR files are the one exception to archive-means-move: they never relocate (stable references), so for ADRs `archive`/Superseded is a status change in place.
+
+### File naming
+
+New documents under `docs/` are named `type_slug.md`: a lowercase single-word type, an underscore, then a kebab-case slug (`spike_toolloop.md`, `plan_scope.md`, `inventory_port.md`). Everything before the first underscore is the type — machine-parseable without ambiguity, sorts a flat directory into type groups, and mirrors the v2 artifact model's `artifact_type`, which these documents will eventually feed via knowledge ingestion.
+
+- Seed types: `plan`, `spike`, `inventory`, `manifest`, `requirements`, `design`, `process`, `research`, `notes`. Extend by use; prefer reuse over coinage.
+- Front-matter gains a fourth field, `type`, matching the filename prefix so name and metadata cannot drift apart.
+- Exceptions: ADRs keep the established `NNNN-slug.md` form (the sequence number is their type marker), and `README.md` remains `README.md`.
+- Existing documents are renamed to the convention during item 11 (`doc-reset`), where cross-references are rewritten anyway (e.g. `scope-and-plan.md` → `plan_scope.md`, `build-process.md` → `process_build.md`); new documents follow it immediately.
 
 ### Documentation authority
 
@@ -64,7 +73,7 @@ Executed in Phase 0 work item 11 (`doc-reset`); this ADR fixes the rules and the
 - Deprecated set (remain at their current locations, `status = "deprecated"`): the historical ADR notes 0001–0016, `docs/wiki/` (human-facing set, pending the wiki/docs-site decision), and the v1 operational docs still referenced by `CLAUDE.md` and `README.md` — currently `GIT.md`, `TESTING_STRATEGY.md`, `MAESTRO_LLMS_MIGRATION.md`, `ARCHITECT_CONTEXT.md`, `MAESTRO_CHAT_SPEC.md`, `HOTFIX_MODE_SPEC.md`, `MODES.md`, `AIRPLANE_MODE.md`, `MAINTENANCE_MODE_SPEC.md`, `OLLAMA.md`, `DOC_GRAPH.md`, plus `BENCHMARK_HOWTO.md` and `BENCHMARKS.md` as Phase 1 seeds and `WELCOME_TO_MAESTRO.md`. These are retained, unverified v1 references — not authority. Each flips to `archive` when its subject is ported, rewritten, or dropped, or its last reference is removed.
 - Everything else under `docs/` root and all of `docs/specs/` archives: these are v1 design specs, plans, and TODOs whose decisions are either implemented (the code is now the authority) or abandoned.
 - `docs/screenshots/` archives unless referenced by a kept document.
-- Item 11 produces the exact file-by-file manifest as `docs/v2/phase_0/doc-reset-manifest.md`, reviewed like any other work item. Files whose disposition is unclear default to archive — recovery from git or `docs/archive/` is cheap; stale authority is not.
+- Item 11 also executes the file-naming renames for existing live documents, and produces the exact file-by-file manifest as `docs/v2/phase_0/manifest_doc-reset.md`, reviewed like any other work item. Files whose disposition is unclear default to archive — recovery from git or `docs/archive/` is cheap; stale authority is not.
 
 ## Consequences
 

--- a/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
+++ b/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
@@ -24,9 +24,16 @@ The repo currently holds three generations of documentation: ADRs 0001–0016 (p
 
 ### Front-matter
 
-All markdown documents under `docs/` that are created or substantively edited from now on carry Hugo-style TOML front-matter with three fields: `title`, `edit_date`, and `status` ∈ {`draft`, `live`, `archive`}.
+All markdown documents under `docs/` that are created or substantively edited from now on carry Hugo-style TOML front-matter with three fields: `title`, `edit_date`, and `status` ∈ {`draft`, `live`, `deprecated`, `archive`}.
 
-The doc status and the ADR status are two views of one state: Proposed ↔ `draft`, Accepted ↔ `live`, Superseded/Rejected ↔ `archive`. Phase artifacts follow the lifecycle defined in the [Phase 0 plan](../v2/phase_0/scope-and-plan.md): `draft` under review, `live` after both approvals, `archive` when the phase closes.
+- `draft` — under review; not yet authoritative.
+- `live` — actively maintained, v2-era authority. Live status is earned by review, not by being referenced.
+- `deprecated` — describes the deprecated v1 system and has not been verified against current code. Subordinate to code, tests, and the FSM docs for runtime-behavior questions; never authoritative for v2 design. Retained in place only while something references or needs it; flips to `archive` when its subject is ported, rewritten, or dropped — the D8 inventory execution and phase completions are the natural triggers. A `deprecated` document contradicting a v2 ADR is not an inconsistency to fix; it is the transition state made explicit, exactly as the v1 code itself contradicts the v2 design until replaced.
+- `archive` — history; no authority for any question.
+
+The doc status and the ADR status are two views of one state: Proposed ↔ `draft`, Accepted ↔ `live`, Superseded/Rejected ↔ `archive`; the historical v1 notes (0001–0016) are `deprecated`. Phase artifacts follow the lifecycle defined in the [Phase 0 plan](../v2/phase_0/scope-and-plan.md): `draft` under review, `live` after both approvals, `archive` when the phase closes.
+
+ADR files are the one exception to archive-means-move: they never relocate (stable references), so for ADRs `archive`/Superseded is a status change in place.
 
 ### Documentation authority
 
@@ -37,6 +44,7 @@ For current runtime behavior (the code as it runs today):
 1. Code and tests.
 2. Canonical FSM docs: `pkg/pm/STATES.md`, `pkg/architect/STATES.md`, `pkg/coder/STATES.md`.
 3. Implementation summaries: `CLAUDE.md`, `README.md`.
+4. `deprecated` v1 docs — unverified hints, useful for orientation, always outranked by the above.
 
 For v2 design intent:
 
@@ -52,7 +60,8 @@ Documents with `status = "archive"` carry no authority for any question; they ar
 Executed in Phase 0 work item 11 (`doc-reset`); this ADR fixes the rules and the keep list.
 
 - Archived documents move to `docs/archive/`, preserving filenames, and receive `status = "archive"` front-matter. Git history preserves original paths; no redirects are maintained.
-- Keep list (remain live at their current locations): `docs/adr/`, `docs/v2/`, `docs/wiki/` (human-facing set, pending the wiki/docs-site decision), and the operational docs referenced by `CLAUDE.md` and `README.md` — currently `GIT.md`, `TESTING_STRATEGY.md`, `MAESTRO_LLMS_MIGRATION.md`, `ARCHITECT_CONTEXT.md`, `MAESTRO_CHAT_SPEC.md`, `HOTFIX_MODE_SPEC.md`, `MODES.md`, `AIRPLANE_MODE.md`, `MAINTENANCE_MODE_SPEC.md`, `OLLAMA.md`, `DOC_GRAPH.md`, plus `BENCHMARK_HOWTO.md` and `BENCHMARKS.md` as Phase 1 seeds and `WELCOME_TO_MAESTRO.md`. Kept v1 docs get front-matter with `status = "live"` and remain authoritative only for current runtime behavior.
+- Live set (remain at their current locations, `status = "live"`): `docs/adr/` v2 ADRs and `docs/v2/` — the actively maintained v2-era documents. Nothing inherits `live` by being referenced; live is earned by review.
+- Deprecated set (remain at their current locations, `status = "deprecated"`): the historical ADR notes 0001–0016, `docs/wiki/` (human-facing set, pending the wiki/docs-site decision), and the v1 operational docs still referenced by `CLAUDE.md` and `README.md` — currently `GIT.md`, `TESTING_STRATEGY.md`, `MAESTRO_LLMS_MIGRATION.md`, `ARCHITECT_CONTEXT.md`, `MAESTRO_CHAT_SPEC.md`, `HOTFIX_MODE_SPEC.md`, `MODES.md`, `AIRPLANE_MODE.md`, `MAINTENANCE_MODE_SPEC.md`, `OLLAMA.md`, `DOC_GRAPH.md`, plus `BENCHMARK_HOWTO.md` and `BENCHMARKS.md` as Phase 1 seeds and `WELCOME_TO_MAESTRO.md`. These are retained, unverified v1 references — not authority. Each flips to `archive` when its subject is ported, rewritten, or dropped, or its last reference is removed.
 - Everything else under `docs/` root and all of `docs/specs/` archives: these are v1 design specs, plans, and TODOs whose decisions are either implemented (the code is now the authority) or abandoned.
 - `docs/screenshots/` archives unless referenced by a kept document.
 - Item 11 produces the exact file-by-file manifest as `docs/v2/phase_0/doc-reset-manifest.md`, reviewed like any other work item. Files whose disposition is unclear default to archive — recovery from git or `docs/archive/` is cheap; stale authority is not.
@@ -61,7 +70,8 @@ Executed in Phase 0 work item 11 (`doc-reset`); this ADR fixes the rules and the
 
 - Agents get a deterministic answer to "which document wins," at the cost of maintaining front-matter discipline going forward.
 - ADRs 0001–0016 stay useful as v1 context without ever being mistaken for v2 decisions.
-- The keep list makes `CLAUDE.md`/`README.md` references the de facto liveness test for v1 docs; both files should be updated in item 11 if their references change.
+- The `deprecated` state makes the transition legible: no v1 document has to be either trusted or destroyed, and contradictions with v2 ADRs are expected rather than alarming.
+- The retained set makes `CLAUDE.md`/`README.md` references the de facto retention test for v1 docs; both files should be updated in item 11 if their references change.
 - Roughly 110 files move in item 11 — a large but mechanical diff, reviewed via the manifest rather than file-by-file.
 
 ## Related Documents

--- a/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
+++ b/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
@@ -1,7 +1,8 @@
 +++
 title = "ADR 0017: v2 Documentation Authority And Lifecycle"
-edit_date = "2026-07-12"
+edit_date = "2026-07-13"
 status = "draft"
+summary = "Defines v2 doc conventions: ADR numbering and acceptance lifecycle, front-matter schema, draft/live/deprecated/archive authority, type_slug.md naming, directory indexes, and the v1 doc archive plan."
 +++
 
 # 0017. v2 Documentation Authority And Lifecycle
@@ -24,7 +25,9 @@ The repo currently holds three generations of documentation: ADRs 0001–0016 (p
 
 ### Front-matter
 
-All markdown documents under `docs/` that are created or substantively edited from now on carry Hugo-style TOML front-matter with `title`, `edit_date`, `status` ∈ {`draft`, `live`, `deprecated`, `archive`}, and — for documents following the file-naming convention below — `type`.
+All markdown documents under `docs/` that are created or substantively edited from now on carry Hugo-style TOML front-matter with `title`, `edit_date`, `status` ∈ {`draft`, `live`, `deprecated`, `archive`}, `summary`, and — for documents following the file-naming convention below — `type`.
+
+`summary` is one tight sentence stating what the document contains and when to read it — a retrieval hook, not an abstract. It exists so an LLM can triage a file from its front-matter alone (~50 tokens) instead of reading it, and it is the single source for directory README indexes, which quote it rather than maintaining separate one-liners. It is also the document's future artifact-row line in the v2 artifact model.
 
 - `draft` — under review; not yet authoritative.
 - `live` — actively maintained, v2-era authority. Live status is earned by review, not by being referenced.

--- a/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
+++ b/docs/adr/0017-v2-documentation-authority-and-lifecycle.md
@@ -1,13 +1,13 @@
 +++
 title = "ADR 0017: v2 Documentation Authority And Lifecycle"
 edit_date = "2026-07-13"
-status = "draft"
+status = "live"
 summary = "Defines v2 doc conventions: ADR numbering and acceptance lifecycle, front-matter schema, draft/live/deprecated/archive authority, type_slug.md naming, directory indexes, and the v1 doc archive plan."
 +++
 
 # 0017. v2 Documentation Authority And Lifecycle
 
-Status: Proposed
+Status: Accepted (Codex + DR, 2026-07-13)
 
 ## Context
 
@@ -44,7 +44,7 @@ New documents under `docs/` are named `type_slug.md`: a lowercase single-word ty
 
 These documents are primarily LLM-facing, which sets the design principle: predictability and self-description before opening. A regular convention lets an agent guess paths instead of spending tool calls exploring, and a self-describing name plus front-matter means type and authority are known from a directory listing and the first five lines of the file. Status deliberately stays out of filenames — a status transition must not break links or remembered paths.
 
-- Seed types: `plan`, `spike`, `inventory`, `manifest`, `requirements`, `design`, `process`, `research`, `notes`. Extend by use; prefer reuse over coinage.
+- Seed types: `plan`, `spike`, `inventory`, `manifest`, `requirements`, `design`, `process`, `research`, `notes`. Prefer reuse; add a type only when a document class has repeated examples. `notes` is a temporary catchall — promote durable notes into a real type rather than letting `notes` become the junk drawer.
 - Front-matter gains a fourth field, `type`, matching the filename prefix so name and metadata cannot drift apart.
 - Slugs favor full explicit words over abbreviations — filename tokens are cheap and orientation is not (`inventory_port-vs-rewrite.md`, not `inventory_pvr.md`).
 - Every directory under `docs/` maintains a `README.md` index with a one-line description per document — the highest-leverage aid for LLM readers, who consult one small index instead of opening files to find the right one. Item 11 creates the missing indexes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,8 +11,9 @@ numbered sequence with two tiers:
 
 - **0001–0016: historical v1 notes.** Proposed current-state summaries of the v1
   implementation (as of 2026-07-06). They were never accepted as binding and never
-  will be; they remain useful context about how v1 works. v1 is deprecated as of
-  2026-07-11 (tag `v1-freeze`).
+  will be; they remain useful context about how v1 works and carry `deprecated`
+  status (stamped in the Phase 0 doc reset). v1 is deprecated as of 2026-07-11
+  (tag `v1-freeze`).
 - **0017+: v2 decisions.** These follow the lifecycle in
   [ADR 0017](0017-v2-documentation-authority-and-lifecycle.md): Proposed →
   Accepted (Codex + DR approval) → Superseded/Rejected. A v2 ADR that replaces a
@@ -22,10 +23,10 @@ numbered sequence with two tiers:
 
 Defined by [ADR 0017](0017-v2-documentation-authority-and-lifecycle.md). In short:
 for current runtime behavior — code and tests, then the canonical FSM docs
-(`pkg/*/STATES.md`), then `CLAUDE.md`/`README.md`. For v2 design intent — Accepted
-ADRs (0017+), then live phase artifacts in `docs/v2/phase_x/`, then the roadmap and
-cross-phase docs in `docs/v2/`, then the historical notes below. Archived documents
-carry no authority.
+(`pkg/*/STATES.md`), then `CLAUDE.md`/`README.md`, then `deprecated` v1 docs as
+unverified hints. For v2 design intent — Accepted ADRs (0017+), then live phase
+artifacts in `docs/v2/phase_x/`, then the roadmap and cross-phase docs in
+`docs/v2/`, then the historical notes below. Archived documents carry no authority.
 
 ## v2 ADRs
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,32 +1,33 @@
 # Architecture Decision Records
 
-This directory contains proposed Architecture Decision Records (ADRs) for Maestro.
+This directory contains Architecture Decision Records (ADRs) for Maestro, in a single
+numbered sequence with two tiers:
 
-The repository has many design specs, implementation notes, and historical plans in
-`docs/`. Those files are useful context, but they are not all equally current. These
-ADRs are intended to become the concise decision log that future implementation work
-and future agents can consult before reading older planning documents.
-
-## Status
-
-All ADRs in this initial batch are `Proposed`. They summarize the current code and
-the apparent intended design as of 2026-07-06. They should be reviewed, edited, and
-then either accepted, replaced, or deleted.
+- **0001–0016: historical v1 notes.** Proposed current-state summaries of the v1
+  implementation (as of 2026-07-06). They were never accepted as binding and never
+  will be; they remain useful context about how v1 works. v1 is deprecated as of
+  2026-07-11 (tag `v1-freeze`).
+- **0017+: v2 decisions.** These follow the lifecycle in
+  [ADR 0017](0017-v2-documentation-authority-and-lifecycle.md): Proposed →
+  Accepted (Codex + DR approval) → Superseded/Rejected. A v2 ADR that replaces a
+  historical note marks it Superseded explicitly.
 
 ## Documentation Authority
 
-Until an ADR is accepted, use this precedence when docs conflict:
+Defined by [ADR 0017](0017-v2-documentation-authority-and-lifecycle.md). In short:
+for current runtime behavior — code and tests, then the canonical FSM docs
+(`pkg/*/STATES.md`), then `CLAUDE.md`/`README.md`. For v2 design intent — Accepted
+ADRs (0017+), then live phase artifacts in `docs/v2/phase_x/`, then the roadmap and
+cross-phase docs in `docs/v2/`, then the historical notes below. Archived documents
+carry no authority.
 
-1. Actual code and tests.
-2. Canonical FSM docs in `pkg/pm/STATES.md`, `pkg/architect/STATES.md`, and
-   `pkg/coder/STATES.md`.
-3. Accepted ADRs in this directory.
-4. Current implementation summaries such as `CLAUDE.md`, `README.md`, and focused
-   docs like `docs/GIT.md`, `docs/TESTING_STRATEGY.md`, and
-   `docs/MAESTRO_LLMS_MIGRATION.md`.
-5. Older specs, plans, and TODO files under `docs/` and `docs/specs/`.
+## v2 ADRs
 
-## Proposed ADRs
+| ADR | Title | Status |
+| --- | --- | --- |
+| [0017](0017-v2-documentation-authority-and-lifecycle.md) | v2 documentation authority and lifecycle | Proposed |
+
+## Historical v1 Notes
 
 | ADR | Title |
 | --- | --- |
@@ -49,12 +50,15 @@ Until an ADR is accepted, use this precedence when docs conflict:
 
 ## ADR Format
 
-Each ADR should include:
+v2 ADRs (0017+) carry TOML front-matter (`title`, `edit_date`, `status`) and include:
 
 - `Status`: Proposed, Accepted, Superseded, or Rejected.
 - `Context`: Why this decision matters.
-- `Decision`: The intended design contract.
-- `Current Implementation`: Code paths that show the current state.
+- `Decision`: The design contract.
 - `Consequences`: Trade-offs and follow-up obligations.
-- `Related Documents`: Older docs that provide detail or history.
+- `Related Documents`: Sources, superseded notes, and history.
+- `Implementation Notes` (optional): code paths, when implementation exists.
+
+The historical notes (0001–0016) used a mandatory `Current Implementation` section
+instead, appropriate to their current-state purpose.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,6 +2,7 @@
 title = "Architecture Decision Records"
 edit_date = "2026-07-13"
 status = "live"
+summary = "Index of Maestro ADRs: the v2 decision sequence (0017+) and the deprecated historical v1 notes (0001-0016), with the documentation authority order in brief."
 +++
 
 # Architecture Decision Records

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,7 +33,7 @@ artifacts in `docs/v2/phase_x/`, then the roadmap and cross-phase docs in
 
 | ADR | Title | Status |
 | --- | --- | --- |
-| [0017](0017-v2-documentation-authority-and-lifecycle.md) | v2 documentation authority and lifecycle | Proposed |
+| [0017](0017-v2-documentation-authority-and-lifecycle.md) | v2 documentation authority and lifecycle | Accepted |
 
 ## Historical v1 Notes
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,9 @@
++++
+title = "Architecture Decision Records"
+edit_date = "2026-07-13"
+status = "live"
++++
+
 # Architecture Decision Records
 
 This directory contains Architecture Decision Records (ADRs) for Maestro, in a single

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,7 +58,7 @@ artifacts in `docs/v2/phase_x/`, then the roadmap and cross-phase docs in
 
 ## ADR Format
 
-v2 ADRs (0017+) carry TOML front-matter (`title`, `edit_date`, `status`) and include:
+v2 ADRs (0017+) carry TOML front-matter (`title`, `edit_date`, `status`, `summary`) and include:
 
 - `Status`: Proposed, Accepted, Superseded, or Rejected.
 - `Context`: Why this decision matters.

--- a/docs/v2/build-process.md
+++ b/docs/v2/build-process.md
@@ -2,6 +2,7 @@
 title = "Maestro v2 Build Process (Interim)"
 edit_date = "2026-07-13"
 status = "live"
+summary = "Working agreement for building v2 until Maestro can build Maestro: Claude authors, Codex reviews, DR orchestrates and accepts; branching, review cadence, spikes, testing, and merge rules."
 +++
 
 # Maestro v2 Build Process (Interim)

--- a/docs/v2/build-process.md
+++ b/docs/v2/build-process.md
@@ -33,6 +33,11 @@ An artifact is Accepted when both Codex and DR have approved it.
 - CI runs automated review agents on every PR. All of their feedback must be resolved before merge: each thread is either fixed or explicitly pushed back on with a reasoned reply, then marked resolved. Resolving CI reviewer feedback is Claude's job.
 - Final approval and the merge button are DR's.
 
+## Spikes
+
+- Before a spike begins, all open document work is committed (risk minimization).
+- Spike code never merges into app packages (`pkg/`, `internal/`, `cmd/`). Reports land in the phase directory; scripts worth revisiting may be preserved under `spikes/phase_x/`, a standalone module excluded from the main build, test, and lint walkers. Preserved scripts are unmaintained by definition.
+
 ## Deferred Work Tracking
 
 All deferred work discovered during v2 development is tracked as GitHub Issues — a durable record that keeps the primary docs and repo clean and does not rely on any one agent's memory. The division of labor: the roadmap holds planned work (phases and spikes), Issues hold deferred work discovered along the way, and the docs/v2 parking lot holds design ideas.

--- a/docs/v2/build-process.md
+++ b/docs/v2/build-process.md
@@ -1,6 +1,12 @@
++++
+title = "Maestro v2 Build Process (Interim)"
+edit_date = "2026-07-13"
+status = "live"
++++
+
 # Maestro v2 Build Process (Interim)
 
-Status: agreed working agreement, 2026-07-11
+Status: live — agreed working agreement, 2026-07-11.
 
 This defines how v2 gets built until Maestro can build Maestro (the Phase 9 ramp). It manually implements the generate/review invariant that Maestro v2 automates: one author, one reviewer, human escalation.
 

--- a/docs/v2/phase_0/scope-and-plan.md
+++ b/docs/v2/phase_0/scope-and-plan.md
@@ -1,12 +1,12 @@
 +++
 title = "Maestro v2 Phase 0: Scope And Plan"
 edit_date = "2026-07-12"
-status = "draft"
+status = "live"
 +++
 
 # Phase 0: v2 Design Groundwork — Scope And Plan
 
-Status: draft. Per [build-process.md](../build-process.md), the scope and the plan each require Codex and DR approval before Phase 0 work items start.
+Status: live — approved by Codex and DR, 2026-07-12, per [build-process.md](../build-process.md).
 
 Status lifecycle (applies to all phase artifacts): `draft` while under review; flipped to `live` after both approvals, as the final commit before merge and before any work items start; `archive` when the phase completes and the document becomes a historical record. Work item 1 formalizes this lifecycle as part of the front-matter convention.
 
@@ -25,7 +25,7 @@ In scope:
 
 Out of scope:
 
-- Implementation code. Spike code is throwaway and never merges.
+- Implementation code. Spike code never merges into app packages; scripts worth revisiting may be preserved under `spikes/phase_0/` (see sequencing notes).
 - Golden story and runner *implementation* (Phase 1) — but their ADR is in scope and Phase 0 exit-blocking.
 - The final intake executor design (pre-Phase-5 spike). Phase 0 fixes only the intake artifact contract and orchestrator seam.
 - Postgres DDL and migrations (Phase 2). Phase 0 decides the stack and schema families only.
@@ -36,6 +36,8 @@ The v2 product thesis and MPH definition already exist in the roadmap and README
 ## Deliverables And PR Sequence
 
 One short-lived branch per item (`v2/phase_0/XXX`), one open at a time, single end-of-work review each per the build process. Order respects dependencies; sizes are rough (S under a day of review-ready work, M a few days).
+
+Deliverable locations: ADRs land in `docs/adr/` (continuing the single 0017+ sequence); all other deliverables — spike reports, the port inventory, checklists — land in this directory (`docs/v2/phase_0/`). The backlog reconciliation edits the existing cross-phase docs at the `docs/v2/` root.
 
 | # | Branch suffix | Deliverable | Size |
 |---|---|---|---|
@@ -58,6 +60,8 @@ Sequencing notes:
 - Items 8 and 9 have no ADR dependencies and are the designated slack: if an ADR review stalls, a spike proceeds without violating the one-branch rule (the stalled branch closes or merges first).
 - Item 2 bundles three closely coupled conceptual ADRs for review coherence. If it runs large, the plan's checkpoint mechanism applies: review checkpoint after the taxonomy ADR before the other two are drafted.
 - Item 7 is deliberately last of the ADRs: it consumes the artifact model (3), data plane families (4), and branching (5).
+- Before a spike begins, all open document work is committed — risk minimization against spike churn.
+- Spike scripts worth revisiting may be preserved under `spikes/phase_0/`, which must be its own Go module (own `go.mod`) so `go build ./...`, `go test ./...`, and lint walkers exclude it. Spike code never lives under `pkg/`, `internal/`, or `cmd/`. The report remains the deliverable; preserved scripts are a courtesy to the future, not a maintained surface.
 
 ## Exit Checklist
 

--- a/docs/v2/phase_0/scope-and-plan.md
+++ b/docs/v2/phase_0/scope-and-plan.md
@@ -1,6 +1,6 @@
 +++
 title = "Maestro v2 Phase 0: Scope And Plan"
-edit_date = "2026-07-12"
+edit_date = "2026-07-13"
 status = "live"
 summary = "Approved Phase 0 scope and execution plan: 13 serial work items (ADRs, two spikes, port inventory, doc reset) with sizes, ordering, exit checklist, and resolved reviewer questions."
 +++

--- a/docs/v2/phase_0/scope-and-plan.md
+++ b/docs/v2/phase_0/scope-and-plan.md
@@ -2,6 +2,7 @@
 title = "Maestro v2 Phase 0: Scope And Plan"
 edit_date = "2026-07-12"
 status = "live"
+summary = "Approved Phase 0 scope and execution plan: 13 serial work items (ADRs, two spikes, port inventory, doc reset) with sizes, ordering, exit checklist, and resolved reviewer questions."
 +++
 
 # Phase 0: v2 Design Groundwork — Scope And Plan


### PR DESCRIPTION
## Summary

Phase 0 work item 1 (`adr-lifecycle`), per the [Phase 0 plan](../blob/main/docs/v2/phase_0/scope-and-plan.md). First ADR in the v2 sequence.

### ADR 0017 decides

- **Single ADR sequence** (per the resolved reviewer question): 0001–0016 are formally historical v1 notes — useful context, never binding, never to be Accepted. v2 decisions continue at 0017.
- **ADR lifecycle**: Proposed → Accepted (Codex + DR approval; status flips as the final commit on the PR, **and merge waits until that commit is visible** — the rule yesterday's race demonstrated the need for) → Superseded/Rejected.
- **Front-matter convention**: TOML (`title`, `edit_date`, `status` ∈ draft/live/archive) on all new/edited docs; the ADR status vocabulary maps onto the doc status vocabulary (Proposed↔draft, Accepted↔live, Superseded↔archive).
- **Question-dependent authority**: current runtime behavior resolves through code → FSM docs → CLAUDE.md/README; v2 design intent resolves through Accepted ADRs → live phase artifacts → docs/v2 → historical notes. Archived docs carry no authority for anything.
- **Archive plan** (rules + keep list; execution is item 11): ~130 v1-era docs move to `docs/archive/`; keep list is `docs/adr/`, `docs/v2/`, the wiki set, and the operational docs referenced by CLAUDE.md/README. Unclear disposition defaults to archive. Item 11 produces a reviewable file-by-file manifest.

The ADR README is restructured into the two tiers (v2 ADRs table + historical notes), and ADR 0017 itself carries the front-matter and lifecycle it mandates.

### Also in this PR

- Cherry-pick of the approved-but-lost final commit from #240 (deliverable locations, spike rules, build-process Spikes section, status flip to `live`) — the #240 merge raced the push and GitHub deleted the branch mid-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)