### PR TITLE
docs(adr): ADR 0023 — v2 branch strategy; unconditional human Accept doctrine (Phase 0, item 5)

### DIFF
--- a/docs/adr/0020-review-invariant-reviewer-vs-partner.md
+++ b/docs/adr/0020-review-invariant-reviewer-vs-partner.md
@@ -7,7 +7,7 @@ summary = "Canonical statement of the symmetric review invariant (every Manageme
 
 # 0020. The Review Invariant — Reviewer vs Partner/Supervisor
 
-Status: Accepted (Codex + DR, 2026-07-13); amended 2026-07-13 (code review is review, not a human reservation)
+Status: Accepted (Codex + DR, 2026-07-13); amended 2026-07-13 (code review is review, not a human reservation); amended 2026-07-13 (human Accept is unconditional — auto-merge waiver withdrawn)
 
 ## Context
 
@@ -43,7 +43,7 @@ Homogeneous review — author and reviewer on the same model — is a permitted 
 
 ### Human-reserved approvals
 
-The invariant has a ceiling: some approvals are reserved to the human operator by default and can never be satisfied by agent review alone — canonically, final acceptance that an Epic is complete (the Epic-to-default merge, roadmap D4). Agents review; humans accept. The reservation is independent of tempo. It may be waived only by an explicit, recorded configuration choice (D4's auto-merge for low-risk Epics) — which is itself a human policy act, not a review outcome standing in for the human.
+The invariant has a ceiling: some approvals are reserved to the human operator and can never be satisfied by agent review alone — canonically, final acceptance that an Epic is complete (the Epic-to-default merge, roadmap D4). Agents review; humans accept. The reservation is independent of tempo and is **unconditional** (amended 2026-07-13: the earlier low-risk auto-merge waiver is withdrawn). Acceptance is not about risk — it is outcome validation, whether the work solves the need, and no risk assessment can stand in for the one answer only the human holds. Accepting a trivial Epic costs one glance at its evidence, because acceptance is not code review; the click is cheap and the invariant is load-bearing.
 
 ### Code review is review, not a human reservation
 

--- a/docs/adr/0023-v2-branch-strategy.md
+++ b/docs/adr/0023-v2-branch-strategy.md
@@ -1,0 +1,62 @@
++++
+title = "ADR 0023: v2 Branch Strategy"
+edit_date = "2026-07-13"
+status = "draft"
+summary = "Maps git structure to the work hierarchy: Epic branches off default, Story branches off Epic; automated Story merges on passing evidence, human Accept for Epic-to-default; rebase as a harness function; branch naming for machine and human branches."
++++
+
+# 0023. v2 Branch Strategy
+
+Status: Proposed
+
+## Context
+
+v1 merges every Story directly to the default branch, which makes the Epic-level integration and acceptance unit invisible in git. ADR 0018 makes the mapping explicit — Story is the local implementation/review unit, Epic the integration/acceptance unit, Feature the cross-repo intent unit — and the git model should mirror it one-to-one. An agent fleet also needs branch conventions that are deterministic and collision-free (the `v2/roadmap` leaf-vs-namespace collision during the v2 build demonstrated the failure mode).
+
+## Decision
+
+### The mapping
+
+- **Feature** owns no branch — it may span repositories and is coordinated through artifacts, not git.
+- **Epic** owns one branch per Epic, cut from the default branch head of its repository.
+- **Story** owns one branch, cut from its Epic branch head; Story branches merge back into the Epic branch.
+- The **Epic branch merges into default** only on acceptance (roadmap D4): human Accept by default, waivable per Epic by explicit recorded configuration for low-risk cases.
+
+### Merge policy
+
+- **Story → Epic** merges are automated when the Story's evidence passes review (roadmap pillar 8) — the Architect's review record is the gate, not a human click.
+- **Epic → default** is the human acceptance gate (ADR 0020's human-reserved approval). This creates deliberate back-pressure in large Features (D4); the dashboard makes the queue visible.
+- Merged Story branches are deleted; Epic branches are deleted after acceptance. Golden-story fixture branches are cleaned per the benchmark ADR (item 7).
+
+### Rebase is a harness function
+
+Keeping Story branches current against the Epic head, and Epic branches current against default, is scheduled harness work — not an incidental git operation left to agent whim. The split follows ADR 0019's boundary rule: a mechanically clean rebase is Orchestrator work; a conflict requiring judgment spawns an agent — dispatched as a conflict-resolution Story or a Workbench session (roadmap pillar 6). The Orchestrator never resolves a conflict by inference, because it can't.
+
+### Diff semantics
+
+v1's phantom-diff prevention carries forward, retargeted to the hierarchy: review diffs use merge-base semantics against the branch one level up — Story diffs against the Epic branch, Epic diffs against default — so a review never contains changes that arrived from elsewhere. Reviewers obtain diffs themselves (fresh `get_diff`-style calls); diffs are never delivered as stale payload.
+
+### Branch naming
+
+Machine-managed branches are namespaced away from human branches:
+
+- `maestro/epic/<epic-id>` and `maestro/story/<epic-id>/<story-id>` for runtime branches. IDs, not titles — deterministic, collision-free, and stable under renames.
+- Human development branches keep their own namespaces (during the v2 build: `v2/phase_x/*`, `v2/fix/*` per the build process).
+- The leaf-vs-namespace rule is law: a name once used as a leaf branch is never reused as a namespace prefix, and the ID-based scheme above is constructed so the situation cannot arise (`maestro/epic/<id>` is always a leaf; `maestro/story/<epic-id>/` is always a namespace).
+
+### What carries forward
+
+The clone/mirror/forge workflow of historical note [0009](0009-clone-mirror-and-forge-pr-workflow.md) is kept and extended: local bare mirrors, forge-mediated PRs, and branch protection on default remain; only the branch topology above it changes. Forge bindings are repo attributes (ADR 0022), so the strategy is forge-independent — an Epic branch behaves identically on a local airplane-mode forge and on GitHub.
+
+## Consequences
+
+- The git graph mirrors the work hierarchy, so dashboards and golden stories can derive integration state from git itself rather than shadow bookkeeping.
+- Long-lived Epic branches make rebase cadence a real harness parameter (an H lever in MPH) — measurable by the golden suite's merge-conflict stories.
+- The automated Story→Epic merge concentrates CI attention where it belongs: Story-level checks gate the automated merge; Epic-level integration checks gate the human Accept.
+- Phase 4 implements exactly this ADR (branch creation, both merge paths, rebase functions, conflict dispatch); its exit criteria already match.
+
+## Related Documents
+
+- [ADR 0018](0018-v2-work-taxonomy.md) (the hierarchy and its git mapping), [ADR 0019](0019-orchestrator-boundary.md) (mechanical-vs-judgment split), [ADR 0020](0020-review-invariant-reviewer-vs-partner.md) (review gates, human-reserved Accept), [ADR 0022](0022-v2-data-plane.md) (forge-independent repos).
+- [Roadmap](../v2/roadmap.md) pillars 6 and 8, D4; [build-process](../v2/build-process.md) (human branch conventions); [ADR backlog](../v2/adr-backlog.md) Branch Strategy entry.
+- Historical note [0009](0009-clone-mirror-and-forge-pr-workflow.md) (kept and extended; superseded only in branch topology).

--- a/docs/adr/0023-v2-branch-strategy.md
+++ b/docs/adr/0023-v2-branch-strategy.md
@@ -2,7 +2,7 @@
 title = "ADR 0023: v2 Branch Strategy"
 edit_date = "2026-07-13"
 status = "live"
-summary = "Maps git structure to the work hierarchy: Epic branches off default, Story branches off Epic; automated Story merges on passing evidence, human Accept for Epic-to-default; rebase as a harness function; branch naming for machine and human branches."
+summary = "Maps git structure to the work hierarchy: Epic branches off default, Story branches off Epic; automated Story→Epic merges, human Accept for Epic→default; reviewed history immutability; naming for Orchestrator-managed branches."
 +++
 
 # 0023. v2 Branch Strategy

--- a/docs/adr/0023-v2-branch-strategy.md
+++ b/docs/adr/0023-v2-branch-strategy.md
@@ -1,13 +1,13 @@
 +++
 title = "ADR 0023: v2 Branch Strategy"
 edit_date = "2026-07-13"
-status = "draft"
+status = "live"
 summary = "Maps git structure to the work hierarchy: Epic branches off default, Story branches off Epic; automated Story merges on passing evidence, human Accept for Epic-to-default; rebase as a harness function; branch naming for machine and human branches."
 +++
 
 # 0023. v2 Branch Strategy
 
-Status: Proposed
+Status: Accepted (Codex + DR, 2026-07-13)
 
 ## Context
 

--- a/docs/adr/0023-v2-branch-strategy.md
+++ b/docs/adr/0023-v2-branch-strategy.md
@@ -20,29 +20,31 @@ v1 merges every Story directly to the default branch, which makes the Epic-level
 - **Feature** owns no branch — it may span repositories and is coordinated through artifacts, not git.
 - **Epic** owns one branch per Epic, cut from the default branch head of its repository.
 - **Story** owns one branch, cut from its Epic branch head; Story branches merge back into the Epic branch.
-- The **Epic branch merges into default** only on acceptance (roadmap D4): human Accept by default, waivable per Epic by explicit recorded configuration for low-risk cases.
+- The **Epic branch merges into default as part of human acceptance** — the conceptual big green Accept after UAT (roadmap D4). Acceptance always belongs to the human (ADR 0020); what the human chooses is inspection depth — dig into the code, or rely on the evidence and reviews. The merge is implicit in the Accept, not a separate decision.
 
 ### Merge policy
 
-- **Story → Epic** merges are automated when the Story's evidence passes review (roadmap pillar 8) — the Architect's review record is the gate, not a human click.
-- **Epic → default** is the human acceptance gate (ADR 0020's human-reserved approval). This creates deliberate back-pressure in large Features (D4); the dashboard makes the queue visible.
+- **Story → Epic** merges execute when the Architect's review record completes after final code review (roadmap pillar 8) — the review record is the gate, not a human click.
+- **Epic → default** executes when the human's Accept is recorded after UAT (ADR 0020's human-reserved approval). This creates deliberate back-pressure in large Features (D4); the dashboard makes the queue visible.
 - Merged Story branches are deleted; Epic branches are deleted after acceptance. Golden-story fixture branches are cleaned per the benchmark ADR (item 7).
 
-### Rebase is a harness function
+### Rebase and merge are harness functions
 
 Keeping Story branches current against the Epic head, and Epic branches current against default, is scheduled harness work — not an incidental git operation left to agent whim. The split follows ADR 0019's boundary rule: a mechanically clean rebase is Orchestrator work; a conflict requiring judgment spawns an agent — dispatched as a conflict-resolution Story or a Workbench session (roadmap pillar 6). The Orchestrator never resolves a conflict by inference, because it can't.
+
+**Merging itself is exclusively a harness function.** Agents resolve conflicts and update PRs; only the harness merges, and only when the workflow rules are satisfied — Story to Epic on the Architect's completed review record, Epic to default on the recorded human Accept. Workbench presets may adjust trigger conditions, but never the rule that only the harness merges.
 
 ### Diff semantics
 
 v1's phantom-diff prevention carries forward, retargeted to the hierarchy: review diffs use merge-base semantics against the branch one level up — Story diffs against the Epic branch, Epic diffs against default — so a review never contains changes that arrived from elsewhere. Reviewers obtain diffs themselves (fresh `get_diff`-style calls); diffs are never delivered as stale payload.
 
-### Branch naming
+### Branch naming (Orchestrator-created branches only)
 
-Machine-managed branches are namespaced away from human branches:
+Scope: this ADR governs branches the Orchestrator creates at runtime. The conventions for building Maestro v2 itself are the build process's concern and are unchanged here.
 
-- `maestro/epic/<epic-id>` and `maestro/story/<epic-id>/<story-id>` for runtime branches. IDs, not titles — deterministic, collision-free, and stable under renames.
-- Human development branches keep their own namespaces (during the v2 build: `v2/phase_x/*`, `v2/fix/*` per the build process).
-- The leaf-vs-namespace rule is law: a name once used as a leaf branch is never reused as a namespace prefix, and the ID-based scheme above is constructed so the situation cannot arise (`maestro/epic/<id>` is always a leaf; `maestro/story/<epic-id>/` is always a namespace).
+- `maestro/epic/<epic-id>` and `maestro/story/<story-id>`. IDs, not titles — deterministic and stable under renames. Story IDs are globally unique, so the flat form is collision-free without encoding the Epic in the name; parentage is data-plane lineage (ADR 0018), not ref-name payload.
+- The `maestro/` prefix marks machine-managed refs, keeping them disjoint from every human branch namespace.
+- The leaf-vs-namespace rule is law: a name once used as a leaf branch is never reused as a namespace prefix. The fixed two-level scheme makes the collision structurally impossible — `maestro/epic/` and `maestro/story/` are always namespaces, IDs are always leaves.
 
 ### What carries forward
 

--- a/docs/adr/0023-v2-branch-strategy.md
+++ b/docs/adr/0023-v2-branch-strategy.md
@@ -30,9 +30,19 @@ v1 merges every Story directly to the default branch, which makes the Epic-level
 
 ### Rebase and merge are harness functions
 
-Keeping Story branches current against the Epic head, and Epic branches current against default, is scheduled harness work — not an incidental git operation left to agent whim. The split follows ADR 0019's boundary rule: a mechanically clean rebase is Orchestrator work; a conflict requiring judgment spawns an agent — dispatched as a conflict-resolution Story or a Workbench session (roadmap pillar 6). The Orchestrator never resolves a conflict by inference, because it can't.
+Keeping branches current is scheduled harness work — not an incidental git operation left to agent whim — with one hard constraint: **reviewed history is immutable**. Once Stories have merged into an Epic branch, that branch carries reviewed work whose evidence binds commit and branch provenance (ADR 0021); rewriting it would orphan the evidence. Therefore:
+
+- **Story branches rebase** against the Epic head before their merge — in-flight work, standard PR flow.
+- **Epic branches never rebase.** They take default through history-preserving merge commits on a scheduled cadence (the cadence is an H lever in MPH).
+
+Conflict resolution follows ADR 0019's boundary rule — the Orchestrator detects conflicts mechanically and never resolves them, because resolution requires inference:
+
+- **Story-level**: a rebase conflict routes back to the owning Coder to fix (v1 already has this flow).
+- **Epic-level**: when the Architect signals ready to merge — or a scheduled sync-merge from default conflicts — the Orchestrator detects the conflict and routes it to the Architect, who mints a supplementary conflict-resolution Story (late-bound Stories, ADR 0018); on its completion the merge retries. When a human is present, a Workbench session is the interactive alternative (roadmap pillar 6).
 
 **Merging itself is exclusively a harness function.** Agents resolve conflicts and update PRs; only the harness merges, and only when the workflow rules are satisfied — Story to Epic on the Architect's completed review record, Epic to default on the recorded human Accept. Workbench presets may adjust trigger conditions, but never the rule that only the harness merges.
+
+Enforcement is structural, not aspirational: machine-managed integration refs — `maestro/epic/*` and the default branch — are writable only by the harness. Agents may push Story branches and update PRs; they can never mutate Epic or default refs directly, so review records and the Accept gate cannot be bypassed. Enforced via forge branch protection where available plus credential scoping; mechanics are Phase 4 implementation detail, the invariant is not.
 
 ### Diff semantics
 
@@ -42,7 +52,7 @@ v1's phantom-diff prevention carries forward, retargeted to the hierarchy: revie
 
 Scope: this ADR governs branches the Orchestrator creates at runtime. The conventions for building Maestro v2 itself are the build process's concern and are unchanged here.
 
-- `maestro/epic/<epic-id>` and `maestro/story/<story-id>`. IDs, not titles — deterministic and stable under renames. Story IDs are globally unique, so the flat form is collision-free without encoding the Epic in the name; parentage is data-plane lineage (ADR 0018), not ref-name payload.
+- `maestro/epic/<epic-id>` and `maestro/story/<story-id>`. IDs, not titles — deterministic and stable under renames. Both Epic and Story IDs are globally unique, branch-safe opaque identifiers (no `/`, forge-safe character set), so the flat forms are collision-free without encoding parentage in the name; parentage is data-plane lineage (ADR 0018), not ref-name payload.
 - The `maestro/` prefix marks machine-managed refs, keeping them disjoint from every human branch namespace.
 - The leaf-vs-namespace rule is law: a name once used as a leaf branch is never reused as a namespace prefix. The fixed two-level scheme makes the collision structurally impossible — `maestro/epic/` and `maestro/story/` are always namespaces, IDs are always leaves.
 
@@ -53,7 +63,7 @@ The clone/mirror/forge workflow of historical note [0009](0009-clone-mirror-and-
 ## Consequences
 
 - The git graph mirrors the work hierarchy, so dashboards and golden stories can derive integration state from git itself rather than shadow bookkeeping.
-- Long-lived Epic branches make rebase cadence a real harness parameter (an H lever in MPH) — measurable by the golden suite's merge-conflict stories.
+- Long-lived Epic branches make sync-merge cadence a real harness parameter (an H lever in MPH) — measurable by the golden suite's merge-conflict stories.
 - The automated Story→Epic merge concentrates CI attention where it belongs: Story-level checks gate the automated merge; Epic-level integration checks gate the human Accept.
 - Phase 4 implements exactly this ADR (branch creation, both merge paths, rebase functions, conflict dispatch); its exit criteria already match.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ artifacts in `docs/v2/phase_x/`, then the roadmap and cross-phase docs in
 | [0020](0020-review-invariant-reviewer-vs-partner.md) | The review invariant — Reviewer vs Partner/Supervisor | Accepted |
 | [0021](0021-artifacts-and-principal-instances.md) | Artifacts and principal instances | Accepted |
 | [0022](0022-v2-data-plane.md) | v2 data plane | Accepted |
+| [0023](0023-v2-branch-strategy.md) | v2 branch strategy | Proposed |
 
 ## Historical v1 Notes
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,7 +39,7 @@ artifacts in `docs/v2/phase_x/`, then the roadmap and cross-phase docs in
 | [0020](0020-review-invariant-reviewer-vs-partner.md) | The review invariant — Reviewer vs Partner/Supervisor | Accepted |
 | [0021](0021-artifacts-and-principal-instances.md) | Artifacts and principal instances | Accepted |
 | [0022](0022-v2-data-plane.md) | v2 data plane | Accepted |
-| [0023](0023-v2-branch-strategy.md) | v2 branch strategy | Proposed |
+| [0023](0023-v2-branch-strategy.md) | v2 branch strategy | Accepted |
 
 ## Historical v1 Notes
 

--- a/docs/v2/adr-backlog.md
+++ b/docs/v2/adr-backlog.md
@@ -1,6 +1,13 @@
++++
+title = "Maestro v2 ADR Backlog"
+edit_date = "2026-07-13"
+status = "live"
+summary = "Concepts that need ADRs before implementation, with key questions per candidate; reconciled and dependency-ordered in Phase 0 item 12."
++++
+
 # Maestro v2 ADR Backlog
 
-Status: rough companion note
+Status: live — actively maintained; reconciled in Phase 0 item 12.
 
 These are concepts that likely need ADRs before implementation. They are listed here to keep the main roadmap readable.
 

--- a/docs/v2/adr-backlog.md
+++ b/docs/v2/adr-backlog.md
@@ -180,7 +180,7 @@ Key questions:
 - What exactly does the trailing agent reviewer check (syntax, rules, architectural drift), and when does it run?
 - What of the session transcript becomes evidence versus Audit-only data?
 - Budgets/limits for open-ended sessions.
-- Can Workbench merges to the Epic branch auto-accept given human presence and a clean drift check?
+- Within a Workbench session, can Story-to-Epic merges execute on the present human's approval plus a clean trailing drift check, without a separate Architect review record? (Epic-to-default always requires the human Accept — ADR 0020.)
 - Promotion path when a session outgrows its scope.
 
 ### UAT And Demo Mode

--- a/docs/v2/provenance-matrix.md
+++ b/docs/v2/provenance-matrix.md
@@ -84,6 +84,9 @@ Source categories:
 | Tool call as the Audit action unit | DR notes | An LLM call without a tool call does nothing; LLM call records are token/cost metrics and optional traces (ADR 0022). |
 | Object storage first-class with pluggable interface | DR notes | Local and cloud use different products; the contract is fixed, implementations plug in; retention pins apply to objects. |
 | Generalized persistence interface + cloud auth mini-app | DR notes | Auth, data, and object persistence as pluggable modules per mode; cloud is not "point at another database" (ADR 0022). |
+| Unconditional human Accept; auto-merge withdrawn | DR notes | Acceptance is outcome validation (need solved), not risk management; the D4 low-risk auto-merge idea is withdrawn from 0020/D4/pillar 8 (2026-07-13). |
+| Reviewed history is immutable; Epic branches never rebase | Codex synthesis | Evidence binds commit provenance; Epics sync default via history-preserving merges; only Story branches rebase (ADR 0023). |
+| Epic conflict flow via supplementary Story | DR notes | Orchestrator detects, Architect mints a conflict-resolution Story, merge retries — the Story-level flow one level up. |
 | Golden build tags (`golden-minimal`/`golden-all`) | DR notes | Extends the existing `integration` build-tag pattern to automate golden story runs. |
 | Artifact scope model (`scope_type`/`scope_id` + lineage) | Codex synthesis | Pre-Epic Feature artifacts, Product/org artifacts, and benchmark artifacts do not hang off an Epic. |
 | Phase 1 target strategy (minimally patched v1 path) | Codex synthesis, DR notes | Codex surfaced the missing-target problem; DR resolved it: post-freeze main is v2 raw material, patched just enough for golden-minimal. |

--- a/docs/v2/roadmap.md
+++ b/docs/v2/roadmap.md
@@ -1,8 +1,14 @@
-# Maestro v2 Roadmap Draft
++++
+title = "Maestro v2 Roadmap"
+edit_date = "2026-07-13"
+status = "live"
+summary = "The v2 roadmap: thesis, economic argument, vocabulary, 17 design pillars, phases 0-9 with exit criteria, and decisions D1-D10. Decisions are progressively ratified into ADRs (0017+), which outrank this document."
++++
 
-Date: 2026-07-10
-Revised: 2026-07-12 (intake/triage revision; earlier Claude review pass 2026-07-11)
-Status: rough roadmap for review
+# Maestro v2 Roadmap
+
+Date: 2026-07-10; revised through 2026-07-13.
+Status: live planning document — decisions are progressively ratified into ADRs (0017+), which outrank this roadmap for v2 design intent.
 
 This document blends:
 

--- a/docs/v2/roadmap.md
+++ b/docs/v2/roadmap.md
@@ -731,7 +731,7 @@ Open design questions (parked until the ADR):
 - What exactly does the trailing agent reviewer check, and when does it run?
 - How much of the session transcript becomes evidence versus Audit-only data?
 - Budgets and limits for open-ended interactive sessions.
-- Can Workbench merges to the Epic branch auto-accept given human presence plus a clean trailing drift check?
+- Within a Workbench session, can Story-to-Epic merges execute on the present human's approval plus a clean trailing drift check, without a separate Architect review record? (Epic-to-default always requires the human Accept — ADR 0020.)
 
 ## Proposed Sequencing
 

--- a/docs/v2/roadmap.md
+++ b/docs/v2/roadmap.md
@@ -448,7 +448,7 @@ Recommended default:
 
 - Story-to-Epic branch merge can be automated when Story evidence passes.
 - Epic-to-default merge should default to human Accept.
-- Config can later allow Epic auto-merge for low-risk Epics.
+- (Withdrawn 2026-07-13: the earlier idea of config-based Epic auto-merge for low-risk Epics. Acceptance is outcome validation, not risk management — see ADR 0020.)
 
 Demo Mode likely becomes the foundation for UAT. It is not conceptually hard, but it becomes much cleaner after artifacts, gates, and Epic branches exist.
 
@@ -1095,7 +1095,7 @@ The Epic plan cites requirements; it never restates them. If intent changes, the
 
 Agreed answer:
 
-Default no. Require human Accept for Epic branch to default. Allow config-based auto-merge later for low-risk Epics with clean evidence and passing gates.
+No — unconditionally (revised 2026-07-13). Human Accept is required for every Epic-to-default merge. The earlier low-risk auto-merge idea is withdrawn: acceptance is outcome validation — does the work solve the need — which has nothing to do with risk, and no risk assessment can stand in for it (ADR 0020). Accepting a trivial Epic costs one glance at evidence, because acceptance is not code review.
 
 This is the right human-level gate. Note that it creates deliberate back-pressure in large automated Features: the dependency graph cannot unblock downstream Epics until upstream Epics merge. The dashboard should make that queue visible so the operator can see when they are the bottleneck.
 


### PR DESCRIPTION
## Summary

Phase 0 work item 5, fully reviewed in place (one DR round, one Codex round, plus a doctrinal hash-out) and flipped to Accepted (Codex + DR, 2026-07-13). Single round-ending push.

### ADR 0023 — v2 Branch Strategy

- **The mapping**: Feature owns no branch; Epic branch off default; Story branch off Epic head. The Epic-to-default merge is **implicit in the human's post-UAT Accept** — the human always accepts the work; the only variable is inspection depth.
- **Reviewed history is immutable**: Story branches rebase pre-merge; Epic branches never rebase — they sync default via history-preserving merge commits (evidence binds commit provenance per ADR 0021).
- **Conflict flows, self-similar at both levels**: Story rebase conflicts route to the owning Coder (v1's existing flow); Epic conflicts are detected by the Orchestrator and routed to the Architect, who mints a supplementary conflict-resolution Story, then the merge retries. Workbench session as the interactive alternative.
- **Merging is exclusively a harness function**, structurally enforced: `maestro/epic/*` and default are writable only by the harness (forge protection + credential scoping); agents push Story branches and PRs, never integration refs.
- **Naming** (Orchestrator-created branches only): `maestro/epic/<epic-id>`, `maestro/story/<story-id>` — globally unique, branch-safe opaque IDs; parentage is data-plane lineage, not ref-name payload; the two-level scheme makes leaf-vs-namespace collisions structurally impossible.
- Merge-base diff semantics retargeted one level up; clone/mirror/forge workflow from historical 0009 kept.

### Doctrine: Epic auto-merge withdrawn

Settled during review, per DR: **human Accept at the Epic level is unconditional.** Acceptance is outcome validation — does the work solve the need — which has nothing to do with risk; no risk assessment can stand in for the one answer only the human holds. The low-risk auto-merge waiver is withdrawn from ADR 0020 (second amendment), roadmap D4, and pillar 8; the Workbench open question is rephrased to avoid "auto-accept." Provenance matrix records the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)