### PR TITLE
docs(v2): flip Phase 1 plan and index to live — missed lifecycle step from #259

### DIFF
--- a/docs/v2/phase_1/README.md
+++ b/docs/v2/phase_1/README.md
@@ -1,7 +1,7 @@
 +++
 title = "Phase 1 Artifacts"
-edit_date = "2026-07-15"
-status = "draft"
+edit_date = "2026-07-16"
+status = "live"
 summary = "Index of Phase 1 working artifacts: the scope/plan for the golden story runner and measurement harness; later the v1 patch record, D9 policy record, and cost-instrumentation report."
 +++
 
@@ -9,6 +9,6 @@ summary = "Index of Phase 1 working artifacts: the scope/plan for the golden sto
 
 Working artifacts of Phase 1 (golden stories and measurement harness), produced under the [build process](../process_build.md) and the [Phase 1 plan](plan_scope.md). The binding specification for the phase is [ADR 0025](../../adr/0025-golden-stories-and-benchmark-runner.md); these documents carry the work that executes it.
 
-- [Maestro v2 Phase 1: Scope And Plan](plan_scope.md) — Proposed Phase 1 scope and execution plan: build the golden story runner per ADR 0025 — 11 serial work items covering the runner module, fixtures, the v1-as-patched target, the single-agent baseline, D9 cost instrumentation, and the first 5-10 stories.
+- [Maestro v2 Phase 1: Scope And Plan](plan_scope.md) — Approved Phase 1 scope and execution plan: build the golden story runner per ADR 0025 — 11 serial work items covering the runner module, fixtures, the v1-as-patched target, the single-agent baseline, D9 cost instrumentation, and the first 5-10 stories.
 
 Expected to land here as the phase executes: the fixture conventions doc (item 2), the v1 patch record (item 5), the D9 policy record and cost-instrumentation report (item 6), and the phase exit baseline report (item 10).

--- a/docs/v2/phase_1/plan_scope.md
+++ b/docs/v2/phase_1/plan_scope.md
@@ -1,14 +1,14 @@
 +++
 title = "Maestro v2 Phase 1: Scope And Plan"
-edit_date = "2026-07-15"
-status = "draft"
-summary = "Proposed Phase 1 scope and execution plan: build the golden story runner per ADR 0025 — 11 serial work items covering the runner module, fixtures, the v1-as-patched target, the single-agent baseline, D9 cost instrumentation, and the first 5-10 stories."
+edit_date = "2026-07-16"
+status = "live"
+summary = "Approved Phase 1 scope and execution plan: build the golden story runner per ADR 0025 — 11 serial work items covering the runner module, fixtures, the v1-as-patched target, the single-agent baseline, D9 cost instrumentation, and the first 5-10 stories."
 type = "plan"
 +++
 
 # Phase 1: Golden Stories And Measurement Harness — Scope And Plan
 
-Status: draft — under review per [process_build.md](../process_build.md). Flips to `live` after Codex and DR approval, as the final commit before merge; flips to `archive` when Phase 1 closes (lifecycle per ADR 0017 and the Phase 0 precedent).
+Status: live — approved by Codex and DR, 2026-07-15 (PR #259; the status flip landed one commit late, in a follow-up). Flips to `archive` when Phase 1 closes (lifecycle per ADR 0017 and the Phase 0 precedent).
 
 Goal (from the [roadmap](../plan_roadmap.md)): build the measuring instrument before rewriting the machine.
 


### PR DESCRIPTION
The Phase 1 scope-and-plan was Accepted (Codex + DR, 2026-07-15) but #259 merged before the draft→live flip that should have been the final pre-merge commit per ADR 0017's lifecycle. This corrects the record:

- `plan_scope.md` and `phase_1/README.md` front-matter: `draft` → `live`, edit_date bumped.
- Plan status line records the approval and notes the flip landed one commit late.
- Summary moves "Proposed" → "Approved" (Phase 0 parity); README index re-quotes it verbatim.

Docs-only; no content changes to the approved plan. Uses `v2/fix/` per the build process so it can ride alongside the first Phase 1 work branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)