### PR TITLE
feat(benchmark): fixtures — pinned golden-fixture repos + first three stories (Phase 1, item 2)

### DIFF
--- a/benchmark/stories/README.md
+++ b/benchmark/stories/README.md
@@ -1,18 +1,27 @@
 +++
 title = "Golden Stories"
 edit_date = "2026-07-16"
-status = "live"
-summary = "Authored golden story definitions (TOML, one file per story), validated against the story schema on load. First definitions land with Phase 1 item 2 (fixtures)."
+status = "draft"
+summary = "Authored golden story definitions (TOML, one file per story), validated against the story schema in CI. The first three ladder rungs — dependency bump, small cleanup, focused bug fix — against the pinned golden-fixture repos."
 +++
 
 # Golden Stories
 
 Authored golden story definitions: TOML, one file per story, strict keys,
-validated against `story.SchemaVersion` on load. Definitions reference
-pinned external fixture repositories — see the schema in
-[`../story/`](../story/story.go) and the fixture conventions doc (Phase 1
-item 2, forthcoming).
+validated against `story.SchemaVersion` by `stories_test.go` in CI.
+Definitions reference pinned fixture repositories — see the schema in
+[`../story/`](../story/story.go) and the
+[fixture conventions](../../docs/v2/phase_1/process_fixtures.md).
 
-The first 3 definitions land with item 2 (`fixtures`); the suite grows to
-5–10 in item 9 (`stories-suite`), which also assigns the `golden-minimal`
-and `golden-all` tiers.
+The ladder's first three rungs:
+
+- `dep-bump-xnet` — dependency bump on `golden-fixture-cms`.
+- `cleanup-provider-options` — small code cleanup on `golden-fixture-chat`
+  (natural duplication, not seeded).
+- `bugfix-openai-stopreason` — focused bug fix on `golden-fixture-llms`,
+  pinned at the parent of the real upstream fix (solution not in history).
+
+Definitions are drafts until the runner executes them (items 3–5 make
+them runnable; item 6 fixes budgets from instrumented costs). The suite
+grows to 5–10 in item 9 (`stories-suite`), which also assigns the
+`golden-minimal` and `golden-all` tiers.

--- a/benchmark/stories/README.md
+++ b/benchmark/stories/README.md
@@ -1,7 +1,7 @@
 +++
 title = "Golden Stories"
 edit_date = "2026-07-16"
-status = "draft"
+status = "live"
 summary = "Authored golden story definitions (TOML, one file per story), validated against the story schema in CI. The first three ladder rungs — dependency bump, small cleanup, focused bug fix — against the pinned golden-fixture repos."
 +++
 

--- a/benchmark/stories/bugfix-openai-stopreason.toml
+++ b/benchmark/stories/bugfix-openai-stopreason.toml
@@ -1,0 +1,65 @@
+# Golden story: ladder rung 3 (focused bug fix).
+# The fixture is truncated at the parent of the real upstream fix
+# (maestro-llms 92eceb8), so the solution is not present anywhere in
+# history — see docs/v2/phase_1/process_fixtures.md.
+schema_version = 1
+id = "bugfix-openai-stopreason"
+title = "Surface the real OpenAI finish reason instead of the envelope status"
+level = "story"
+
+[fixture]
+repo = "https://github.com/SnapdragonPartners/golden-fixture-llms"
+commit = "d5078df1dc3e304e9f1327e29ecfb48d1998f3dc"
+base_branch = "main"
+
+[prompt]
+text = """
+Bug report: a chat request through the OpenAI adapter that hits the
+max-output-token limit returns StopReason "incomplete". That is the
+Responses envelope status, not a finish reason — the real reason
+("max_output_tokens" or "content_filter") is only reachable by type
+asserting Raw, which is outside the toolkit's stability contract.
+Every other adapter (anthropic, google, ollama) passes the raw provider
+finish reason through StopReason.
+
+Fix the OpenAI chat adapter so consumers can detect length truncation
+and content filtering from StopReason alone: when the response status is
+incomplete and a more specific reason is present, surface that reason;
+otherwise keep the current status behavior. Tool calls present on a
+truncated response must still be surfaced. Add hermetic tests (no live
+API calls) covering the truncation reason, the incomplete-without-reason
+fallback, and tool-call preservation on a truncated response.
+"""
+
+[expectations]
+allowed_paths = ["llms/providers/openai/", "docs/"]
+required_artifacts = ["pr"]
+evidence_shape = ["diff", "test-output"]
+
+[[validators]]
+name = "build"
+command = "go build ./..."
+
+[[validators]]
+name = "test"
+command = "go test ./..."
+
+[[checks]]
+name = "diff-confined-to-openai-adapter"
+type = "files_changed_within"
+
+[[checks]]
+name = "fix-reads-incomplete-details"
+type = "file_contains"
+path = "llms/providers/openai/chatconvert.go"
+contains = "IncompleteDetails"
+
+[[checks]]
+name = "openai-tests-pass"
+type = "command"
+command = "go test ./llms/providers/openai/..."
+
+[budget]
+max_tokens = 400000
+max_wall_clock_seconds = 2700
+max_cost_usd = 8.0

--- a/benchmark/stories/bugfix-openai-stopreason.toml
+++ b/benchmark/stories/bugfix-openai-stopreason.toml
@@ -1,7 +1,11 @@
 # Golden story: ladder rung 3 (focused bug fix).
 # The fixture is truncated at the parent of the real upstream fix
-# (maestro-llms 92eceb8), so the solution is not present anywhere in
-# history — see docs/v2/phase_1/process_fixtures.md.
+# (maestro-llms 92eceb8) so the solution is not in history, and carries
+# SEEDED regression tests (stopreason_seed_test.go, sourced from that
+# fix's test additions) that fail at the base and pass when solved —
+# acceptance is behavioral, independent of agent-authored tests. The
+# seed-tests-untouched check pins the seed file against the base commit.
+# See docs/v2/phase_1/process_fixtures.md.
 schema_version = 1
 id = "bugfix-openai-stopreason"
 title = "Surface the real OpenAI finish reason instead of the envelope status"
@@ -9,7 +13,7 @@ level = "story"
 
 [fixture]
 repo = "https://github.com/SnapdragonPartners/golden-fixture-llms"
-commit = "d5078df1dc3e304e9f1327e29ecfb48d1998f3dc"
+commit = "891dce215ef5c27cf575020e98f29bb876d96abc"
 base_branch = "main"
 
 [prompt]
@@ -26,9 +30,11 @@ Fix the OpenAI chat adapter so consumers can detect length truncation
 and content filtering from StopReason alone: when the response status is
 incomplete and a more specific reason is present, surface that reason;
 otherwise keep the current status behavior. Tool calls present on a
-truncated response must still be surfaced. Add hermetic tests (no live
-API calls) covering the truncation reason, the incomplete-without-reason
-fallback, and tool-call preservation on a truncated response.
+truncated response must still be surfaced.
+
+The failing tests in llms/providers/openai/stopreason_seed_test.go
+express the expected behavior; make them pass without modifying that
+file. Add your own tests for anything you change beyond what they cover.
 """
 
 [expectations]
@@ -49,10 +55,9 @@ name = "diff-confined-to-openai-adapter"
 type = "files_changed_within"
 
 [[checks]]
-name = "fix-reads-incomplete-details"
-type = "file_contains"
-path = "llms/providers/openai/chatconvert.go"
-contains = "IncompleteDetails"
+name = "seed-tests-untouched"
+type = "command"
+command = "git diff --exit-code 891dce215ef5c27cf575020e98f29bb876d96abc -- llms/providers/openai/stopreason_seed_test.go"
 
 [[checks]]
 name = "openai-tests-pass"

--- a/benchmark/stories/cleanup-provider-options.toml
+++ b/benchmark/stories/cleanup-provider-options.toml
@@ -1,0 +1,54 @@
+# Golden story: ladder rung 2 (small code cleanup).
+schema_version = 1
+id = "cleanup-provider-options"
+title = "Consolidate the duplicated per-provider option functions"
+level = "story"
+
+[fixture]
+repo = "https://github.com/SnapdragonPartners/golden-fixture-chat"
+commit = "91514c98f944ca6a8a93a518429d4da0645a2c87"
+base_branch = "main"
+
+[prompt]
+text = """
+providers.go builds one ModelOption per provider through five
+near-identical functions (anthropicOption, openAIOption, googleOption,
+ollamaOption, vllmOption): each looks up environment credentials,
+constructs a client, lists models under the shared timeout, selects a
+model, and returns a ModelOption. Consolidate this duplication behind a
+shared helper so each provider contributes only what genuinely differs
+(its credential lookup, its client constructor, and its model-selection
+rule — Gemini orders by the version embedded in the ID, Ollama takes the
+most recently pulled model, vLLM takes the first served model).
+
+This is a refactor: observable behavior must not change, including the
+provider prefixes in log messages and the order providers appear in the
+model dropdown.
+"""
+
+[expectations]
+allowed_paths = ["providers.go"]
+required_artifacts = ["pr"]
+evidence_shape = ["diff"]
+
+[[validators]]
+name = "build"
+command = "go build ./..."
+
+[[validators]]
+name = "vet"
+command = "go vet ./..."
+
+[[checks]]
+name = "diff-confined-to-providers"
+type = "files_changed_within"
+
+[[checks]]
+name = "gofmt-clean"
+type = "command"
+command = "sh -c 'test -z \"$(gofmt -l .)\"'"
+
+[budget]
+max_tokens = 250000
+max_wall_clock_seconds = 1800
+max_cost_usd = 5.0

--- a/benchmark/stories/cleanup-provider-options.toml
+++ b/benchmark/stories/cleanup-provider-options.toml
@@ -1,4 +1,11 @@
 # Golden story: ladder rung 2 (small code cleanup).
+# Consolidation is verified structurally: the fixture base has 5 call
+# sites each of .ListModels(, "construct failed", and "ListModels failed"
+# (one per provider); a real consolidation collapses each to a shared
+# helper. The <= 2 thresholds tolerate one idiosyncratic path without
+# admitting the unconsolidated original. Hermetic regression tests are
+# deliberately not seeded: the refactor's entire surface is internal, so
+# tests would pin the very names the refactor is free to change.
 schema_version = 1
 id = "cleanup-provider-options"
 title = "Consolidate the duplicated per-provider option functions"
@@ -6,7 +13,7 @@ level = "story"
 
 [fixture]
 repo = "https://github.com/SnapdragonPartners/golden-fixture-chat"
-commit = "91514c98f944ca6a8a93a518429d4da0645a2c87"
+commit = "e71d51bb8486137d8bf8fdf18da8913c3c021edd"
 base_branch = "main"
 
 [prompt]
@@ -44,9 +51,26 @@ name = "diff-confined-to-providers"
 type = "files_changed_within"
 
 [[checks]]
-name = "gofmt-clean"
+name = "listmodels-call-sites-consolidated"
 type = "command"
-command = "sh -c 'test -z \"$(gofmt -l .)\"'"
+command = "sh -c 'test \"$(grep -c \"\\.ListModels(\" providers.go)\" -le 2'"
+
+[[checks]]
+name = "construct-log-consolidated"
+type = "command"
+command = "sh -c 'test \"$(grep -c \"construct failed\" providers.go)\" -le 2'"
+
+[[checks]]
+name = "listmodels-log-consolidated"
+type = "command"
+command = "sh -c 'test \"$(grep -c \"ListModels failed\" providers.go)\" -le 2'"
+
+[[checks]]
+# Scoped to the story's one allowed file: the fixture's server.go ships
+# from upstream with minor gofmt drift (realistic friction, out of scope).
+name = "gofmt-clean-providers"
+type = "command"
+command = "sh -c 'test -z \"$(gofmt -l providers.go)\"'"
 
 [budget]
 max_tokens = 250000

--- a/benchmark/stories/dep-bump-xnet.toml
+++ b/benchmark/stories/dep-bump-xnet.toml
@@ -1,0 +1,50 @@
+# Golden story: ladder rung 1 (dependency bump).
+schema_version = 1
+id = "dep-bump-xnet"
+title = "Bump golang.org/x/net to the latest release and keep the build green"
+level = "story"
+
+[fixture]
+repo = "https://github.com/SnapdragonPartners/golden-fixture-cms"
+commit = "e7a7422bad4dec726b62eec2cd6d759cd7780deb"
+base_branch = "main"
+
+[prompt]
+text = """
+Update the golang.org/x/net dependency of this module to the latest
+available release. Do not change any other direct dependency. The module
+must still build and its tests must still pass.
+"""
+
+[expectations]
+allowed_paths = ["go.mod", "go.sum"]
+required_artifacts = ["pr"]
+evidence_shape = ["diff", "test-output"]
+
+[[validators]]
+name = "build"
+command = "go build ./..."
+
+[[validators]]
+name = "test"
+command = "go test ./..."
+
+[[checks]]
+name = "diff-confined-to-module-files"
+type = "files_changed_within"
+
+[[checks]]
+name = "xnet-no-longer-at-pinned-version"
+type = "command"
+command = "sh -c '! grep -q \"golang.org/x/net v0.55.0\" go.mod'"
+
+[[checks]]
+name = "xnet-still-required"
+type = "file_contains"
+path = "go.mod"
+contains = "golang.org/x/net v"
+
+[budget]
+max_tokens = 150000
+max_wall_clock_seconds = 1200
+max_cost_usd = 3.0

--- a/benchmark/stories/dep-bump-xnet.toml
+++ b/benchmark/stories/dep-bump-xnet.toml
@@ -1,7 +1,9 @@
 # Golden story: ladder rung 1 (dependency bump).
+# The target version is pinned so identical MPH runs receive identical
+# tasks; the other-direct-deps checks make "only x/net moved" deterministic.
 schema_version = 1
 id = "dep-bump-xnet"
-title = "Bump golang.org/x/net to the latest release and keep the build green"
+title = "Bump golang.org/x/net to v0.57.0 and keep the build green"
 level = "story"
 
 [fixture]
@@ -11,9 +13,9 @@ base_branch = "main"
 
 [prompt]
 text = """
-Update the golang.org/x/net dependency of this module to the latest
-available release. Do not change any other direct dependency. The module
-must still build and its tests must still pass.
+Update the golang.org/x/net dependency of this module from v0.55.0 to
+v0.57.0. Do not change any other direct dependency. The module must
+still build and its tests must still pass.
 """
 
 [expectations]
@@ -34,15 +36,34 @@ name = "diff-confined-to-module-files"
 type = "files_changed_within"
 
 [[checks]]
-name = "xnet-no-longer-at-pinned-version"
-type = "command"
-command = "sh -c '! grep -q \"golang.org/x/net v0.55.0\" go.mod'"
-
-[[checks]]
-name = "xnet-still-required"
+name = "xnet-at-target-version"
 type = "file_contains"
 path = "go.mod"
-contains = "golang.org/x/net v"
+contains = "golang.org/x/net v0.57.0"
+
+[[checks]]
+name = "storage-dep-unchanged"
+type = "file_contains"
+path = "go.mod"
+contains = "cloud.google.com/go/storage v1.62.3"
+
+[[checks]]
+name = "llms-dep-unchanged"
+type = "file_contains"
+path = "go.mod"
+contains = "github.com/SnapdragonPartners/maestro-llms v0.7.1"
+
+[[checks]]
+name = "pdf-dep-unchanged"
+type = "file_contains"
+path = "go.mod"
+contains = "github.com/dslipak/pdf v0.0.2"
+
+[[checks]]
+name = "googleapi-dep-unchanged"
+type = "file_contains"
+path = "go.mod"
+contains = "google.golang.org/api v0.274.0"
 
 [budget]
 max_tokens = 150000

--- a/benchmark/stories/stories_test.go
+++ b/benchmark/stories/stories_test.go
@@ -1,0 +1,25 @@
+// Package stories_test validates every authored golden story definition in
+// this directory: strict schema, unique IDs, and the Phase 1 constraint
+// that stories are Story-scoped (ADR 0025).
+package stories_test
+
+import (
+	"testing"
+
+	"github.com/SnapdragonPartners/maestro/benchmark/story"
+)
+
+func TestAuthoredStoriesAreValid(t *testing.T) {
+	loaded, err := story.LoadDir(".")
+	if err != nil {
+		t.Fatalf("stories directory must load cleanly: %v", err)
+	}
+	if len(loaded) == 0 {
+		t.Fatalf("no story definitions found")
+	}
+	for _, one := range loaded {
+		if one.Definition.Level != story.LevelStory {
+			t.Errorf("%s: Phase 1 stories are single-repo and Story-scoped, got level %q", one.Definition.ID, one.Definition.Level)
+		}
+	}
+}

--- a/docs/v2/phase_1/README.md
+++ b/docs/v2/phase_1/README.md
@@ -11,5 +11,6 @@ Working artifacts of Phase 1 (golden stories and measurement harness), produced 
 
 - [Maestro v2 Phase 1: Scope And Plan](plan_scope.md) — Approved Phase 1 scope and execution plan: build the golden story runner per ADR 0025 — 11 serial work items covering the runner module, fixtures, the v1-as-patched target, the single-agent baseline, D9 cost instrumentation, and the first 5-10 stories.
 - [Design: Benchmark Runner Module Contracts (Item 1)](design_runner.md) — Design sketch for the runner-skeleton work item: module layout, the run-record and four-state metric contracts, story and MPH bundle schemas, the results store, the adapter interface with its engine/adapter division of labor, and build wiring.
+- [Fixture Conventions For Golden Stories](process_fixtures.md) — The golden story fixture repositories (pinned variants of maestro-llms, maestro-cms, and the extracted chat app), their provenance, and the conventions that keep them honest: pinned immutable bases, solution-leakage truncation, no tags, run-branch cleanup, and the re-pin procedure.
 
 Expected to land here as the phase executes: the fixture conventions doc (item 2), the v1 patch record (item 5), the D9 policy record and cost-instrumentation report (item 6), and the phase exit baseline report (item 10).

--- a/docs/v2/phase_1/process_fixtures.md
+++ b/docs/v2/phase_1/process_fixtures.md
@@ -15,9 +15,9 @@ Golden stories run against **fixture repositories**: pinned, purpose-held varian
 
 | Fixture | Source provenance | `main` head | Role |
 |---|---|---|---|
-| [`golden-fixture-llms`](https://github.com/SnapdragonPartners/golden-fixture-llms) | `maestro-llms`, history **truncated** at `d5078df1dc3e304e9f1327e29ecfb48d1998f3dc` (the parent of upstream fix `92eceb8`) | `d5078df1dc3e304e9f1327e29ecfb48d1998f3dc` | Library fixture; the bug-fix rung runs here against the pre-fix state |
+| [`golden-fixture-llms`](https://github.com/SnapdragonPartners/golden-fixture-llms) | `maestro-llms`, history **truncated** at `d5078df1dc3e304e9f1327e29ecfb48d1998f3dc` (the parent of upstream fix `92eceb8`), plus one seeded commit: `stopreason_seed_test.go` — the upstream fix's regression tests, seeded without the fix so acceptance is behavioral | `891dce215ef5c27cf575020e98f29bb876d96abc` | Library fixture; the bug-fix rung runs here against the pre-fix state |
 | [`golden-fixture-cms`](https://github.com/SnapdragonPartners/golden-fixture-cms) | `maestro-cms` at `e7a7422bad4dec726b62eec2cd6d759cd7780deb` (full history) | `e7a7422bad4dec726b62eec2cd6d759cd7780deb` | Library fixture; dependency-bump and later rungs |
-| [`golden-fixture-chat`](https://github.com/SnapdragonPartners/golden-fixture-chat) | `maestro-llms@6d9a7aa` `examples/chat`, extracted standalone: module repointed, toolkit dependency pinned to `v0.7.1`, provenance note in its README (fresh single-commit history) | `91514c98f944ca6a8a93a518429d4da0645a2c87` | The app-bearing fixture; cleanup and later app-change rungs |
+| [`golden-fixture-chat`](https://github.com/SnapdragonPartners/golden-fixture-chat) | `maestro-llms@6d9a7aa` `examples/chat`, extracted standalone: module repointed, toolkit dependency pinned to `v0.7.1`, provenance note in its README; second commit corrects the README's stale monorepo/`replace`-directive language | `e71d51bb8486137d8bf8fdf18da8913c3c021edd` | The app-bearing fixture; cleanup and later app-change rungs |
 
 ## Resolution Of ADR 0025's "LLM-tester CLI App"
 
@@ -28,16 +28,17 @@ ADR 0025 names "the standalone LLM-tester CLI app from the toolkit repos" as the
 1. **Stories pin commits, not branches.** Every story definition carries a full 40-hex commit; the runner checks out that commit into a fresh run-scoped workspace (ADR 0025 repeat isolation). The fixture's `main` is a human convenience, not an input.
 2. **Fixture `main` never advances casually.** A fixture moves only by the deliberate re-pin procedure below. Fixtures are never tracked against their upstreams automatically (Phase 1 plan risk list).
 3. **No solution leakage.** A fixture whose story is "fix this bug" must not contain the future fix anywhere reachable — history is truncated at the story's base commit (`golden-fixture-llms` is cut at the parent of the upstream fix), and **no tags are pushed** to any fixture (a tag could reference a descendant carrying the solution).
-4. **Fixtures are variants, and deltas carry provenance.** Any difference from source (the chat app's extraction: module path, version pin, README note) is recorded in the fixture's README and in the table above. Seeded warts, if a future story ever needs one, follow the same rule: recorded, never silent.
-5. **Run-branch cleanup.** Everything a run creates in a fixture lives under its run-scoped branch namespace and is deleted after every run (ADR 0023's cleanup rule via ADR 0025). A run whose cleanup cannot be verified is recorded `invalid`. Fixture default branches are never written by runs.
-6. **Fixtures are not dependencies.** No Maestro module may import fixture code; fixtures exist only to be cloned by the runner. They are public (their sources are public) and marked "not maintained" in their descriptions.
+4. **Fixtures are variants, and deltas carry provenance.** Any difference from source (the chat app's extraction: module path, version pin, README note) is recorded in the fixture's README and in the table above. Seeded content follows the same rule: recorded, never silent.
+5. **Seeded regression tests make bug-fix acceptance behavioral.** A bug-fix story's expected behavior is expressed by tests seeded into the fixture (sourced from the real upstream fix where one exists), failing at the base and passing when solved — never by agent-authored tests, which cannot independently prove the behavior, and never by string-presence checks, which are gameable. Seed files declare themselves off-limits, and the story carries a deterministic check that the seed file is byte-identical to the base commit.
+6. **Run-branch cleanup.** Everything a run creates in a fixture lives under its run-scoped branch namespace and is deleted after every run (ADR 0023's cleanup rule via ADR 0025). A run whose cleanup cannot be verified is recorded `invalid`. Fixture default branches are never written by runs.
+7. **Fixtures are not dependencies.** No Maestro module may import fixture code; fixtures exist only to be cloned by the runner. They are public (their sources are public) and marked "not maintained" in their descriptions.
 
 ## Re-Pin Procedure
 
 To move a fixture base (new rung requirements, upstream refresh):
 
 1. Choose the new commit in the source repo; for bug-fix stories, choose the parent of the target fix and verify no descendant leaks the solution.
-2. Push that history to the fixture (force-push of `main` is acceptable here — fixtures are not collaborative repos; open runs pin old commits and are unaffected as long as the old objects remain reachable, so prefer additive pushes when possible).
+2. **Re-pins are additive — force-pushes are prohibited.** Every base commit any story definition has ever referenced must remain reachable from a ref, or a fresh clone cannot fetch it and old run records become unreproducible. New bases land as descendants of `main`, or as a new immutable `base/<story-id>` branch when the base is not a descendant. If the needed history genuinely diverges from what the fixture holds (e.g. a pre-fix cut *earlier* than the existing truncation), create a **new fixture repo** rather than rewriting this one.
 3. Update the provenance table above and the affected story definitions' `fixture.commit` in the same PR — the story hash changes with it, keeping run records comparable-by-identity.
 
 ## Related Documents

--- a/docs/v2/phase_1/process_fixtures.md
+++ b/docs/v2/phase_1/process_fixtures.md
@@ -1,0 +1,47 @@
++++
+title = "Fixture Conventions For Golden Stories"
+edit_date = "2026-07-16"
+status = "draft"
+summary = "The golden story fixture repositories (pinned variants of maestro-llms, maestro-cms, and the extracted chat app), their provenance, and the conventions that keep them honest: pinned immutable bases, solution-leakage truncation, no tags, run-branch cleanup, and the re-pin procedure."
++++
+
+# Fixture Conventions For Golden Stories
+
+Status: draft — Phase 1 item 2 (`fixtures`), under [ADR 0025](../../adr/0025-golden-stories-and-benchmark-runner.md) and the [Phase 1 plan](plan_scope.md). Flips to `live` on item 2 approval.
+
+Golden stories run against **fixture repositories**: pinned, purpose-held variants of real codebases under the SnapdragonPartners GitHub org (the plan's ratified reviewer question 4). Fixtures give stories realistic brownfield friction without depending on the source repos' ongoing motion.
+
+## The Fixture Repositories
+
+| Fixture | Source provenance | `main` head | Role |
+|---|---|---|---|
+| [`golden-fixture-llms`](https://github.com/SnapdragonPartners/golden-fixture-llms) | `maestro-llms`, history **truncated** at `d5078df1dc3e304e9f1327e29ecfb48d1998f3dc` (the parent of upstream fix `92eceb8`) | `d5078df1dc3e304e9f1327e29ecfb48d1998f3dc` | Library fixture; the bug-fix rung runs here against the pre-fix state |
+| [`golden-fixture-cms`](https://github.com/SnapdragonPartners/golden-fixture-cms) | `maestro-cms` at `e7a7422bad4dec726b62eec2cd6d759cd7780deb` (full history) | `e7a7422bad4dec726b62eec2cd6d759cd7780deb` | Library fixture; dependency-bump and later rungs |
+| [`golden-fixture-chat`](https://github.com/SnapdragonPartners/golden-fixture-chat) | `maestro-llms@6d9a7aa` `examples/chat`, extracted standalone: module repointed, toolkit dependency pinned to `v0.7.1`, provenance note in its README (fresh single-commit history) | `91514c98f944ca6a8a93a518429d4da0645a2c87` | The app-bearing fixture; cleanup and later app-change rungs |
+
+## Resolution Of ADR 0025's "LLM-tester CLI App"
+
+ADR 0025 names "the standalone LLM-tester CLI app from the toolkit repos" as the starting app-bearing fixture. A search of both toolkit repos finds exactly one standalone application (`package main` with its own `go.mod`): `maestro-llms/examples/chat` — an LLM-tester that exercises every provider through one UI, explicitly designed to be copied out of the monorepo. It serves a local web page rather than being a pure CLI; this does not violate the ADR's constraint, which is about **evidence** ("no browser tooling required"): the low-rung stories against it validate through `go build`/`go vet`, not browser evidence. This document records that resolution; item 2's approval confirms it. (App-change stories with behavioral evidence remain deferred per the ADR until browser/evidence tooling exists.)
+
+## Conventions
+
+1. **Stories pin commits, not branches.** Every story definition carries a full 40-hex commit; the runner checks out that commit into a fresh run-scoped workspace (ADR 0025 repeat isolation). The fixture's `main` is a human convenience, not an input.
+2. **Fixture `main` never advances casually.** A fixture moves only by the deliberate re-pin procedure below. Fixtures are never tracked against their upstreams automatically (Phase 1 plan risk list).
+3. **No solution leakage.** A fixture whose story is "fix this bug" must not contain the future fix anywhere reachable — history is truncated at the story's base commit (`golden-fixture-llms` is cut at the parent of the upstream fix), and **no tags are pushed** to any fixture (a tag could reference a descendant carrying the solution).
+4. **Fixtures are variants, and deltas carry provenance.** Any difference from source (the chat app's extraction: module path, version pin, README note) is recorded in the fixture's README and in the table above. Seeded warts, if a future story ever needs one, follow the same rule: recorded, never silent.
+5. **Run-branch cleanup.** Everything a run creates in a fixture lives under its run-scoped branch namespace and is deleted after every run (ADR 0023's cleanup rule via ADR 0025). A run whose cleanup cannot be verified is recorded `invalid`. Fixture default branches are never written by runs.
+6. **Fixtures are not dependencies.** No Maestro module may import fixture code; fixtures exist only to be cloned by the runner. They are public (their sources are public) and marked "not maintained" in their descriptions.
+
+## Re-Pin Procedure
+
+To move a fixture base (new rung requirements, upstream refresh):
+
+1. Choose the new commit in the source repo; for bug-fix stories, choose the parent of the target fix and verify no descendant leaks the solution.
+2. Push that history to the fixture (force-push of `main` is acceptable here — fixtures are not collaborative repos; open runs pin old commits and are unaffected as long as the old objects remain reachable, so prefer additive pushes when possible).
+3. Update the provenance table above and the affected story definitions' `fixture.commit` in the same PR — the story hash changes with it, keeping run records comparable-by-identity.
+
+## Related Documents
+
+- [ADR 0025](../../adr/0025-golden-stories-and-benchmark-runner.md) (fixture and cleanup rules), [ADR 0023](../../adr/0023-v2-branch-strategy.md) (branch cleanup).
+- [Phase 1 plan](plan_scope.md) item 2; [design_runner.md](design_runner.md) (story schema the definitions follow).
+- The first three story definitions: `benchmark/stories/` in the maestro repo.

--- a/docs/v2/phase_1/process_fixtures.md
+++ b/docs/v2/phase_1/process_fixtures.md
@@ -1,13 +1,13 @@
 +++
 title = "Fixture Conventions For Golden Stories"
 edit_date = "2026-07-16"
-status = "draft"
+status = "live"
 summary = "The golden story fixture repositories (pinned variants of maestro-llms, maestro-cms, and the extracted chat app), their provenance, and the conventions that keep them honest: pinned immutable bases, solution-leakage truncation, no tags, run-branch cleanup, and the re-pin procedure."
 +++
 
 # Fixture Conventions For Golden Stories
 
-Status: draft — Phase 1 item 2 (`fixtures`), under [ADR 0025](../../adr/0025-golden-stories-and-benchmark-runner.md) and the [Phase 1 plan](plan_scope.md). Flips to `live` on item 2 approval.
+Status: live — approved with item 2 (PR #262, Codex + DR, 2026-07-16; one Codex round incorporated), under [ADR 0025](../../adr/0025-golden-stories-and-benchmark-runner.md) and the [Phase 1 plan](plan_scope.md).
 
 Golden stories run against **fixture repositories**: pinned, purpose-held variants of real codebases under the SnapdragonPartners GitHub org (the plan's ratified reviewer question 4). Fixtures give stories realistic brownfield friction without depending on the source repos' ongoing motion.
 


### PR DESCRIPTION
Phase 1 item 2 (`fixtures`) per the [Phase 1 plan](docs/v2/phase_1/plan_scope.md). See `docs/v2/phase_1/process_fixtures.md` for the conventions and provenance table.

## Fixture repos (created under the org, per ratified reviewer question 4)

| Repo | Provenance | Pinned main |
|---|---|---|
| [golden-fixture-llms](https://github.com/SnapdragonPartners/golden-fixture-llms) | maestro-llms, **history truncated** at the parent of upstream fix `92eceb8` | `d5078df` |
| [golden-fixture-cms](https://github.com/SnapdragonPartners/golden-fixture-cms) | maestro-cms at HEAD, full history | `e7a7422` |
| [golden-fixture-chat](https://github.com/SnapdragonPartners/golden-fixture-chat) | `maestro-llms/examples/chat` extracted standalone (module repointed, toolkit pinned `v0.7.1`) | `91514c9` |

Key conventions: stories pin 40-hex commits; fixture mains never advance casually; **no solution leakage** (the bug-fix fixture is verified to contain zero descendants of its base, zero tags, and no trace of the fix — and still builds with the OpenAI provider tests passing); no tags on any fixture; run-branch cleanup per ADR 0023/0025; deltas from source always carry provenance.

**One resolution for reviewers to confirm**: ADR 0025's "standalone LLM-tester CLI app from the toolkit repos" resolves to `maestro-llms/examples/chat` — the only `package main` in either toolkit repo, an LLM-tester designed to be copied out. It serves a local web page rather than being a pure CLI; the ADR's "no browser tooling required" constraint is about evidence, and its low-rung stories validate via build/vet. Recorded in the conventions doc.

## First three stories (`benchmark/stories/`, CI-validated by `stories_test.go`)

- **`dep-bump-xnet`** (rung 1, cms fixture): bump `golang.org/x/net`, diff confined to go.mod/go.sum.
- **`cleanup-provider-options`** (rung 2, chat fixture): consolidate five near-identical per-provider option functions — natural duplication found in the code, not seeded.
- **`bugfix-openai-stopreason`** (rung 3, llms fixture at the pre-fix pin): symptom-based bug report derived from the real upstream issue; checks require the fix to read `IncompleteDetails` and the hermetic provider tests to pass.

Definitions are drafts until the runner executes them (items 3–5); budgets are placeholders until item 6's instrumented cost runs.

Doc lifecycle: `process_fixtures.md` and the updated `stories/README.md` are `draft`; they flip `live` as the final pre-merge commit on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)