### PR TITLE
#336 + #306: bound the sweep barrier, then make the pre-push gate actually run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,16 +76,29 @@ test: benchmark-test
 #     internal/dataplane/benchmarkimport  86.9s   (1.5s standalone: ~58x)
 #
 # 40m leaves the long pole better than 3x headroom, and matches what the
-# ubuntu-latest recovery job in ci.yml already uses. Headroom here absorbs
-# CONTENTION rather than slow tests: `./...` runs packages concurrently against
-# one shared Postgres and one MinIO, and the inflation factors above are what
-# that costs.
+# ubuntu-latest recovery job in ci.yml already uses.
 #
-# Linux is not slower. The recovery subset of the stack suite takes 261-289s on
-# ubuntu-latest in CI against 233s on this machine, so the macOS figures are a
-# reasonable basis for both. The full suite has not been timed on Linux, because
-# it does not run there yet -- CI's integration job is still the commented-out
-# template at the foot of ci.yml.
+# The inflation column has TWO causes, not one, which is why its range is so
+# wide. Packages built on `planetest` take a database and a bucket per test on
+# the ALREADY-RUNNING dev stack, so under `./...` they compete for one Postgres
+# and one MinIO -- that is benchmarkimport's ~58x. The stack package instead
+# brings up its own throwaway Compose planes per test, so it is not queueing
+# behind anyone for a shared server; its 1.04x is near-zero for that reason and
+# because, as the long pole, little else is still running near its end. Reading
+# 1.04x as "contention is mild" would be the wrong lesson.
+#
+# Linux is somewhat SLOWER, not faster. On the only subset timed on both, the
+# stack recovery tests take 261-289s on ubuntu-latest in CI against 238.3s here:
+# roughly 1.1-1.2x. Applied to the long pole that is ~900s, still under half the
+# timeout, which is what makes deferring the full Linux measurement safe rather
+# than merely convenient.
+#
+# The full suite has NOT been timed on Linux. It does not run there -- CI's
+# integration job is still the commented-out template at the foot of ci.yml --
+# and standing that up means a paid-API surface and a dispatch trigger that
+# cannot be exercised until it exists on the default branch. #306 was amended to
+# defer it until that job legitimately enters CI, rather than leaving an
+# acceptance criterion nobody could satisfy.
 test-integration:
 	@echo "🧪 Running integration tests..."
 	go test -tags=integration -cover -count=1 -timeout=40m ./...

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,38 @@ test: benchmark-test
 	go test -cover ./...
 
 # Run integration tests only (requires API keys and external services)
+#
+# -count=1 is REQUIRED, not tidiness. These tests depend on mutable external
+# state -- a Postgres cluster, MinIO buckets, containers -- and Go's test cache
+# keys on inputs it can see, which excludes all of it. A cached PASS is a claim
+# about a plane that may since have been reset, migrated or emptied. Measured on
+# #286's branch: a pre-push run that failed was followed by one that passed with
+# 71 packages `(cached)`, including the two heaviest, so the accepting run had
+# executed strictly less than the run it was taken to overrule (#306).
+#
+# -timeout applies PER TEST BINARY, so it is sized by the slowest single
+# package, not by the suite. Measured on macOS (M3) 2026-08-17, from a fully
+# uncached run of this target -- 747s wall clock, zero packages cached:
+#
+#     internal/dataplane/stack           745.1s   <- the long pole
+#     internal/dataplane/store/postgres  292.8s   (187.2s standalone: 1.6x)
+#     tests/integration                  215.8s
+#     internal/dataplane/benchmarkimport  86.9s   (1.5s standalone: ~58x)
+#
+# 40m leaves the long pole better than 3x headroom, and matches what the
+# ubuntu-latest recovery job in ci.yml already uses. Headroom here absorbs
+# CONTENTION rather than slow tests: `./...` runs packages concurrently against
+# one shared Postgres and one MinIO, and the inflation factors above are what
+# that costs.
+#
+# Linux is not slower. The recovery subset of the stack suite takes 261-289s on
+# ubuntu-latest in CI against 233s on this machine, so the macOS figures are a
+# reasonable basis for both. The full suite has not been timed on Linux, because
+# it does not run there yet -- CI's integration job is still the commented-out
+# template at the foot of ci.yml.
 test-integration:
 	@echo "🧪 Running integration tests..."
-	go test -tags=integration -cover -timeout=20m ./...
+	go test -tags=integration -cover -count=1 -timeout=40m ./...
 
 # Run the GCS adapter tests against a REAL Google Cloud Storage bucket.
 #

--- a/internal/dataplane/store/postgres/sweep_integration_test.go
+++ b/internal/dataplane/store/postgres/sweep_integration_test.go
@@ -392,12 +392,18 @@ type stallAfterPromote struct {
 
 // newStallAfterPromote builds a stall and registers its release as CLEANUP.
 //
-// The release must happen on every exit path, not only the successful one. A
-// stalled writer holds an open transaction and a digest lock; if the test fails
-// an assertion between the stall and its release, `t.Fatal` ends the test
-// goroutine while that writer stays blocked forever — leaking a goroutine that
-// holds locks other tests in this package then wait on. One failed assertion
-// becomes a cascade whose root cause is invisible.
+// The release must happen on every exit path, not only the successful one, and
+// the reason is more specific than a leaked goroutine. The stalled writer holds
+// an ACQUIRED POOLED CONNECTION with an open transaction, and `pgxpool.Close()`
+// waits for acquired connections to be released. So a `t.Fatal` between the
+// stall and its release does not merely strand a goroutine that might collide
+// with a later test — it blocks this fixture's own teardown, forever, every
+// time. That is why the failure presents as a package-wide timeout rather than
+// as one test failing.
+//
+// MEASURED: removing this registration and forcing a failure inside the window
+// reproduces `panic: test timed out after 1m30s`; with it, the same assertion
+// fails in 0.63s.
 //
 // Registering the release here rather than remembering it at each call site is
 // the point: the paths that need it most are the ones nobody writes out.

--- a/internal/dataplane/store/postgres/sweep_integration_test.go
+++ b/internal/dataplane/store/postgres/sweep_integration_test.go
@@ -75,13 +75,31 @@ func (f *fixture) unreferencedObject(t *testing.T, body []byte) string {
 	return digest
 }
 
+// barrierTimeout bounds a single external call made while a test is holding a
+// forced window open.
+//
+// Every such call needs a deadline of its own. A test that stalls a writer
+// inside its transaction and then makes an unbounded call has arranged for one
+// slow response to become a deadlock: the writer cannot proceed, whatever is
+// blocked behind its lock cannot proceed, and the goroutine that would release
+// the stall is the one waiting. Nothing breaks that cycle except the package
+// timeout, which fails the whole suite twenty minutes later and names no cause.
+//
+// Generous on purpose. It is not a performance assertion — a loaded object store
+// legitimately takes seconds — it exists so that "slow" cannot become "never".
+const barrierTimeout = 60 * time.Second
+
 // storedVersions counts what the bucket actually holds for a digest,
 // including delete markers. Zero means the storage is genuinely reclaimed
 // rather than merely hidden behind a marker.
+//
+// Bounded, because this is called inside forced windows: see barrierTimeout.
 func (f *fixture) storedVersions(t *testing.T, digest string) int {
 	t.Helper()
 	key := objectKeyFor(f.organizationID, digest)
-	versions, err := f.blob.ListVersions(context.Background(), key)
+	ctx, cancel := context.WithTimeout(context.Background(), barrierTimeout)
+	defer cancel()
+	versions, err := f.blob.ListVersions(ctx, key)
 	if err != nil {
 		t.Fatalf("list versions of %s: %v", key, err)
 	}
@@ -292,11 +310,7 @@ func TestSweepBlocksOnTheLockAndThenFindsTheReference(t *testing.T) {
 	body := []byte("bytes whose attachment row has not committed yet")
 	digest := digestOf(body)
 
-	stall := &stallAfterPromote{
-		key:     objectKeyFor(f.organizationID, digest),
-		reached: make(chan struct{}),
-		release: make(chan struct{}),
-	}
+	stall := newStallAfterPromote(t, objectKeyFor(f.organizationID, digest))
 	writer := f.storeWithTransport(t, stall)
 
 	written := make(chan error, 1)
@@ -306,7 +320,7 @@ func TestSweepBlocksOnTheLockAndThenFindsTheReference(t *testing.T) {
 	case <-stall.reached:
 	case err := <-written:
 		t.Fatalf("the write finished without ever stalling (%v), so no window was held open", err)
-	case <-time.After(30 * time.Second):
+	case <-time.After(barrierTimeout):
 		t.Fatal("the writer never reached its post-promote read-back")
 	}
 
@@ -332,7 +346,7 @@ func TestSweepBlocksOnTheLockAndThenFindsTheReference(t *testing.T) {
 	// instead would make the test pass whether or not the lock was ever
 	// taken.
 	waitForLockWait(t, f)
-	close(stall.release)
+	stall.free()
 
 	if err := <-written; err != nil {
 		t.Fatalf("the stalled write failed: %v", err)
@@ -371,6 +385,38 @@ type stallAfterPromote struct {
 	release  chan struct{}
 	promoted atomic.Bool
 	once     sync.Once
+	// freed guards the release channel so it can be closed from both the test's
+	// success path and its cleanup. See newStallAfterPromote.
+	freed sync.Once
+}
+
+// newStallAfterPromote builds a stall and registers its release as CLEANUP.
+//
+// The release must happen on every exit path, not only the successful one. A
+// stalled writer holds an open transaction and a digest lock; if the test fails
+// an assertion between the stall and its release, `t.Fatal` ends the test
+// goroutine while that writer stays blocked forever — leaking a goroutine that
+// holds locks other tests in this package then wait on. One failed assertion
+// becomes a cascade whose root cause is invisible.
+//
+// Registering the release here rather than remembering it at each call site is
+// the point: the paths that need it most are the ones nobody writes out.
+func newStallAfterPromote(t *testing.T, key string) *stallAfterPromote {
+	t.Helper()
+	stall := &stallAfterPromote{
+		key:     key,
+		reached: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	t.Cleanup(stall.free)
+	return stall
+}
+
+// free releases the stalled writer, and is safe to call more than once — the
+// test's own success path calls it too, and a cleanup that panicked on a
+// second close would convert a passing test into a failing one.
+func (s *stallAfterPromote) free() {
+	s.freed.Do(func() { close(s.release) })
 }
 
 func (s *stallAfterPromote) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/dataplane/store/postgres/truncation_seam_integration_test.go
+++ b/internal/dataplane/store/postgres/truncation_seam_integration_test.go
@@ -238,14 +238,30 @@ func TestConcurrentTruncationRetriesOnItsOwnSnapshot(t *testing.T) {
 // Polling pg_stat_activity rather than sleeping, because a sleep long
 // enough to be reliable is also long enough to hide the race it was meant
 // to create.
+// The deadline governs the CALL, not merely the iteration.
+//
+// An earlier version wrapped an unbounded `context.Background()` query in a
+// 30-second loop. That bounds how many times the query is retried, which is not
+// the failure mode: one query that never returns never reaches the next deadline
+// check, so the loop's bound cannot fire. This is called while a writer is
+// deliberately stalled holding a lock, so a hang here deadlocks the test until
+// the package timeout.
 func waitForLockWait(t *testing.T, f *fixture) {
 	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
+	ctx, cancel := context.WithTimeout(context.Background(), barrierTimeout)
+	defer cancel()
+
+	for ctx.Err() == nil {
 		var waiting int
-		if err := f.pool.QueryRow(context.Background(), `
+		if err := f.pool.QueryRow(ctx, `
 			SELECT count(*) FROM pg_stat_activity
 			WHERE datname = current_database() AND wait_event_type = 'Lock'`).Scan(&waiting); err != nil {
+			// A deadline reached mid-query is this helper's own timeout, not a
+			// database fault, and reporting it as one would send the next reader
+			// looking at Postgres.
+			if ctx.Err() != nil {
+				break
+			}
 			t.Fatalf("read pg_stat_activity: %v", err)
 		}
 		if waiting > 0 {
@@ -253,5 +269,6 @@ func waitForLockWait(t *testing.T, f *fixture) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatal("no backend ever blocked on a lock, so the collision this test depends on never happened")
+	t.Fatalf("no backend blocked on a lock within %s, so the collision this test depends on never "+
+		"happened", barrierTimeout)
 }

--- a/internal/dataplane/store/postgres/truncation_seam_integration_test.go
+++ b/internal/dataplane/store/postgres/truncation_seam_integration_test.go
@@ -256,10 +256,19 @@ func waitForLockWait(t *testing.T, f *fixture) {
 		if err := f.pool.QueryRow(ctx, `
 			SELECT count(*) FROM pg_stat_activity
 			WHERE datname = current_database() AND wait_event_type = 'Lock'`).Scan(&waiting); err != nil {
-			// A deadline reached mid-query is this helper's own timeout, not a
-			// database fault, and reporting it as one would send the next reader
-			// looking at Postgres.
-			if ctx.Err() != nil {
+			// Attributed by the ERROR, not by ambient deadline state.
+			//
+			// A deadline reached mid-query is this helper's own timeout rather
+			// than a database fault, and reporting it as one would send the next
+			// reader looking at Postgres. But asking `ctx.Err() != nil` here
+			// answers a different question: it is true for ANY failure that
+			// happens to coincide with the deadline expiring, so a genuine pool
+			// or database fault arriving in that same instant would be swallowed
+			// and reported below as "no backend ever blocked on a lock" -- the
+			// one message guaranteed to send someone looking in the wrong place.
+			// The window is narrow; the cost of landing in it is a debugging
+			// session against a healthy database.
+			if errors.Is(err, context.DeadlineExceeded) {
 				break
 			}
 			t.Fatalf("read pg_stat_activity: %v", err)


### PR DESCRIPTION
Closes #336
Closes #306

Two tightly coupled changes, kept on one branch because the order between them is the point: #336 had to land before uncached runs were enabled, or #306 would have converted a latent deadlock into a routine gate failure for everyone.

## #336 — the sweep barrier could deadlock

`TestSweepBlocksOnTheLockAndThenFindsTheReference` stalls a writer inside its transaction, holding a digest lock, and then made **unbounded external calls before releasing that stall**. One slow response and nothing could break the cycle: the writer could not proceed, the sweep was blocked behind its lock, and the goroutine that would release the stall was the one waiting.

- `storedVersions` had **no deadline at all**.
- `waitForLockWait` looked bounded and was not — its 30-second loop governed how many times the query was *retried*, and a query that never returns never reaches the next deadline check. The bound could not fire on the failure it was written for.

Both now take `barrierTimeout`, named so the reasoning travels with it. The release moved into `t.Cleanup` via `sync.Once`, registered by a constructor rather than remembered at the call site, because the paths that need it are the ones nobody writes out.

**The mechanism turned out to be more specific than filed.** The damage is not an untidy leaked goroutine that might collide with a later test: the stalled writer holds an **acquired pooled connection with an open transaction**, and `pgxpool.Close()` waits for acquired connections, so fixture teardown blocks deterministically. That is why it presented as a package-wide timeout rather than one test failing. The issue, the commit and the code comment were all corrected to the measured mechanism.

Both halves mutation-verified, each dying for the right reason:

| Mutation | Result |
| --- | --- |
| `barrierTimeout` shrunk to 1ns | Fails in **0.63s** with `context deadline exceeded` *at the barrier call* — proves the context reaches `ListVersions` rather than being constructed and discarded, which would read identically in review |
| `t.Cleanup(stall.free)` removed | **`panic: test timed out after 1m30s`** — reproduces the original symptom exactly |

## #306 — the gate could pass without running

`-count=1` added. These tests validate mutable external state that Go's cache cannot see, so a cached `ok` asserts nothing while presenting identically to a real pass. The demonstration came from #286's branch: a push that **failed** was followed by one that **passed with 71 packages cached**, including the two heaviest — the accepting run had executed strictly less than the run it was taken to overrule.

Timeout raised 20m to 40m, **sized from a measured cold run** rather than picked: 747s wall clock, zero packages cached, slowest package 745.1s. Per-package timings recorded beside the flag.

That run is also the first in-situ evidence for #336: under the same conditions that previously produced `panic: test timed out after 20m0s` at 1203.8s, `store/postgres` completed in **292.8s**.

## Corrections made during review

Two comments asserted more than their own data supported, and are fixed here rather than left standing:

- The Linux note said *"Linux is not slower"* directly above numbers showing the opposite, and leaned on a **recalled** figure beside fresh CI ones. Re-measured like-for-like: macOS 238.3s against ubuntu-latest 261–289s — Linux is ~1.1–1.2x **slower**. The recalled number was close to the measured one, so the fault was the inference, not the fact.
- The contention note gave one cause for an inflation column with two. `planetest` packages share the running dev stack's Postgres and MinIO (benchmarkimport ~58x); `stack` brings up its own throwaway Compose planes (1.04x). Presenting them as one phenomenon invited the conclusion that contention is mild.

## Scope decision recorded, not quietly taken

#306 originally required a full uncached **ubuntu-latest** measurement. Amended in the open, with the original struck through: full Linux measurement is **deferred** until the paid integration suite legitimately enters CI. It could not change the outcome — the platform ratio applied to the long pole is ~900s, still under half the timeout — while satisfying it now would mean a `workflow_dispatch` trigger that generally cannot be exercised until it exists on the default branch, plus a paid-API surface deserving its own decision.

A trap for whoever does enable that job is recorded on #306: the commented-out template runs `make test-integration` with **no `make dataplane-up`**, so the planetest packages would skip, the job would go green, and it would record a Linux measurement of a suite that never ran.

## Verification

`internal/dataplane/store/postgres` green before and after the #336 change (175.0s, 175.6s). Full uncached `make test-integration` green, 747s, zero cached.

**This branch's own pre-push gate was the first exercise of the `-count=1` change, and it passed on the first attempt with zero packages cached** — `stack` 731.1s, `store/postgres` 289.5s. Both fixes therefore have an independent confirmation beyond the runs that produced them: the gate ran everything, and the package that previously deadlocked under exactly this load completed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
